### PR TITLE
Silicon/Sophgo: Get the PCIe topology at DXE phase

### DIFF
--- a/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
+++ b/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
@@ -410,11 +410,14 @@
   #gEfiMdeModulePkgTokenSpaceGuid.PcdConOutRow|0
   #gEfiMdeModulePkgTokenSpaceGuid.PcdConOutColumn|0
 
+  #
   # RC#0(P0L0,BIT0); RC#1(P0L1,BIT1); RC#2(P1L0,BIT2); RC#3(P1L1,BIT3)
   # 2U Server: 0x4
   # X8\X4 EVB: 0x7
   # PioneerBox: 0xF
-  gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPcieEnableMask|0x7
+  # Set the value at the PCIe RC initialization phase
+  #
+  gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPcieEnableMask|0x0
 
 [PcdsDynamicHii]
   gUefiOvmfPkgTokenSpaceGuid.PcdForceNoAcpi|L"ForceNoAcpi"|gOvmfVariableGuid|0x0|TRUE|NV,BS
@@ -548,6 +551,7 @@
   Silicon/Sophgo/SG2042Pkg/Override/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf {
     <LibraryClasses>
       NULL|Silicon/Sophgo/SG2042Pkg/Library/PlatformPciLib/PlatformPciLib.inf
+      PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
   }
 
   #

--- a/Silicon/Sophgo/SG2042Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
+++ b/Silicon/Sophgo/SG2042Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.inf
@@ -24,6 +24,7 @@
 [Packages]
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
   UefiCpuPkg/UefiCpuPkg.dec
   Silicon/Sophgo/SG2042Pkg/SG2042Pkg.dec
 
@@ -34,6 +35,12 @@
   DevicePathLib
   MemoryAllocationLib
   UefiBootServicesTableLib
+
+[Protocols]
+  gFdtClientProtocolGuid                                            ## CONSUMES
+
+[Depex]
+  gFdtClientProtocolGuid
 
 [Pcd]
   gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPcieEnableMask     ## CONSUMES

--- a/Silicon/Sophgo/SG2042Pkg/SG2042Pkg.dec
+++ b/Silicon/Sophgo/SG2042Pkg/SG2042Pkg.dec
@@ -78,8 +78,7 @@
   gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPci1Link1Region4Size|0x0|UINT64|0x00001039
 
 [PcdsPatchableInModule, PcdsDynamic]
-  # Enable both RC#0, RC#1 and RC#2 by default
-  gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPcieEnableMask|0x7|UINT8|0x0000103A
+  gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdMangoPcieEnableMask|0x0|UINT8|0x0000103A
   gSophgoSG2042PlatformPkgTokenSpaceGuid.PcdSG2042PhyAddrToVirAddr|0x0|UINT64|0x00001002
 
 [UserExtensions.TianoCore."ExtraFiles"]


### PR DESCRIPTION
Get the PCIe topology at the DXE phase by parsing devicetree, set the PcdMangoPcieEnableMask value dynamically.