### PR TITLE
Silicon/Sophgo: Initialize the whole memory node.

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
+++ b/Silicon/Sophgo/SG2042Pkg/Sec/Memory.c
@@ -278,17 +278,20 @@ MemoryPeimInitialization (
         CurBase = fdt64_to_cpu (ReadUnaligned64 (RegProp));
         CurSize = fdt64_to_cpu (ReadUnaligned64 (RegProp + 1));
 
-        DEBUG ((
-          DEBUG_INFO,
-          "%a: System RAM @ 0x%lx - 0x%lx\n",
-          __func__,
-          CurBase,
-          CurBase + CurSize - 1
-          ));
-
         if ((LowestMemBase == 0) || (CurBase <= LowestMemBase)) {
           LowestMemBase = CurBase;
           LowestMemSize = CurSize;
+          if (CurBase != 0) {
+            DEBUG ((
+              DEBUG_INFO,
+              "%a: Initialize System RAM @ 0x%lx - 0x%lx\n",
+              __func__,
+              CurBase,
+              CurBase + CurSize - 1
+            ));
+
+            InitializeRamRegions (CurBase, CurSize);
+          }
         }
 
       } else {
@@ -308,7 +311,7 @@ MemoryPeimInitialization (
 
   DEBUG ((
     DEBUG_INFO,
-    "%a: Total System RAM @ 0x%lx - 0x%lx\n",
+    "%a: Initialize System RAM @ 0x%lx - 0x%lx\n",
     __func__,
     LowestMemBase,
     LowestMemBase + LowestMemSize - 1


### PR DESCRIPTION
The physical memory range of 3GB to 4GB has been reserved for PCIe, so the real memory layout is segmented. To avoid relocation overflow occurring when GRUB2 boot kernel, we only initialized the lowest memory range, which is below 3GB.

The kernel will get the memory map from firmware by the UEFI Boot Service GetMemoryMap when executing efi_boot_kernel(). Although the device tree has been transferred to the kernel and is parsed, the real useable physical memory size is only in the range of 3GB.

Now we initialize the whole memory node from the device tree in the UEFI SEC phase. On condition that the GRUB2 had the corresponding temporary workaround to support the segmented memory layout for RISC-V.