### PR TITLE
Silicon/Sophgo: Reduce the trans freq of SD card

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/Drivers/MmcDxe/MmcIdentification.c
+++ b/Silicon/Sophgo/SG2042Pkg/Drivers/MmcDxe/MmcIdentification.c
@@ -665,7 +665,7 @@ MmcIdentificationMode (
     }
   }
 
-  Status = MmcEnumerte (MmcHostInstance, 50 * 1000 * 1000, MMC_BUS_WIDTH_4);
+  Status = MmcEnumerte (MmcHostInstance, 25 * 1000 * 1000, MMC_BUS_WIDTH_4);
 
   if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "MmcIdentificationMode() : Error MmcEnumerte, Status=%r.\n", Status));


### PR DESCRIPTION
On Milk-V PioneerBox, SDHCI read data timeout always occurs which is caused by CRC error. Reduce the transfer frequency of the Micro SD card from 50MB to 25MB to keep the read and write right.