### PR TITLE
Silicon/Sophgo: Not build high memory map for Sv39

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/Library/MmuLib/RiscVMmuLib.c
+++ b/Silicon/Sophgo/SG2042Pkg/Library/MmuLib/RiscVMmuLib.c
@@ -686,6 +686,12 @@ RiscVMmuSetSatpMode (
         );
       ASSERT_EFI_ERROR (Status);
     } else if (MemoryMap[Index].GcdMemoryType == EfiGcdMemoryTypeSystemMemory) {
+      //
+      // For Sv39, do not create the high memory map (512GB or more).
+      //
+      if (SatpMode == SATP_MODE_SV39 && MemoryMap[Index].BaseAddress >= SIZE_512GB) {
+        continue;
+      }
       // Default Read/Write/Execute attribute for system memory
       Status = UpdateRegionMapping (
         MemoryMap[Index].BaseAddress,


### PR DESCRIPTION
For the Pisces Server, the first memory node base address on CHIP1 is fixed at 512GB in the system map. SG2042 only supports Sv39, the high memory (512GB or more) is not allowed to create the memory map directly according to the MMU coding logic. So we do not create va-pa map for high memory at the EDKII phase.