### PR TITLE
Platform/Sophgo: Fix FW_SIZE to 8MB (requires 2MB alignment)

### DIFF
--- a/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
+++ b/Platform/Sophgo/SG2042_EVB_Board/SG2042.dsc
@@ -334,7 +334,7 @@
   # 64KB + 64KB + 64KB
   # Flash Offset: 32MB
   #
-  gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x02800000
+  gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x02780000
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize|0x00010000
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize|0x00010000
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize|0x00010000
@@ -405,9 +405,9 @@
 
 [PcdsDynamicDefault]
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0x02800000
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0x02810000
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0x02820000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0x02780000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0x02790000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0x027A0000
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|FALSE
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosVersion|0x0208

--- a/Platform/Sophgo/SG2042_EVB_Board/SG2042.fdf.inc
+++ b/Platform/Sophgo/SG2042_EVB_Board/SG2042.fdf.inc
@@ -9,16 +9,16 @@
 [Defines]
 DEFINE BLOCK_SIZE        = 0x1000
 DEFINE FW_BASE_ADDRESS   = 0x02000000
-DEFINE FW_SIZE           = 0x00900000
-DEFINE FW_BLOCKS         = 0x900
+DEFINE FW_SIZE           = 0x00800000
+DEFINE FW_BLOCKS         = 0x800
 
 #
-# 0x000000-0x7FFFFF code
-# 0x800000-0x82FFFF variables
+# 0x000000-0x77FFFF code
+# 0x780000-0x7AFFFF variables
 #
 DEFINE CODE_BASE_ADDRESS = $(FW_BASE_ADDRESS)
-DEFINE CODE_SIZE         = 0x00800000
-DEFINE CODE_BLOCKS       = 0x800
+DEFINE CODE_SIZE         = 0x00780000
+DEFINE CODE_BLOCKS       = 0x780
 DEFINE VARS_BLOCKS       = 0x20
 
 #
@@ -29,14 +29,14 @@ DEFINE VARS_BLOCKS       = 0x20
 # FW memory region
 #
 DEFINE FVMAIN_OFFSET                 = 0x00000000
-DEFINE FVMAIN_SIZE                   = 0x00800000
+DEFINE FVMAIN_SIZE                   = 0x00780000
 
 #
 # EFI Variable memory region.
 # The total size of EFI Variable FD must include
 # all of sub regions of EFI Variable
 #
-DEFINE VARS_OFFSET                   = 0x00800000
+DEFINE VARS_OFFSET                   = 0x00780000
 DEFINE VARS_SIZE                     = 0x00010000
 DEFINE VARS_FTW_WORKING_OFFSET       = $(VARS_OFFSET) + $(VARS_SIZE)
 DEFINE VARS_FTW_WORKING_SIZE         = 0x00010000


### PR DESCRIPTION
When FW_SIZE is 9MB, the linux 6.6 kernel boot process throws a memory access exception in the get_boot_config_from_initrd function. We have to modify FW_SIZE to 8MB (requires 2MB alignment) as a workaround.