### PR TITLE
Silicom/Sophgo/Acpi: Add attributes to PCI2

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/AcpiTables/Dsdt/Pci.asl
+++ b/Silicon/Sophgo/SG2042Pkg/AcpiTables/Dsdt/Pci.asl
@@ -345,6 +345,8 @@ Scope(_SB)
         Package () { "pcie-id", 0x1 },
         Package () { "link-id", 0x0 },
         Package () { "top-intc-used", 1 },
+        Package () { "top-intc-id", 0 },
+        Package () { "msix-supported", 0 },
       }
     })
 


### PR DESCRIPTION
Set 'top-intc-id' and 'msix-supported' to 0 for PCI2 host bridge