### PR TITLE
Platform/Sophgo: Add a compile option FPGA_ENABLE

### DIFF
--- a/Platform/Sophgo/SG2380Pkg/SG2380.dsc
+++ b/Platform/Sophgo/SG2380Pkg/SG2380.dsc
@@ -326,9 +326,23 @@
   #
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType|4
 
+  #
+  # Variable store - default values
+  # 64KB + 64KB + 64KB
+  # Flash Offset: 32MB
+  #
+!if $(FPGA_ENABLE) == FALSE
+  gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x02800000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize|0x00010000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingSize|0x00010000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize|0x00010000
+!endif
 
 [PcdsFixedAtBuild.common]
   gSophgoTokenSpaceGuid.PcdSDIOBase|0x5090000000
+!if $(FPGA_ENABLE) == FALSE
+  gSophgoTokenSpaceGuid.PcdSPIFMC1Base|0x5091000000
+!endif
 
 ################################################################################
 #
@@ -338,9 +352,15 @@
 
 [PcdsDynamicDefault]
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
+!if $(FPGA_ENABLE) == TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase|0
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase|0
+!else
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64|0x80A00000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64|0x80A10000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0x80A20000
+!endif
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDisableBusEnumeration|FALSE
 
   #gEfiMdeModulePkgTokenSpaceGuid.PcdSmbiosVersion|0x0208
@@ -429,7 +449,13 @@
   #
   # RISC-V Platform module
   #
+!if $(FPGA_ENABLE) == TRUE
   Platform/SiFive/U5SeriesPkg/Universal/Dxe/RamFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+!else
+  Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.inf
+  Silicon/Sophgo/Drivers/NorFlashDxe/NorFlashDxe.inf
+  Silicon/Sophgo/Drivers/FlashFvbDxe/FlashFvbDxe.inf
+!endif
   Silicon/Sophgo/Drivers/MmcDxe/MmcDxe.inf
   Silicon/Sophgo/Drivers/SdHostDxe/SdHostDxe.inf
 

--- a/Platform/Sophgo/SG2380Pkg/SG2380.fdf
+++ b/Platform/Sophgo/SG2380Pkg/SG2380.fdf
@@ -50,8 +50,14 @@ READ_LOCK_STATUS   = TRUE
 APRIORI DXE {
   INF  MdeModulePkg/Universal/DevicePathDxe/DevicePathDxe.inf
   INF  MdeModulePkg/Universal/PCD/Dxe/Pcd.inf
-  INF  Platform/SiFive/U5SeriesPkg/Universal/Dxe/RamFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
   INF  UefiCpuPkg/CpuDxeRiscV64/CpuDxeRiscV64.inf
+!if $(FPGA_ENABLE) == TRUE
+  INF  Platform/SiFive/U5SeriesPkg/Universal/Dxe/RamFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+!else
+  INF  Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.inf
+  INF  Silicon/Sophgo/Drivers/NorFlashDxe/NorFlashDxe.inf
+  INF  Silicon/Sophgo/Drivers/FlashFvbDxe/FlashFvbDxe.inf
+!endif
 }
 
 #
@@ -72,7 +78,13 @@ INF  MdeModulePkg/Universal/Metronome/Metronome.inf
 INF  EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
 
 # RISC-V Platform Drivers
+!if $(FPGA_ENABLE) == TRUE
 INF  Platform/SiFive/U5SeriesPkg/Universal/Dxe/RamFvbServicesRuntimeDxe/FvbServicesRuntimeDxe.inf
+!else
+INF  Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.inf
+INF  Silicon/Sophgo/Drivers/NorFlashDxe/NorFlashDxe.inf
+INF  Silicon/Sophgo/Drivers/FlashFvbDxe/FlashFvbDxe.inf
+!endif
 INF  Silicon/Sophgo/Drivers/MmcDxe/MmcDxe.inf
 INF  Silicon/Sophgo/Drivers/SdHostDxe/SdHostDxe.inf
 

--- a/Platform/Sophgo/SG2380Pkg/SG2380.fdf.inc
+++ b/Platform/Sophgo/SG2380Pkg/SG2380.fdf.inc
@@ -10,16 +10,16 @@
 [Defines]
 DEFINE BLOCK_SIZE        = 0x1000
 DEFINE FW_BASE_ADDRESS   = 0x80200000
-DEFINE FW_SIZE           = 0x00800000
-DEFINE FW_BLOCKS         = 0x800
+DEFINE FW_SIZE           = 0x00900000
+DEFINE FW_BLOCKS         = 0x900
 
 #
-# 0x000000-0x77FFFF code
-# 0x780000-0x82FFFF variables
+# 0x000000-0x7FFFFF code
+# 0x800000-0x82FFFF variables
 #
 DEFINE CODE_BASE_ADDRESS = $(FW_BASE_ADDRESS)
-DEFINE CODE_SIZE         = 0x00780000
-DEFINE CODE_BLOCKS       = 0x780
+DEFINE CODE_SIZE         = 0x00800000
+DEFINE CODE_BLOCKS       = 0x800
 DEFINE VARS_BLOCKS       = 0x20
 
 #
@@ -30,14 +30,14 @@ DEFINE VARS_BLOCKS       = 0x20
 # FW memory region
 #
 DEFINE FVMAIN_OFFSET                 = 0x00000000
-DEFINE FVMAIN_SIZE                   = 0x00780000
+DEFINE FVMAIN_SIZE                   = 0x00800000
 
 #
 # EFI Variable memory region.
 # The total size of EFI Variable FD must include
 # all of sub regions of EFI Variable
 #
-DEFINE VARS_OFFSET                   = 0x00780000
+DEFINE VARS_OFFSET                   = 0x00800000
 DEFINE VARS_SIZE                     = 0x00010000
 DEFINE VARS_FTW_WORKING_OFFSET       = $(VARS_OFFSET) + $(VARS_SIZE)
 DEFINE VARS_FTW_WORKING_SIZE         = 0x00010000


### PR DESCRIPTION
 - On the FPGA, Palladium emulation platform, or the SoC without SPI Nor Flash, we still use RamFvbServicesRuntimeDxe to keep the variables in RAM. FPGA_ENABLE is a compile option - "-D FPGA_ENABLE".

 - Enlarge the size of the firmware region.