### PR TITLE
Silicon/Sophgo: Fix read nor flash ID failed

### DIFF
--- a/Silicon/Sophgo/Drivers/FlashFvbDxe/FlashFvbDxe.c
+++ b/Silicon/Sophgo/Drivers/FlashFvbDxe/FlashFvbDxe.c
@@ -1276,7 +1276,11 @@ FlashFvbEntryPoint (
 		  RuntimeMmioRegionSize,
                   EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to add memory space\n", __FUNCTION__));
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to add memory space\n",
+      __func__
+      ));
     goto ErrorAddSpace;
   }
 
@@ -1284,7 +1288,11 @@ FlashFvbEntryPoint (
                   RuntimeMmioRegionSize,
                   EFI_MEMORY_UC | EFI_MEMORY_RUNTIME);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to set memory attributes\n", __FUNCTION__));
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to set memory attributes\n",
+      __func__
+      ));
     goto ErrorSetMemAttr;
   }
 

--- a/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.c
+++ b/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.c
@@ -79,6 +79,10 @@ SpifmcReadRegister (
   Register |= SPIFMC_TRAN_CSR_WITH_CMD;
   Register |= SPIFMC_TRAN_CSR_TRAN_MODE_RX | SPIFMC_TRAN_CSR_TRAN_MODE_TX;
 
+  //
+  // OPT bit[1]: Disable no address cmd fifo flush
+  //
+  MmioWrite32 ((UINTN)(SpiBase + SPIFMC_OPT), 2);
   MmioWrite32 ((UINTN)(SpiBase + SPIFMC_FIFO_PT), 0);
   MmioWrite8 ((UINTN)(SpiBase + SPIFMC_FIFO_PORT), Opcode);
 

--- a/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.h
+++ b/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.h
@@ -91,6 +91,8 @@
 #define SPIFMC_INT_RX_FRAME_EN                BIT4
 #define SPIFMC_INT_TX_FRAME_EN                BIT5
 
+#define SPIFMC_OPT                        0x30
+
 #define SPIFMC_MAX_FIFO_DEPTH             8
 
 #define SPI_MASTER_SIGNATURE                      SIGNATURE_32 ('M', 'S', 'P', 'I')


### PR DESCRIPTION
On the SG2260 platform, the SPIFMC includes an additional register 0x30 (OPT), for handling no address cmd transfer. To ensure read nor flash ID successfully, bit[1] must be set to disable no address cmd FIFO flush.