### PR TITLE
Platform/Sophgo: fix check RequiredAlignment error

### DIFF
--- a/Platform/Sophgo/SG2380Pkg/SG2380.dsc
+++ b/Platform/Sophgo/SG2380Pkg/SG2380.dsc
@@ -48,6 +48,17 @@
   GCC:*_*_RISCV64_GENFW_FLAGS    = --keepexceptiontable
 !endif
 
+#
+# Force PE/COFF sections to be aligned at 4KB boundaries to support page level protection
+#
+[BuildOptions.common.EDKII.DXE_CORE,BuildOptions.common.EDKII.DXE_DRIVER,BuildOptions.common.EDKII.UEFI_DRIVER,BuildOptions.common.EDKII.UEFI_APPLICATION]
+  GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000
+  MSFT: *_*_*_DLINK_FLAGS = /ALIGN:4096
+
+[BuildOptions.common.EDKII.DXE_RUNTIME_DRIVER]
+  GCC:  *_*_*_DLINK_FLAGS = -z common-page-size=0x1000
+  MSFT: *_*_*_DLINK_FLAGS = /ALIGN:4096
+
 ################################################################################
 #
 # SKU Identification section - list of all SKU IDs supported by this Platform.


### PR DESCRIPTION
When loading images into memory, the following error occurs:

MemoryProtectionCpuArchProtocolNotify:
ProtectUefiImageCommon - 0x8208B760
  - 0x0000000082054000 - 0x000000000003C000 !!!!!!!!  Image Section Alignment(0x40) does not match Required Alignment (0x1000)  !!!!!!!! ProtectUefiImage failed to create image properties record

We set the linker's page size to 0x1000. Ensure that sections are aligned to the above page size when loaded into memory. i.e., SectionAlignment of the Optional Header of PE/COFF equals 4KB.