### PR TITLE
Sophgo/SG2380Pkg: fix timer frequency

### DIFF
--- a/Platform/Sophgo/SG2380Pkg/SG2380.dsc
+++ b/Platform/Sophgo/SG2380Pkg/SG2380.dsc
@@ -357,6 +357,8 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize|0x00010000
 !endif
 
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency|50000000
+
 [PcdsFixedAtBuild.common]
   gSophgoTokenSpaceGuid.PcdSDIOBase|0x5090000000
 !if $(FPGA_ENABLE) == FALSE


### PR DESCRIPTION
Set timer frequency to 50MHz.