### PR TITLE
Sv39: Remove SG2042 Sv39 physical address quirk

### DIFF
--- a/Silicon/Sophgo/Drivers/SdHostDxe/SdHostDxe.c
+++ b/Silicon/Sophgo/Drivers/SdHostDxe/SdHostDxe.c
@@ -421,16 +421,6 @@ SdHostInitialize (
   Handle            = NULL;
   Base              = SDIO_BASE;
 
-  if(PcdGet32 (PcdCpuRiscVMmuMaxSatpMode) > 0UL){
-    for (INT32 I = 39; I < 64; I++) {
-      if (Base & (1ULL << 38)) {
-        Base |= (1ULL << I);
-      } else {
-        Base &= ~(1ULL << I);
-      }
-    }
-  }
-
   BmParams.RegBase  = Base;
   BmParams.ClkRate  = 50 * 1000 * 1000;
   BmParams.BusWidth = MMC_BUS_WIDTH_4;

--- a/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.c
+++ b/Silicon/Sophgo/Drivers/SpiDxe/SpiFlashMasterController.c
@@ -424,8 +424,6 @@ SpiMasterSetupSlave (
   IN SPI_NOR                    *Nor
   )
 {
-  UINT32 Index;
-
   if (!Nor) {
     Nor = AllocateZeroPool (sizeof(SPI_NOR));
     if (!Nor) {
@@ -445,15 +443,6 @@ SpiMasterSetupSlave (
   }
 
   Nor->SpiBase = SPIFMC_BASE;
-  if (PcdGet32 (PcdCpuRiscVMmuMaxSatpMode) > 0UL) {
-     for (Index = 39; Index < 64; Index++) {
-       if (Nor->SpiBase & (1ULL << 38)) {
-         Nor->SpiBase |= (1ULL << Index);
-       } else {
-         Nor->SpiBase &= ~(1ULL << Index);
-       }
-     }
-  }
 
   SpifmcInit (Nor);
 


### PR DESCRIPTION
Background:
1. Devices' base address on SG2042 are higher than 39bit (larger than 0x3FFFFFFFFF).
2. SG2042 uses T-HEAD C920v1 which only support Sv39, it doesn't support Sv48 and Sv57.
3. RISC-V MMU require 64:38 bits are the same, if bit38 is 1, then bit 64:39 should be 1.

When MMU is enabled, we cannot access device registers by physical address. We should make bit 64:39 1 when we want to access registers, otherwise, an page fault exception will occur.

Now, SG2044 and later chips always support Sv48, so remove these quirks of SG2042.