### PR TITLE
SG2044: PCIe: Support MMU

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/Sophgo/SG2044Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -79,9 +79,11 @@ PciHostBridgeResourceConflict (
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
 
+#ifndef MDEPKG_NDEBUG
   CONST CHAR16  *PciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
     L"Mem", L"I/O", L"Bus"
   };
+#endif
 
   DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 

--- a/Silicon/Sophgo/SG2044Pkg/Library/PciPlatformLib/PciPlatformLib.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Library/PciPlatformLib/PciPlatformLib.inf
@@ -30,3 +30,4 @@
 
 [Protocols]
   gFdtClientProtocolGuid		## CONSUMES
+  gEfiCpuArchProtocolGuid		## CONSUMES


### PR DESCRIPTION
After MMU enabled, all physical address should be mapped before using. For SG2044 PCIe controller, three regions should be mapped. DBI, ATU and a piece of config space. One should use gEfiCpuArchProtocolGuid service, SetMemoryAttributes function. This service won't add memory region to System Map. So if ACPI is used instead of device tree, we should add these memory regions to System Map, too.