### PR TITLE
SG2044: PCIe: Wrong function number when cfg write

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Library/PciPlatformLib/PciPlatformLib.c
+++ b/Silicon/Sophgo/SG2044Pkg/Library/PciPlatformLib/PciPlatformLib.c
@@ -972,7 +972,7 @@ PciSegmentWrite (
   Segment = GET_SEGMENT (Address);
   Bus = GET_BUS (Address);
   Device = GET_DEVICE (Address);
-  Function = GET_DEVICE (Address);
+  Function = GET_FUNCTION (Address);
   Offset = GET_OFFSET (Address);
 
   if (Segment > mSG2044PciRoot.Count) {


### PR DESCRIPTION
Fixbug: Using device number as function number when config write