### PR TITLE
MmcDxe, SdHostDxe: Fixbug: Exception occur on SD

### DIFF
--- a/Silicon/Sophgo/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Silicon/Sophgo/Drivers/MmcDxe/MmcBlockIo.c
@@ -58,7 +58,7 @@ ValidateWrittenBlockCount (
   OUT UINTN *TransferredBlocks
   )
 {
-  UINT32                 R1;
+  UINT32                 Response[MMC_RESPONSE_MAX];
   UINT8                  Data[4];
   EFI_STATUS             Status;
   UINT32                 BlocksWritten;
@@ -77,20 +77,20 @@ ValidateWrittenBlockCount (
   MmcHost = MmcHostInstance->MmcHost;
 
   Status  = MmcHost->SendCommand (MmcHost, MMC_CMD55,
-                      MmcHostInstance->CardInfo.RCA << 16, MMC_RESPONSE_R1, &R1);
+                      MmcHostInstance->CardInfo.RCA << 16, MMC_RESPONSE_R1, Response);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n", __func__, __LINE__, Status));
     return Status;
   }
 
-  Status = MmcHost->SendCommand (MmcHost, MMC_ACMD22, 0, MMC_RESPONSE_R1, &R1);
+  Status = MmcHost->SendCommand (MmcHost, MMC_ACMD22, 0, MMC_RESPONSE_R1, Response);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a(%u): error: %r\n",
       __func__, __LINE__, Status));
     return Status;
   }
 
-  Status = R1TranAndReady (&R1);
+  Status = R1TranAndReady (Response);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -139,7 +139,7 @@ WaitUntilTran (
   )
 {
   INTN                   Timeout;
-  UINT32                 Response[1];
+  UINT32                 Response[MMC_RESPONSE_MAX];
   EFI_STATUS             Status;
   EFI_MMC_HOST_PROTOCOL  *MmcHost;
 
@@ -281,7 +281,7 @@ MmcStopTransmission (
   )
 {
   EFI_STATUS              Status;
-  UINT32                  Response[4];
+  UINT32                  Response[MMC_RESPONSE_MAX];
   // Command 12 - Stop transmission (ends read or write)
   // Normally only needed for streaming transfers or after error.
   Status = MmcHost->SendCommand (MmcHost, MMC_CMD12, 0, MMC_RESPONSE_R1B, Response);

--- a/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.c
+++ b/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.c
@@ -312,7 +312,7 @@ BmSdSendCmd (
   }
 
   if ((Status == EFI_SUCCESS) && (Response != NULL)) {
-    for (INT32 I = 0; I < 4; I++) {
+    for (INT32 I = 0; I < MMC_RESPONSE_MAX; I++) {
       *Response = Cmd.Response[I];
       Response++;
     }

--- a/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.h
+++ b/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.h
@@ -11,6 +11,8 @@
 #ifndef _SD_HCI_H_
 #define _SD_HCI_H_
 
+#include <MmcHost.h>
+
 #define SDCARD_INIT_FREQ                (200 * 1000)
 #define SDHCI_DMA_ADDRESS               0x00
 #define SDHCI_BLOCK_SIZE                0x04
@@ -168,7 +170,7 @@ typedef struct {
   UINT32  CmdIdx;
   UINT32  CmdArg;
   UINT32  ResponseType;
-  UINT32  Response[4];
+  UINT32  Response[MMC_RESPONSE_MAX];
 } MMC_CMD;
 
 typedef struct {

--- a/Silicon/Sophgo/Include/MmcHost.h
+++ b/Silicon/Sophgo/Include/MmcHost.h
@@ -85,6 +85,8 @@ typedef UINT32  MMC_IDX;
 
 #define MMC_STATUS_APP_CMD    (1 << 5)
 
+#define MMC_RESPONSE_MAX      4
+
 typedef enum _MMC_STATE {
   MmcInvalidState = 0,
   MmcHwInitializationState,


### PR DESCRIPTION
Exception occur when reading SD card.

Log as below:

!!!! RISCV64 Exception Type -
0000000000000001(EXCEPT_RISCV_INST_ACCESS_FAULT) !!!!
     t0 = 0x00000000082AFF108        t1 = 0x00000000082AFF110
     t2 = 0x000000000FFFFFFFF        t3 = 0x00000000000000000
     t4 = 0x00000000000000400        t5 = 0x0000000000000002E
     t6 = 0x00000000000000035        s0 = 0x00000000082AFF410
     s1 = 0x00000000000000400        s2 = 0x00000000F773A6D00
     s3 = 0x00000000000000001        s4 = 0x00000000F7F1CEC48
     s5 = 0x00000000F7739D000        s6 = 0x000000000007AE000
     s7 = 0x00000000000000400        s8 = 0x00000000F773A6D00
     s9 = 0x00000000F7779E3F4       s10 = 0x00000000F777AD648
    s11 = 0x00000000F773A8820        a0 = 0x00000000000000000
     a1 = 0x0000000000000000D        a2 = 0x0FFFFFFFFAAAA0000
     a3 = 0x0000000000000000D        a4 = 0x00000000082AFF3E0
     a5 = 0x0EFEFEFEFF7F7F7F7        a6 = 0x00000000000000000
     a7 = 0x0000000004442434E      zero = 0x00000000000000000
     ra = 0x00000000F7FDD725C        sp = 0x00000000082AFF3D0
     gp = 0x00000000000000000        tp = 0x00000000080106000
   sepc = 0x0000000EFF7F7F7F6   sstatus = 0x08000000200006720
  stval = 0x0000000EFF7F7F7F6

SendCommand callback of SD card need 4 UINT32 to save response data, no matter how many bytes returned from SD card. But in function WaitUntilTran, only 1 UINT32 is passed to SendCommand callback, which lead to over written error. It overwrites stack parameter MmcHost with 0, then MmcHost->SendCommand is illegal.