### PR TITLE
Sophgo: Remove debug macro MDEPKG_NDEBUG

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -118,7 +118,6 @@
   !endif
 
 [BuildOptions]
-  GCC:RELEASE_*_*_CC_FLAGS       = -DMDEPKG_NDEBUG
 !ifdef $(SOURCE_DEBUG_ENABLE)
   GCC:*_*_RISCV64_GENFW_FLAGS    = --keepexceptiontable
 !endif

--- a/Silicon/Sophgo/Drivers/MmcDxe/MmcDebug.c
+++ b/Silicon/Sophgo/Drivers/MmcDxe/MmcDebug.c
@@ -9,13 +9,11 @@
 
 #include "Mmc.h"
 
-#if !defined(MDEPKG_NDEBUG)
 CONST CHAR8* mStrUnit[] = { "100kbit/s", "1Mbit/s", "10Mbit/s", "100MBit/s",
                             "Unknown", "Unknown", "Unknown", "Unknown" };
 CONST CHAR8* mStrValue[] = { "1.0", "1.2", "1.3", "1.5", "2.0", "2.5",
                              "3.0", "3.5", "4.0", "4.5", "5.0", "5.5",
                              "6.0", "7.0", "8.0" };
-#endif
 
 /**
   Print the Card Identification (CID) register.

--- a/Silicon/Sophgo/SG2044Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
+++ b/Silicon/Sophgo/SG2044Pkg/Library/PciHostBridgeLib/PciHostBridgeLib.c
@@ -79,11 +79,9 @@ PciHostBridgeResourceConflict (
   EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *Descriptor;
   UINTN                             RootBridgeIndex;
 
-#ifndef MDEPKG_NDEBUG
   CONST CHAR16  *PciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
     L"Mem", L"I/O", L"Bus"
   };
-#endif
 
   DEBUG ((DEBUG_ERROR, "PciHostBridge: Resource conflict happens!\n"));
 


### PR DESCRIPTION
eck2 commit: 8f048045934ea8ca390d843221fa954342132e6c removes the need of MDEPKG_NDEBUG