### PR TITLE
Modify exit the BIOS MENU results in a Handle Not Found error

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.c
@@ -342,7 +342,8 @@ FreeFrontPage (
                   NULL
                   );
   ASSERT_EFI_ERROR (Status);
-  HiiRemovePackages (gFrontPagePrivate.HiiHandle);
+  HiiRemovePackages (gFrontPagePrivate.HiiHandle[0]);
+  HiiRemovePackages (gFrontPagePrivate.HiiHandle[1]);
   if (gFrontPagePrivate.LanguageToken != NULL) {
     FreePool (gFrontPagePrivate.LanguageToken);
     gFrontPagePrivate.LanguageToken = NULL;


### PR DESCRIPTION
Modify the issue where pressing "ESC" to exit the BIOS MENU results in a "Handle Not Found" error.