### PR TITLE
Ds1307RealTimeClockLib: Add Pcd variable

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -465,6 +465,7 @@
   gSophgoTokenSpaceGuid.PcdIniFileRamAddress|0x89000000
   gSophgoTokenSpaceGuid.PcdIniFileMaxSize|2048
   gSophgoTokenSpaceGuid.PcdMisa|0x00B4112F
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum|2
 
   gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency|50000000
 

--- a/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
+++ b/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
@@ -18,9 +18,9 @@
 #include <Library/RealTimeClockLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeLib.h>
+#include <Library/PcdLib.h>
 #include <Include/DwI2c.h>
 
-#define I2C_BUS_NUM         2
 #define I2C_SLAVE_RTC_ADDR  0x68
 
 #define DS1307_SEC_BIT_CH   0x80  /* Clock Halt (in Register 0) */
@@ -52,6 +52,7 @@
 
 STATIC SOPHGO_I2C_MASTER_PROTOCOL  *mI2cMasterProtocol;
 STATIC EFI_EVENT                   mVirtualAddrChangeEvent;
+STATIC UINT32                      mI2cBusNum;
 
 /**
   Read data from RTC.
@@ -70,7 +71,7 @@ RtcRead (
   EFI_STATUS   Status;
 
   Status = mI2cMasterProtocol->Read (mI2cMasterProtocol,
-                                     I2C_BUS_NUM,
+                                     mI2cBusNum,
                                      I2C_SLAVE_RTC_ADDR,
                                      0, Length, Data);
 
@@ -94,7 +95,7 @@ RtcWrite (
   EFI_STATUS   Status;
 
   Status = mI2cMasterProtocol->Write (mI2cMasterProtocol,
-                                      I2C_BUS_NUM,
+                                      mI2cBusNum,
                                       I2C_SLAVE_RTC_ADDR,
                                       0, Length, Data);
 
@@ -322,6 +323,7 @@ LibRtcInitialize (
       return Status;
     }
   }
+  mI2cBusNum = FixedPcdGet32 (PcdRtcI2cBusNum);
 
   return EFI_SUCCESS;
 }

--- a/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.inf
+++ b/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.inf
@@ -30,8 +30,11 @@
   UefiBootServicesTableLib
   UefiRuntimeLib
 
+[Pcd]
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum   ## CONSUMES
+
 [Protocols]
-  gSophgoI2cMasterProtocolGuid     ## CONSUMES
+  gSophgoI2cMasterProtocolGuid            ## CONSUMES
 
 [Depex]
   gSophgoI2cMasterProtocolGuid

--- a/Silicon/Sophgo/Sophgo.dec
+++ b/Silicon/Sophgo/Sophgo.dec
@@ -37,6 +37,7 @@
   gSophgoTokenSpaceGuid.PcdTrngBase|0x0|UINT64|0x00001009
   gSophgoTokenSpaceGuid.PcdSpifmcDmmrEnable|FALSE|BOOLEAN|0x00001010
   gSophgoTokenSpaceGuid.PcdFlashPartitionTableAddress|0x0|UINT64|0x00001011
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum|0x0|UINT32|0x00001012
 
 [PcdsDynamic]
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x0|UINT64|0x00001003


### PR DESCRIPTION
Use the Pcd variable to represent the i2c bus num used by RTC.

Signed-off-by: zhouwei.zhang <zhouwei.zhang@sophgo.com>