### PR TITLE
Improve Hotkey Logic and Adjust BIOS MENU Page Design

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -762,7 +762,7 @@
   MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Logo/LogoDxe.inf
-  MdeModulePkg/Universal/LoadFileOnFv2/LoadFileOnFv2.inf
+  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf {
     <LibraryClasses>
       NULL|MdeModulePkg/Library/BootManagerUiLib/BootManagerUiLib.inf
@@ -779,6 +779,3 @@
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
   Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044EvbAcpiTables.inf
 !endif
-
-  # For F7 Boot Menu App
-  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf

--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf
@@ -218,6 +218,7 @@ INF  MdeModulePkg/Universal/SetupBrowserDxe/SetupBrowserDxe.inf
 INF  MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
 INF  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
 INF  Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
+INF  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 
 #
 # ACPI Support
@@ -228,10 +229,6 @@ INF  Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
   INF MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
   INF RuleOverride=ACPITABLE Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044EvbAcpiTables.inf
 !endif
-
-# For F7 Boot Menu App
-INF  MdeModulePkg/Universal/LoadFileOnFv2/LoadFileOnFv2.inf
-INF  MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf
 
 ################################################################################
 

--- a/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBm.h
+++ b/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBm.h
@@ -28,6 +28,7 @@
 #include <IndustryStandard/Pci22.h>
 #include <Guid/SerialPortLibVendor.h>
 #include <Guid/NonDiscoverableDevice.h>
+#include <Uefi/UefiBaseType.h>
 
 #define DP_NODE_LEN(Type) { (UINT8)sizeof (Type), (UINT8)(sizeof (Type) >> 8) }
 

--- a/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
+++ b/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -57,6 +57,7 @@
   gEdkiiNonDiscoverableEhciDeviceGuid
   gEdkiiNonDiscoverableUhciDeviceGuid
   gEdkiiNonDiscoverableXhciDeviceGuid
+  gEfiGlobalVariableGuid
 
 [Protocols]
   gEfiDevicePathProtocolGuid

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
@@ -9,7 +9,7 @@
 #langdef   en-US "English"
 #langdef   en    "Standard English"
 
-#string STR_FRONT_PAGE_TITLE           #language en-US  "BISO MENU"
+#string STR_FRONT_PAGE_TITLE           #language en-US  "BIOS MENU"
 #string STR_FRONT_PAGE_COMPUTER_MODEL  #language en-US  ""
 #string STR_FRONT_PAGE_CPU_MODEL       #language en-US  ""
 #string STR_FRONT_PAGE_CPU_SPEED       #language en-US  ""


### PR DESCRIPTION
Improve Hotkey Logic and Adjust BIOS MENU Page Design
1.Add deduplication logic to resolve the issue of duplicate Boot Options and enhance hotkey design. 
2.Revise the BIOS MENU VFR design.
Signed-off-by: lin peng <peng.lin@sophgo.com>