### PR TITLE
SG2044Pkg/AcpiTables: Correct the "_CCA" value of Dsdt/Pci.asl

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Pci.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Pci.asl
@@ -59,7 +59,7 @@ Scope(_SB)
     Name (_CID, "PNP0A03") // Compatible PCI Root Bridge
     Name (_SEG, 0)         // Segment of this Root complex
     Name (_BBN, 0)         // Base Bus Number
-    Name (_CCA, 0)
+    Name (_CCA, 1)
 
     // PCI Routing Table
     Name (_PRT, Package () {
@@ -220,7 +220,7 @@ Scope(_SB)
     Name (_CID, "PNP0A03") // Compatible PCI Root Bridge
     Name (_SEG, 1)         // Segment of this Root complex
     Name (_BBN, 0x0)      // Base Bus Number
-    Name (_CCA, 0)
+    Name (_CCA, 1)
 
     Name (_PRT, Package (){
       Package () {0xFFFF, 0, 0, 65},         // INT_A
@@ -379,7 +379,7 @@ Scope(_SB)
     Name (_CID, "PNP0A03") // Compatible PCI Root Bridge
     Name (_SEG, 2)         // Segment of this Root complex
     Name (_BBN, 0x0)      // Base Bus Number
-    Name (_CCA, 0)
+    Name (_CCA, 1)
 
     // PCI Routing Table
     Name (_PRT, Package () {
@@ -539,7 +539,7 @@ Scope(_SB)
     Name (_CID, "PNP0A03") // Compatible PCI Root Bridge
     Name (_SEG, 3)         // Segment of this Root complex
     Name (_BBN, 0x0)      // Base Bus Number
-    Name (_CCA, 0)
+    Name (_CCA, 1)
 
     // PCI Routing Table
     Name (_PRT, Package () {
@@ -699,7 +699,7 @@ Scope(_SB)
     Name (_CID, "PNP0A03") // Compatible PCI Root Bridge
     Name (_SEG, 0x4)         // Segment of this Root complex
     Name (_BBN, 0x0)      // Base Bus Number
-    Name (_CCA, 0)
+    Name (_CCA, 1)
 
     // PCI Routing Table
     Name (_PRT, Package () {

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/SG2044EvbDsdt.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/SG2044EvbDsdt.asl
@@ -19,7 +19,7 @@ DefinitionBlock ("DsdtTable.aml", "DSDT", 2, "SOPHGO", "2044    ",
   include ("Mmc.asl")
 //  include ("Ethernet.asl")
   include ("Intc.asl")
-//  include ("Pci.asl")
+  include ("Pci.asl")
 
   Scope (\_SB_.I2C1)
   {


### PR DESCRIPTION
 - "_CCA" means cache coherency attribute.

 - Value 0: The device does not have hardware managed cache coherency which corresponds to the dma-noncoherent of the DTS.

 - Value 1: The device has hardware managed cache coherency which corresponds to the dma-coherent of the DTS.

 - Other Values: Reserved.