### PR TITLE
SG2044Pkg/AcpiTables: update Spcr table to support earlycon

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -481,6 +481,9 @@
   gSophgoTokenSpaceGuid.PcdSDIOSourceClockFrequency|400000000
   gSophgoTokenSpaceGuid.PcdSDIOTransmissionClockFrequency|25000000
   gSophgoTokenSpaceGuid.PcdTrngBase|0x7040020000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x7030001000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate|500000000
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate|115200
 
 ################################################################################
 #

--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf.inc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf.inc
@@ -46,5 +46,3 @@ DEFINE VARS_FTW_SPARE_SIZE           = 0x00010000
 
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamBase                  = $(CODE_BASE_ADDRESS) + $(FW_SIZE) + 0x1FF0000
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                  = 0x10000
-
-SET gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase              = 0x7030001000

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044EvbAcpiTables.inf
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044EvbAcpiTables.inf
@@ -32,4 +32,5 @@
 
 [FixedPcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase
-  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Spcr.aslc
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Spcr.aslc
@@ -20,14 +20,14 @@
 #include <Library/AcpiLib.h>
 #include "SG2044AcpiHeader.h"
 
-STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
+STATIC EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_SOPHGO_TABLE Spcr = {
   RISCV_ACPI_HEADER (
     EFI_ACPI_6_5_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_SIGNATURE,
-    EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE,
-    EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_REVISION
+    EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_SOPHGO_TABLE,
+    EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_REVISION
   ),
   // UINT8                                   InterfaceType;
-  0x0015,
+  EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_INTERFACE_TYPE_16550,
   // UINT8                                   Reserved1[3];
   {
     EFI_ACPI_RESERVED_BYTE,
@@ -43,7 +43,7 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
   // UINT32                                  GlobalSystemInterrupt;
   42,
   // UINT8                                   BaudRate;
-  EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_BAUD_RATE_115200,
+  0,
   // UINT8                                   Parity;
   EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE_PARITY_NO_PARITY,
   // UINT8                                   StopBits;
@@ -68,8 +68,16 @@ STATIC EFI_ACPI_SERIAL_PORT_CONSOLE_REDIRECTION_TABLE Spcr = {
   0x00000000,
   // UINT8                                   PciSegment;
   0x00,
-  // UINT32                                  Reserved3;
-  EFI_ACPI_RESERVED_DWORD
+  // UINT32                                    UartClockFrequency;
+  FixedPcdGet32 (PcdSerialClockRate),
+  // UINT32                                    PreciseBaudRate;
+  FixedPcdGet32 (PcdSerialBaudRate),
+  // UINT16                                    NameSpaceStrLength;
+  16,
+  // UINT16                                    NameSpaceStrOffset;
+  88,
+  // CHAR8                                     NameSpaceString[0];
+  "ACPI.SerialPort"
 };
 
 //

--- a/Silicon/Sophgo/SG2044Pkg/Include/SG2044AcpiHeader.h
+++ b/Silicon/Sophgo/SG2044Pkg/Include/SG2044AcpiHeader.h
@@ -56,6 +56,39 @@
 #define OSC_CAP_PLAT_COORDINATED_LPI  (1U << 7)
 #define OSC_CAP_OS_INITIATED_LPI      (1U << 8)
 
+///
+/// Sophgo Serial Port Console Redirection Table Format Revision 4
+///
+#pragma pack(1)
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER               Header;
+  UINT8                                     InterfaceType;
+  UINT8                                     Reserved1[3];
+  EFI_ACPI_5_0_GENERIC_ADDRESS_STRUCTURE    BaseAddress;
+  UINT8                                     InterruptType;
+  UINT8                                     Irq;
+  UINT32                                    GlobalSystemInterrupt;
+  UINT8                                     BaudRate;
+  UINT8                                     Parity;
+  UINT8                                     StopBits;
+  UINT8                                     FlowControl;
+  UINT8                                     TerminalType;
+  UINT8                                     Reserved2;
+  UINT16                                    PciDeviceId;
+  UINT16                                    PciVendorId;
+  UINT8                                     PciBusNumber;
+  UINT8                                     PciDeviceNumber;
+  UINT8                                     PciFunctionNumber;
+  UINT32                                    PciFlags;
+  UINT8                                     PciSegment;
+  UINT32                                    UartClockFrequency;
+  UINT32                                    PreciseBaudRate;
+  UINT16                                    NameSpaceStrLength;
+  UINT16                                    NameSpaceStrOffset;
+  CHAR8                                     NameSpaceString[16];
+} EFI_ACPI_4_0_SERIAL_PORT_CONSOLE_REDIRECTION_SOPHGO_TABLE;
+#pragma pack(0)
+
 //
 // "RHCT" RISC-V Hart Capabilities Table
 //

--- a/Silicon/Sophgo/Sophgo.dec
+++ b/Silicon/Sophgo/Sophgo.dec
@@ -44,6 +44,9 @@
   gSophgoTokenSpaceGuid.PcdPhyResetGpio|FALSE|BOOLEAN|0x00001013
   gSophgoTokenSpaceGuid.PcdPhyResetGpioPin|0x0|UINT8|0x00001014
   gSophgoTokenSpaceGuid.PcdDwMac4DefaultMacAddress|0x0|UINT64|0x00001015
+  gSophgoTokenSpaceGuid.PcdSerialRegisterBase|0x0|UINT64|0x00001016
+  gSophgoTokenSpaceGuid.PcdSerialClockRateBase|0x0|UINT32|0x00001017
+  gSophgoTokenSpaceGuid.PcdSerialBaudRate|0x0|UINT32|0x00001018
 
 [PcdsDynamic]
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x0|UINT64|0x00001003


### PR DESCRIPTION
 - Use format revision 4 of Spcr table.

 - Get base, clock and baud of serial through pcd.