### PR TITLE
Update the SMBIOS table population code based on the latest conf.ini

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type04/PlatformProcessorFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type04/PlatformProcessorFunction.c
@@ -46,21 +46,22 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformProcessor) {
       AsciiStrToUnicodeStrS (value, UnicodeStr, SMBIOS_UNICODE_STRING_MAX_LENGTH);
       HiiSetString (mSmbiosPlatformDxeHiiHandle, InputStrToken->TokenArray[3], UnicodeStr, NULL);
     }
-
-    if (IniGetValueBySectionAndName ("CPU", "frequency", value) == 0) {
-      Status = AsciiStrDecimalToUintnS (value, &End, &Freq);
-      if (RETURN_ERROR (Status) || (End - value > 4)) {
-        return RETURN_UNSUPPORTED;
-      }
-      InputData->CurrentSpeed = Freq;
+    if (IniGetValueBySectionAndName("CPU", "frequency", value) == 0) {
+    	Status = AsciiStrDecimalToUintnS(value, &End, &Freq);
+    	if (RETURN_ERROR(Status)) {
+            return RETURN_UNSUPPORTED;
+    	}
+    	if (Freq >= 1000000) {
+            Freq = Freq / 1000000;
+    	}
+    	InputData->CurrentSpeed = Freq;
     }
-
     SmbiosPlatformDxeCreateTable (
       (VOID *)&Type4Record,
       (VOID *)&InputData,
       sizeof (SMBIOS_TABLE_TYPE4),
       InputStrToken
-      );
+    );
     if (Type4Record == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }
@@ -79,6 +80,6 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformProcessor) {
     InputData++;
     InputStrToken++;
   }
-
   return EFI_SUCCESS;
 }
+

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type07/PlatformCacheFunction.c
@@ -37,13 +37,12 @@ UpdateCacheSize(
       return RETURN_UNSUPPORTED;
     }
 
-    Bytes = Uint * 1024ULL;
-    Bytes32 = (Bytes > MAX_UINT32) ? MAX_UINT32 : (UINT32)Bytes;
-
-    if (Uint <= 0x7FFF) {
-      InstalledSizeValue = (UINT16)Uint;
+    Bytes = Uint / 1024;
+    Bytes32 = (Uint > MAX_UINT32) ? MAX_UINT32 : (UINT32)Uint;
+    if (Bytes <= 0x7FFF) {
+      InstalledSizeValue = (UINT16)Bytes;
     } else {
-      UINT64 Increments = Uint / 64;
+      UINT64 Increments = Bytes / 64;
       if (Increments > 0x7FFF) {
         Increments = 0x7FFF;
       }

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
@@ -51,8 +51,8 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
           if (RETURN_ERROR (Status)) {
             return RETURN_UNSUPPORTED;
           }
-          InputData->ExtendedSpeed = Uint;
-          InputData->ExtendedConfiguredMemorySpeed = Uint;
+          InputData->ExtendedSpeed = Uint / 1000000;
+          InputData->ExtendedConfiguredMemorySpeed = Uint / 1000000;
       }
 
       if (IniGetValueBySectionAndName ("DDR", "rank", value) == 0) {


### PR DESCRIPTION
- For CPU frequency in conf.ini, use the smallest unit and modify Type 04 to perform unit conversion.
- For cache size in conf.ini, use the smallest unit and modify Type 07 to perform unit conversion.
- For DDR data-rate in conf.ini, use the smallest unit and modify Type 17 to perform unit conversion.