### PR TITLE
SG2044Pkg/AcpiTables: update Rhct.alsc

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Rhct.aslc
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Rhct.aslc
@@ -46,9 +46,9 @@ STATIC EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE Rhct = {
   },
   {
     0,
-    226,                     // 8 + N + P: Size of this structure.
+    OFFSET_OF (EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE, CMONode) - OFFSET_OF (EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE, ISAStrNode),                     // 8 + N + P: Size of this structure.
     1,
-    216,
+    MAX_ISA_LENGTH,
     "rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt"
   },
   {

--- a/Silicon/Sophgo/SG2044Pkg/Include/SG2044AcpiHeader.h
+++ b/Silicon/Sophgo/SG2044Pkg/Include/SG2044AcpiHeader.h
@@ -97,7 +97,7 @@ typedef struct {
 // RHCT Revision (as defined in ACPI 6.5 spec.)
 //
 #define EFI_ACPI_6_6_RISCV_HART_CAPABILITIES_TABLE_REVISION  0x01
-
+#define MAX_ISA_LENGTH 256
 //
 // RISC-V Hart Capabilities Table header definition.  The rest of the table
 // must be defined in a platform specific manner.
@@ -116,7 +116,7 @@ typedef struct {
   UINT16     Length;
   UINT16     Revision;
   UINT16     ISALen;
-  CHAR8      ISAStr[218];
+  CHAR8      ISAStr[MAX_ISA_LENGTH];
 } EFI_ACPI_6_6_ISA_STRING_NODE_STRUCTURE;
 
 // CMO node structure


### PR DESCRIPTION
 - ISA Node: ISA length use fixed value(256), and ISA string maximum number of characters is 254.

 - Get ISA node length through "OFFSET_OF".