### PR TITLE
SG2044Pkg/AcpiTables: update "_CCA" value

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Mmc.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Mmc.asl
@@ -15,7 +15,7 @@ Scope(_SB)
   {
     Name (_HID, "SGPH0015")
     Name (_UID, 0x00)           // _UID: Unique ID
-    Name (_CCA, 0x01)           // _CCA: Cache Coherency Attribute
+    Name (_CCA, 0x00)           // _CCA: Cache Coherency Attribute
     Method (_STA)
     {
       Return(0x0)
@@ -50,7 +50,7 @@ Scope(_SB)
   {
     Name (_HID, "SGPH0016")
     Name (_UID, 0x1)
-    Name (_CCA, 0x01)           // _CCA: Cache Coherency Attribute
+    Name (_CCA, 0x00)           // _CCA: Cache Coherency Attribute
     Method (_STA)
     {
       Return(0xf)

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Uart.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Dsdt/Uart.asl
@@ -15,7 +15,6 @@ Scope(_SB)
     Name(_HID, "SGPH0003")              // _HID: Hardware ID
     Name(_CID, "HISI0032")              // _CID: Compatible ID
     Name(_UID, 0)
-    Name(_CCA, 1)                       // _CCA: Cache Coherency Attribute
     Name(_DSD, Package () {
       ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
       Package () {


### PR DESCRIPTION
 - All devices are dma-noncoherent except PCIe. If the device does not describe _CCA, the default value in the kernel is "cca=1". However, for a device without a DMA engine, without "_CCA", the default dma coherent has no effect.

 - Currently, in the APCI table, we only describe "_CCA" in SD, MMC and PCIe.