### PR TITLE
Sophgo/DwMac4SnpDxe: Fix the data length of `RecycledTxBuf`

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -43,7 +43,7 @@
   DEFINE NETWORK_ISCSI_ENABLE     = FALSE
 
   DEFINE FLASH_ENABLE             = TRUE
-  DEFINE ETH_ENABLE               = FALSE
+  DEFINE ETH_ENABLE               = TRUE
 
   #
   # x64 Emulator

--- a/Silicon/Sophgo/Drivers/Net/DwMac4SnpDxe/DwMac4DxeUtil.h
+++ b/Silicon/Sophgo/Drivers/Net/DwMac4SnpDxe/DwMac4DxeUtil.h
@@ -1064,10 +1064,9 @@ typedef struct {
   EFI_LOCK                               Lock;
 
   UINTN                                  RegBase;
-#if 1
+
   // Array of the recycled transmit buffer address
-  //UINT64                                 *RecycledTxBuf;
-  UINT8                                  *RecycledTxBuf;
+  UINT64                                 *RecycledTxBuf;
 
   // The maximum number of recycled buffer pointers in RecycledTxBuf
   UINT32                                 MaxRecycledTxBuf;
@@ -1077,7 +1076,6 @@ typedef struct {
 
   // For TX buffer DmaUnmap
   VOID                                   *MappingTxbuf;
-#endif
 } SOPHGO_SIMPLE_NETWORK_DRIVER;
 
 #define SNP_DRIVER_SIGNATURE             SIGNATURE_32('A', 'S', 'N', 'P')

--- a/Silicon/Sophgo/Drivers/Net/DwMac4SnpDxe/DwMac4SnpDxe.c
+++ b/Silicon/Sophgo/Drivers/Net/DwMac4SnpDxe/DwMac4SnpDxe.c
@@ -1073,7 +1073,7 @@ SnpTransmit (
   DMA_DESCRIPTOR                    *TxDescriptor;
   DMA_DESCRIPTOR                    *TxDescriptorMap;
   UINT8                             *EthernetPacket;
-  UINT8                             *Tmp;
+  UINT64                            *Tmp;
   EFI_STATUS                        Status;
   EFI_PHYSICAL_ADDRESS              TxBufferPhysAddress;
   UINT32                            Index;


### PR DESCRIPTION
- The `RecycledTxBuf` should be UINT64*

- Enable build ethernet driver by default