### PR TITLE
Platform/Sophgo/SG2044Pkg/SmbiosPlatformDxe: Modify the logic for ext…

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.c
@@ -23,7 +23,6 @@
 #include <Library/PrintLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/IniParserLib.h>
-#include <Library/IniParserLib/IniParserUtil.h>
 
 #include "SmbiosPlatformDxe.h"
 
@@ -35,77 +34,6 @@ STATIC EFI_STRING           mDefaultHiiDatabaseStr;
 STATIC EFI_SMBIOS_PROTOCOL  *mPlatformDxeSmbios = NULL;
 
 EFI_HII_HANDLE  mSmbiosPlatformDxeHiiHandle;
-
-#define MAX_SECTION_LENGTH	128
-#define MAX_NAME_LENGTH		128
-#define MAX_VALUE_LENGTH	128
-#define MAX_ENTRIES		500
-
-typedef struct {
-  CHAR8 Section[MAX_SECTION_LENGTH];  // section name
-  CHAR8 Name[MAX_NAME_LENGTH];        // name
-  CHAR8 Value[MAX_VALUE_LENGTH];      // value
-} INI_ENTRY;
-
-STATIC UINTN EntryCount = 0;
-STATIC INI_ENTRY gIniEntries[MAX_ENTRIES];
-
-INT32
-IniGetValueBySectionAndName (
-    CONST CHAR8 *Section,
-    CONST CHAR8 *Name,
-    CHAR8 *Value
- )
-{
-  for (UINTN i = 0; i < EntryCount; i++) {
-    if (AsciiStrCmp(gIniEntries[i].Section, Section) != 0)
-      continue;
-
-    if (AsciiStrCmp(gIniEntries[i].Name, Name) != 0)
-      continue;
-
-    AsciiStrCpyS(Value, SMBIOS_UNICODE_STRING_MAX_LENGTH, gIniEntries[i].Value);
-    return 0;
-  }
-
-  return -1;
-};
-
-INT32
-IniHandler (
-    VOID       *User,
-    CONST CHAR8 *Section,
-    CONST CHAR8 *Name,
-    CONST CHAR8 *Value
- )
-{
-    if (!AsciiStrCmp(Section, "eof"))
-      return 0;
-
-    if (EntryCount >= MAX_ENTRIES)
-      return 0;
-
-    AsciiStrCpyS(gIniEntries[EntryCount].Section, sizeof(gIniEntries[EntryCount].Section), Section);
-    AsciiStrCpyS(gIniEntries[EntryCount].Name, sizeof(gIniEntries[EntryCount].Name), Name);
-    AsciiStrCpyS(gIniEntries[EntryCount].Value, sizeof(gIniEntries[EntryCount].Value), Value);
-    EntryCount++;
-
-    return 1;
-}
-
-INT32
-IniConfIniParse (
-    IN INI_HANDLER   Handler,
-    IN VOID          *User
- )
-{
-    INT32 result = -1;
-
-    if (IsIniFileExist ())
-      result = IniParseString(MemoryData, Handler, User);
-
-    return result;
-}
 
 /**
   Standard EFI driver point. This driver parses the mSmbiosPlatformDataTable

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
@@ -54,6 +54,7 @@
   Platform/RISC-V/PlatformPkg/RiscVPlatformPkg.dec
   Silicon/RISC-V/ProcessorPkg/RiscVProcessorPkg.dec
   Silicon/Sophgo/Sophgo.dec
+  EmbeddedPkg/EmbeddedPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -64,6 +65,7 @@
   UefiDriverEntryPoint
   UefiLib
   IniParserLib
+  ConfigUtilsLib
 
 [Protocols]
   gEfiSmbiosProtocolGuid                            ## CONSUMED

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
@@ -12,6 +12,7 @@
 #include <Library/HiiLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PrintLib.h>
+#include <Library/ConfigUtilsLib.h>
 
 #include "SmbiosPlatformDxe.h"
 
@@ -22,6 +23,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
   SMBIOS_TABLE_TYPE17  *Type17Record;
   CHAR16               UnicodeStr[SMBIOS_UNICODE_STRING_MAX_LENGTH];
   CHAR8                value[SMBIOS_UNICODE_STRING_MAX_LENGTH];
+  UINT32               Size;
   UINT64	       Uint;
   CHAR8		       *End;
   InputData         = (SMBIOS_TABLE_TYPE17 *)RecordData;
@@ -62,7 +64,15 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
           }
           InputData->Attributes = Uint;
       }
-
+      if (UpdateSmbiosFromEfuse(1, 352, 4, &Size) == 0) {
+         UINT32 SizeInGB = Size * 8;
+         UINT32 DefaultSize = 0x4000000;
+	 if (SizeInGB != 64 && SizeInGB != 128) {
+              InputData->ExtendedSize = DefaultSize;
+         } else {
+	      InputData->ExtendedSize = Size;
+	 }
+      }
       SmbiosPlatformDxeCreateTable (
         (VOID *)&Type17Record,
         (VOID *)&InputData,

--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -196,6 +196,7 @@
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   IniParserLib|Silicon/Sophgo/Library/IniParserLib/IniParserLib.inf
+  ConfigUtilsLib|Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
 !ifdef $(SOURCE_DEBUG_ENABLE)
   PeCoffExtraActionLib|SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
   DebugCommunicationLib|SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.inf
@@ -821,7 +822,7 @@
 !if $(FLASH_ENABLE) == TRUE
   Silicon/Sophgo/SG2044Pkg/Drivers/FirmwareManagerUiDxe/FirmwareManagerUiDxe.inf
 !endif
-  Silicon/Sophgo/SG2044Pkg/Drivers/Information/ShowInformation.inf
+  Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigUiDxe.inf
 
   #

--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf
@@ -240,7 +240,7 @@ INF  Silicon/Sophgo/SG2044Pkg/Drivers/SetDateAndTime/SetDateAndTime.inf
 !if $(FLASH_ENABLE) == TRUE
 INF  Silicon/Sophgo/SG2044Pkg/Drivers/FirmwareManagerUiDxe/FirmwareManagerUiDxe.inf
 !endif
-INF  Silicon/Sophgo/SG2044Pkg/Drivers/Information/ShowInformation.inf
+INF  Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
 INF  Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigUiDxe.inf
 
 #

--- a/Silicon/Sophgo/Include/Library/ConfigUtilsLib.h
+++ b/Silicon/Sophgo/Include/Library/ConfigUtilsLib.h
@@ -1,0 +1,57 @@
+#ifndef __CONFIG_UTILS_H__
+#define __CONFIG_UTILS_H__
+
+#include <Uefi.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HiiLib.h>
+#include <Library/PrintLib.h>
+#include <Library/IniParserLib.h>
+#include <Library/IniParserLib/IniParserUtil.h>
+#include "Spifmc.h"
+#include "SpiNorFlash.h"
+#include "EfuseLib.h"
+
+#define MAX_SECTION_LENGTH      128
+#define MAX_NAME_LENGTH         128
+#define MAX_VALUE_LENGTH        128
+#define MAX_ENTRIES             500
+#define VERSION_OFFSET          0x0
+#define VERSION_SIZE            7
+#define DATE_OFFSET             0x100
+#define DATE_SIZE               10
+
+typedef struct {
+  CHAR8 Section[MAX_SECTION_LENGTH];
+  CHAR8 Name[MAX_NAME_LENGTH];
+  CHAR8 Value[MAX_VALUE_LENGTH];
+} INI_ENTRY;
+/**
+  Read version and date from storage.
+
+  @param[out] Version   The version string.
+  @param[out] Date      The date string.
+
+  @retval EFI_SUCCESS   Successfully retrieved version and date.
+  @retval Others        Error status.
+**/
+INT32
+ReadVersionAndDateFromFlash (
+  CHAR8 *Version,
+  CHAR8 *Date,
+  UINTN StartAddress,
+  UINTN EndAddress
+ );
+
+INT32
+UpdateSmbiosFromEfuse (
+  UINT32    BusNum,
+  UINT32    Offset,
+  UINT32    Count,
+  UINT32    *Size
+ );
+#endif // __CONFIG_UTILS_H__

--- a/Silicon/Sophgo/Include/Library/IniParserLib.h
+++ b/Silicon/Sophgo/Include/Library/IniParserLib.h
@@ -43,4 +43,56 @@ EFIAPI
 MacAddrIniParser (
   VOID
   );
+
+/**
+  Get the value associated with a section and name.
+
+  @param[in]  Section   The section name.
+  @param[in]  Name      The key name.
+  @param[out] Value     The value associated with the key.
+
+  @retval 0             Successfully retrieved the value.
+  @retval -1            The key was not found.
+**/
+INT32
+IniGetValueBySectionAndName (
+  CONST CHAR8 *Section,
+  CONST CHAR8 *Name,
+  CHAR8 *Value
+  );
+
+/**
+  Handler function for processing INI data.
+
+  @param[in] User       User-defined context data.
+  @param[in] Section    The current section name.
+  @param[in] Name       The current key name.
+  @param[in] Value      The current key value.
+
+  @retval 1             Successfully processed.
+  @retval 0             Parsing complete or failed.
+**/
+INT32
+IniHandler (
+  VOID       *User,
+  CONST CHAR8 *Section,
+  CONST CHAR8 *Name,
+  CONST CHAR8 *Value
+  );
+
+/**
+  Parse INI-format data.
+
+  @param[in] Handler    The handler function for processing INI data.
+  @param[in] User       User-defined context data.
+
+  @retval >=0           Number of successfully parsed key-value pairs.
+  @retval -1            Parsing failed.
+**/
+INT32
+IniConfIniParse (
+  IN INT32 (*Handler)(VOID *User, CONST CHAR8 *Section, CONST CHAR8 *Name, CONST CHAR8 *Value),
+  IN VOID  *User
+  );
+
 #endif /* INI_PARSER_LIB_H_ */

--- a/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.c
+++ b/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.c
@@ -1,0 +1,99 @@
+#include <Library/ConfigUtilsLib.h>
+
+INT32
+UpdateSmbiosFromEfuse (
+  UINT32    BusNum,
+  UINT32    Offset,
+  UINT32    Count,
+  UINT32    *Size
+  )
+{
+  EFI_STATUS Status;
+  UINT8 *Buffer = NULL;
+
+  if (Count == 0) {
+    DEBUG((DEBUG_ERROR, "Invalid Count: %u\n", Count));
+    return -1;
+  }
+
+   Buffer = AllocateZeroPool(Count);
+   if (Buffer == NULL) {
+    DEBUG((DEBUG_ERROR, "Failed to allocate memory for Buffer.\n"));
+    return -1;
+   }
+   if (Size == NULL) {
+    return -1;
+   }
+
+  Status = EfuseReadBytes(BusNum, Offset, Count, Buffer);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to read from eFuse: %r\n", Status));
+    return -1;
+  }
+
+  *Size = SwapBytes32(*(UINT32 *)Buffer);
+  return 0;
+}
+
+INT32
+ReadVersionAndDateFromFlash (
+  CHAR8 *Version,
+  CHAR8 *Date,
+  UINTN StartAddress,
+  UINTN EndAddress
+  )
+{
+  SOPHGO_NOR_FLASH_PROTOCOL *NorFlashProtocol = NULL;
+  SOPHGO_SPI_MASTER_PROTOCOL *SpiMasterProtocol = NULL;
+  SPI_NOR *Nor = NULL;
+  UINTN RangeSize;
+  UINT8 *Buffer = NULL;
+
+  if (Version == NULL || Date == NULL || StartAddress >= EndAddress) {
+    return -1;
+  }
+
+  RangeSize = EndAddress - StartAddress;
+
+  Buffer = AllocateZeroPool(RangeSize);
+
+  gBS->LocateProtocol(
+    &gSophgoSpiMasterProtocolGuid,
+    NULL,
+    (VOID **)&SpiMasterProtocol
+  );
+
+  gBS->LocateProtocol(
+    &gSophgoNorFlashProtocolGuid,
+    NULL,
+    (VOID **)&NorFlashProtocol
+  );
+
+  Nor = SpiMasterProtocol->SetupDevice(
+    SpiMasterProtocol,
+    NULL,
+    0
+  );
+
+  NorFlashProtocol->GetFlashid(Nor, TRUE);
+  NorFlashProtocol->Init(NorFlashProtocol, Nor);
+  EFI_STATUS Status = NorFlashProtocol->ReadData(
+    Nor,
+    StartAddress,
+    RangeSize,
+    Buffer
+  );
+  if(EFI_ERROR(Status)) {
+    return -1;
+  }
+
+  CopyMem(Version, Buffer + VERSION_OFFSET, VERSION_SIZE);
+  Version[VERSION_SIZE] = '\0';
+  CopyMem(Date, Buffer + DATE_OFFSET, DATE_SIZE);
+  Date[DATE_SIZE] = '\0';
+
+  SpiMasterProtocol->FreeDevice(Nor);
+  FreePool(Buffer);
+
+  return 0;
+}

--- a/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
+++ b/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
@@ -1,0 +1,55 @@
+## @file
+#  Implementation for ConfigUtils library class interfaces.
+#
+#  Copyright (c) 2025. SOPHGO Inc. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = ConfigUtilsLib
+  FILE_GUID                      = 3a5b09c3-f53d-4222-8a27-ca48f30a1010
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ConfigUtilsLib
+
+[Sources]
+  ConfigUtilsLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Sophgo/SG2044Pkg/SG2044Pkg.dec
+  Platform/RISC-V/PlatformPkg/RiscVPlatformPkg.dec
+  Silicon/RISC-V/ProcessorPkg/RiscVProcessorPkg.dec
+  Silicon/Sophgo/Sophgo.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HiiLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+  NorFlashInfoLib
+  TimerLib
+  EfuseLib
+
+[Protocols]
+  gSophgoNorFlashProtocolGuid                       ## CONSUMES
+  gSophgoSpiMasterProtocolGuid                      ## CONSUMES
+
+[Pcd]
+  gSophgoTokenSpaceGuid.PcdMisa
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwWorkingBase64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64
+  gSophgoTokenSpaceGuid.PcdFlashVariableOffset
+
+[Depex]
+  TRUE
+

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
@@ -339,7 +339,7 @@ ParseSmbiosTable (VOID) {
         if (Type17->Size & 0x8000) {
           ParsedData.MemorySize *= 1024;
         }
-
+        ParsedData.ExtendSize = Type17->ExtendedSize;
         ParsedData.ExtendedSpeed = Type17->ExtendedSpeed;
         switch (Type17->MemoryType) {
           case 0x1E:
@@ -406,6 +406,7 @@ FillInformationData (
   StrCpyS(InformationData->MemoryType, MAX_STRING_LENGTH, ParsedData->MemoryType);
   InformationData->ExtendedSpeed = ParsedData->ExtendedSpeed;
   InformationData->MemoryRank = ParsedData->MemoryRank;
+  InformationData->ExtendSize = ParsedData->ExtendSize / (1024 * 1024);
   StrCpyS(InformationData->BoardProductName, MAX_STRING_LENGTH, ParsedData->BaseboardProductName);
   StrCpyS(InformationData->BoardVersion, MAX_STRING_LENGTH, ParsedData->BaseboardManufacturer);
   StrCpyS(InformationData->ProductName, MAX_STRING_LENGTH, ParsedData->SystemProductName);
@@ -502,7 +503,7 @@ InformationInit(
   PrivateData->HiiHandle = HiiAddPackages(
     &mConfiginiGuid,
     DriverHandle,
-    ShowInformationVfrBin,
+    InformationVfrBin,
     InformationStrings,
     NULL
   );

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.h
@@ -44,7 +44,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define INFORMATION_PAGE_CALLBACK_DATA_SIGNATURE  SIGNATURE_32 ('S', 'G', 'I', 'S')
 #define END_DEVICE_PATH_LENGTH (sizeof(EFI_DEVICE_PATH_PROTOCOL))
 
-extern UINT8  ShowInformationVfrBin[];
+extern UINT8  InformationVfrBin[];
 extern EFI_FORM_BROWSER2_PROTOCOL  *gFormBrowser2;
 extern EFI_HII_CONFIG_ROUTING_PROTOCOL *gHiiConfigRouting;
 
@@ -108,6 +108,7 @@ typedef struct {
   UINT8  MemoryArrayUse;
   CHAR16 *MemoryManufacturer;
   UINT32 MemorySize;
+  UINT32 ExtendSize;
   UINT16 ExtendedSpeed;
   UINT8  MemoryRank;
   CHAR16 MemoryType[MAX_STRING_LENGTH];

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
@@ -14,7 +14,7 @@
   ENTRY_POINT                    = InformationInit
 
 [Sources]
-  ShowInformationVfr.Vfr
+  InformationVfr.Vfr
   InformationStrings.uni
   Information.c
   Information.h

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
@@ -29,6 +29,7 @@ typedef struct {
   UINT32 L1DCacheSize;
   UINT32 L2CacheSize;
   UINT32 L3CacheSize;
+  UINT32 ExtendSize;
   UINT16 ExtendedSpeed;
   UINT8  MemoryRank;
   CHAR16 BiosVersion[MAX_STRING_LENGTH];

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationStrings.uni
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationStrings.uni
@@ -32,7 +32,7 @@
 #string STR_L1_DCACHE_SIZE #language en-US "L1-DCache-Size(KB): "
 #string STR_L2_CACHE_SIZE #language en-US "L2-Cache-Size(KB): "
 #string STR_L3_CACHE_SIZE #language en-US "L3-Cache-Size(KB): "
-#string STR_MEMORY_SIZE #language en-US "DDR Size: "
+#string STR_MEMORY_SIZE  #language en-US "DDR Size(GB): "
 #string STR_MEMORY_SPEED #language en-US "DDR Speed(MT/s): "
 #string STR_MEMORY_RANK  #language en-US "DDR Rank: "
 #string STR_MEMORY_TYPE  #language en-US "DDR Type: "

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationVfr.Vfr
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationVfr.Vfr
@@ -150,6 +150,14 @@ formset
              maximum = 4,
              step    = 1,
      endnumeric;
+     numeric varid = InformationData.ExtendSize,
+             prompt = STRING_TOKEN(STR_MEMORY_SIZE),
+             help   = STRING_TOKEN(STR_NULL_STRING),
+             flags  = READ_ONLY,
+             minimum = 0,
+             maximum = 1000,
+             step    = 1,
+     endnumeric;
   endform;
 
   form formid = BOARD_FORM_ID,


### PR DESCRIPTION
- SmbiosPlatformDxe:
  - Type00: Update the logic for retrieving BIOS version and date in Type 0: Change the source from conf.ini to extracting the information from the firmware name.
  - Type17: Update the logic for retrieving DDR size in Type 17: Change the source from conf.ini to extracting the information from eFuse

- Silicon/Sophgo/ConfigUtilsLib: Abstract the logic for extracting information from SMBIOS into ConfigUtilsLib

- Silicon/Sophgo/SG2044Pkg/Information/: Display DDR size in GB.