### PR TITLE
Library/ConfigUtilsLib/: Fix Flash Read Hang

### DIFF
--- a/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
+++ b/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
@@ -51,5 +51,6 @@
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset
 
 [Depex]
-  TRUE
+  gSophgoSpiMasterProtocolGuid      AND
+  gSophgoNorFlashProtocolGuid
 


### PR DESCRIPTION
- ConfigUtilsLib.c: Add error handling to prevent boot hang when FLASH_ENABLE is FALSE, caused by attempting to read date and version from flash.

- ConfigUtilsLib.inf: Add dependencies for gSophgoSpiMasterProtocolGuid and gSophgoNorFlashProtocolGuid in the Depex section.