### PR TITLE
SmbiosInformation: Add a library for retrieving information from SMBIOS.

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -198,6 +198,7 @@
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   IniParserLib|Silicon/Sophgo/Library/IniParserLib/IniParserLib.inf
   ConfigUtilsLib|Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
+  SmbiosInformationLib|Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.inf
 !ifdef $(SOURCE_DEBUG_ENABLE)
   PeCoffExtraActionLib|SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
   DebugCommunicationLib|SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.inf

--- a/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
+++ b/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
@@ -1,0 +1,64 @@
+/**
+  @file
+  This header file defines the SMBIOS_PARSED_DATA structure and the
+  ParseSmbiosTable function, which extracts information from SMBIOS tables.
+
+  Copyright (c) Sophgo Inc. All rights reserved.
+**/
+
+#ifndef SMBIOS_INFORMATION_LIB_H
+#define SMBIOS_INFORMATION_LIB_H
+
+#include <Uefi.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UefiLib.h>
+#include <Library/PrintLib.h>
+#include <Protocol/Smbios.h>
+
+#define MAX_STRING_LENGTH 64
+
+typedef struct {
+  CHAR16 *BiosVendor;
+  CHAR16 *BiosVersion;
+  CHAR16 *BiosReleaseDate;
+  CHAR16 *SystemManufacturer;
+  CHAR16 *SystemProductName;
+  CHAR16 *SystemSerialNumber;
+  CHAR16 *BaseboardManufacturer;
+  CHAR16 *BaseboardProductName;
+  CHAR16 *ChassisManufacturer;
+  CHAR16 *ProcessorVersion;
+  UINT16 ProcessorCurrentSpeed;
+  UINT8  ProcessorCoreCount;
+  UINT8  ProcessorThreadCount;
+  UINT16 L1ICacheSize;
+  UINT16 L1DCacheSize;
+  UINT16 L2CacheSize;
+  UINT32 L3CacheSize;
+  UINT8 InstallableLanguages;
+  UINT8 BiosLanguageFlags;
+  UINT8  MemoryArrayLocation;
+  UINT8  MemoryArrayUse;
+  CHAR16 *MemoryManufacturer;
+  UINT32 MemorySize;
+  UINT32 ExtendSize;
+  UINT16 ExtendedSpeed;
+  UINT8  MemoryRank;
+  CHAR16 MemoryType[MAX_STRING_LENGTH];
+  UINT64 MemoryArrayMappedStartingAddress;
+  UINT64 MemoryArrayMappedEndingAddress;
+  UINT8 BootStatus;
+  UINT8 IPMIInterfaceType;
+  CHAR16 *SystemVersion;
+} SMBIOS_PARSED_DATA;
+
+INT32
+ParseSmbiosTable(
+  OUT SMBIOS_PARSED_DATA *ParsedData
+);
+
+#endif

--- a/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.c
+++ b/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.c
@@ -1,0 +1,251 @@
+/**
+  @file
+  This library provides functionality to parse SMBIOS tables and extract relevant information.
+  It defines a function ParseSmbiosTable, which retrieves system information from SMBIOS tables
+  and populates the provided SMBIOS_PARSED_DATA structure.
+
+  Copyright (c) Sophgo Inc. All rights reserved.
+**/
+
+#include <Library/SmbiosInformationLib.h>
+
+EFI_STATUS
+ExtractString(
+  IN  CHAR8   *OptionalStrStart,
+  IN  UINT8   Index,
+  OUT CHAR16  **String
+  )
+{
+  UINTN  StrSize;
+  CHAR8  *CurrentStrPtr;
+
+  if (String == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+  *String = NULL;
+
+  if (Index == 0) {
+    *String = AllocateZeroPool(sizeof(CHAR16));
+    if (*String == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+    return EFI_SUCCESS;
+  }
+
+  CurrentStrPtr = OptionalStrStart;
+  while (Index > 1 && *CurrentStrPtr != '\0') {
+    CurrentStrPtr += AsciiStrSize(CurrentStrPtr);
+    Index--;
+  }
+
+  if (Index != 1 || *CurrentStrPtr == '\0') {
+    *String = AllocateZeroPool(sizeof(CHAR16));
+    if (*String == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+    return EFI_NOT_FOUND;
+  }
+
+  StrSize = AsciiStrSize(CurrentStrPtr);
+  *String = AllocatePool(StrSize * sizeof(CHAR16));
+  if (*String == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  if (EFI_ERROR(AsciiStrToUnicodeStrS(CurrentStrPtr, *String, StrSize))) {
+    FreePool(*String);
+    *String = NULL;
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+INT32
+ParseSmbiosTable (
+  OUT SMBIOS_PARSED_DATA *ParsedData
+) {
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE        SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  EFI_STATUS               Status;
+
+  if (ParsedData == NULL) {
+    return -1;
+  }
+
+  ZeroMem(ParsedData, sizeof(SMBIOS_PARSED_DATA));
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+    return -1;
+  }
+
+  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  while (TRUE) {
+    Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+    if (EFI_ERROR(Status)) {
+      break;
+    }
+
+    switch (Record->Type) {
+      case SMBIOS_TYPE_BIOS_INFORMATION: {
+        SMBIOS_TABLE_TYPE0 *Type0 = (SMBIOS_TABLE_TYPE0 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosVersion, &ParsedData->BiosVersion);
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosReleaseDate, &ParsedData->BiosReleaseDate);
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->Vendor, &ParsedData->BiosVendor);
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_INFORMATION: {
+        SMBIOS_TABLE_TYPE1 *Type1 = (SMBIOS_TABLE_TYPE1 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Manufacturer, &ParsedData->SystemManufacturer);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->ProductName, &ParsedData->SystemProductName);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->SerialNumber, &ParsedData->SystemSerialNumber);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Version, &ParsedData->SystemVersion);
+        break;
+      }
+
+      case SMBIOS_TYPE_BASEBOARD_INFORMATION: {
+        SMBIOS_TABLE_TYPE2 *Type2 = (SMBIOS_TABLE_TYPE2 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->Manufacturer, &ParsedData->BaseboardManufacturer);
+        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->ProductName, &ParsedData->BaseboardProductName);
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_ENCLOSURE: {
+        SMBIOS_TABLE_TYPE3 *Type3 = (SMBIOS_TABLE_TYPE3 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type3 + Type3->Hdr.Length), Type3->Manufacturer, &ParsedData->ChassisManufacturer);
+        break;
+      }
+
+      case SMBIOS_TYPE_PROCESSOR_INFORMATION: {
+        SMBIOS_TABLE_TYPE4 *Type4 = (SMBIOS_TABLE_TYPE4 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type4 + Type4->Hdr.Length), Type4->ProcessorVersion, &ParsedData->ProcessorVersion);
+        ParsedData->ProcessorCurrentSpeed = Type4->CurrentSpeed;
+        ParsedData->ProcessorCoreCount = Type4->CoreCount;
+        ParsedData->ProcessorThreadCount = Type4->ThreadCount;
+        break;
+      }
+
+      case SMBIOS_TYPE_CACHE_INFORMATION: {
+        SMBIOS_TABLE_TYPE7 *Type7 = (SMBIOS_TABLE_TYPE7 *)Record;
+        UINT8 RawLevel = (UINT8)(Type7->CacheConfiguration & 0x7);
+        UINT64 CacheSizeInKB = 0;
+
+        if (Record->Length >= 0x18 && Type7->InstalledSize2 != 0) {
+          UINT32 InstalledSizeInBytes = Type7->InstalledSize2;
+          CacheSizeInKB = InstalledSizeInBytes / 1024;
+        } else {
+          UINT16 RawSize = Type7->InstalledSize;
+          if (RawSize & 0x8000) {
+            CacheSizeInKB = ((RawSize & 0x7FFF) * 64ULL);
+          } else {
+            CacheSizeInKB = (RawSize & 0x7FFF);
+          }
+        }
+        CHAR16 *LevelStr;
+        switch (RawLevel) {
+          case 0: LevelStr = L"L1"; break;
+          case 1: LevelStr = L"L2"; break;
+          case 2: LevelStr = L"L3"; break;
+          default: LevelStr = L"Unknown"; break;
+        }
+
+        UINT8 CacheType = Type7->SystemCacheType;
+        CHAR16 *CacheTypeStr = L"Unknown";
+        if (CacheType == CacheTypeInstruction) {
+          CacheTypeStr = L"Instruction";
+        } else if (CacheType == CacheTypeData) {
+          CacheTypeStr = L"Data";
+        } else if (CacheType == CacheTypeUnified) {
+          CacheTypeStr = L"Unified";
+        }
+
+        if (RawLevel == 0) {
+          if (CacheType == CacheTypeInstruction) {
+            ParsedData->L1ICacheSize = (UINT16)CacheSizeInKB;
+          } else if (CacheType == CacheTypeData) {
+            ParsedData->L1DCacheSize = (UINT16)CacheSizeInKB;
+          } else if (CacheType == CacheTypeUnified) {
+            ParsedData->L1ICacheSize = (UINT16)CacheSizeInKB;
+            ParsedData->L1DCacheSize = (UINT16)CacheSizeInKB;
+          }
+        } else if (RawLevel == 1) {
+          ParsedData->L2CacheSize = (UINT16)CacheSizeInKB;
+        } else if (RawLevel == 2) {
+          ParsedData->L3CacheSize = (UINT32)CacheSizeInKB;
+        }
+        break;
+      }
+
+      case SMBIOS_TYPE_BIOS_LANGUAGE_INFORMATION: {
+        SMBIOS_TABLE_TYPE13 *Type13 = (SMBIOS_TABLE_TYPE13 *)Record;
+        ParsedData->InstallableLanguages = Type13->InstallableLanguages;
+        ParsedData->BiosLanguageFlags = Type13->Flags;
+        break;
+      }
+
+      case SMBIOS_TYPE_PHYSICAL_MEMORY_ARRAY: {
+        SMBIOS_TABLE_TYPE16 *Type16 = (SMBIOS_TABLE_TYPE16 *)Record;
+        ParsedData->MemoryArrayLocation = Type16->Location;
+        ParsedData->MemoryArrayUse = Type16->Use;
+        break;
+      }
+
+      case SMBIOS_TYPE_MEMORY_DEVICE: {
+  	SMBIOS_TABLE_TYPE17 *Type17 = (SMBIOS_TABLE_TYPE17 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type17 + Type17->Hdr.Length), Type17->Manufacturer, &ParsedData->MemoryManufacturer);
+        ParsedData->MemorySize = (Type17->Size & 0x7FFF);
+        if (Type17->Size & 0x8000) {
+          ParsedData->MemorySize *= 1024;
+        }
+        ParsedData->ExtendSize = Type17->ExtendedSize;
+        ParsedData->ExtendedSpeed = Type17->ExtendedSpeed;
+        switch (Type17->MemoryType) {
+          case 0x1E:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"LPDDR4");
+            break;
+          case 0x23:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"LPDDR5");
+            break;
+          case 0x18:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"DDR3");
+            break;
+          case 0x1A:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"DDR4");
+            break;
+          default:
+            UnicodeSPrint(ParsedData->MemoryType, MAX_STRING_LENGTH * sizeof(CHAR16), L"Unknown (0x%X)", Type17->MemoryType);
+            break;
+        }
+        ParsedData->MemoryRank = Type17->Attributes & 0x0F;
+        break;
+      }
+
+      case SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS: {
+        SMBIOS_TABLE_TYPE19 *Type19 = (SMBIOS_TABLE_TYPE19 *)Record;
+        ParsedData->MemoryArrayMappedStartingAddress = Type19->StartingAddress;
+        ParsedData->MemoryArrayMappedEndingAddress = Type19->EndingAddress;
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_BOOT_INFORMATION: {
+        SMBIOS_TABLE_TYPE32 *Type32 = (SMBIOS_TABLE_TYPE32 *)Record;
+        ParsedData->BootStatus = Type32->BootStatus;
+        break;
+      }
+
+      case SMBIOS_TYPE_IPMI_DEVICE_INFORMATION: {
+        SMBIOS_TABLE_TYPE38 *Type38 = (SMBIOS_TABLE_TYPE38 *)Record;
+        ParsedData->IPMIInterfaceType = Type38->InterfaceType;
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.inf
+++ b/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.inf
@@ -1,0 +1,42 @@
+##
+#  @file
+#  This INF file describes the SmbiosInformationLib library, which provides
+#  functionality to parse SMBIOS tables and extract relevant system information.
+#
+#  Copyright (c) Sophgo Inc. All rights reserved.
+##
+
+[Defines]
+  INF_VERSION                    = 1.29
+  BASE_NAME                      = SmbiosInformationLib
+  FILE_GUID                      = 8cc98d6f-825f-40c4-9360-2e76e02d52c3
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmbiosInformationLib
+
+[Sources]
+  SmbiosInformationLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Sophgo/SG2044Pkg/SG2044Pkg.dec
+  Silicon/Sophgo/Sophgo.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  UefiBootServicesTableLib
+  UefiLib
+  MemoryAllocationLib
+  DevicePathLib
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                         ## CONSUMES
+
+[Pcd]
+
+[Depex]
+  TRUE
+

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
@@ -10,7 +10,7 @@
 EFI_HANDLE                  DriverHandle;
 INFORMATION_PAGE_CALLBACK_DATA *PrivateData;
 INFORMATION_DATA gInformationData;
-SMBIOS_PARSED_DATA ParsedData;
+SMBIOS_PARSED_DATA *ParsedData;
 EFI_GUID mConfiginiGuid = CONFIG_INI_FORMSET_GUID;
 
 HII_VENDOR_DEVICE_PATH mInformationHiiVendorDevicePath = {
@@ -48,58 +48,6 @@ DriverCallback(
 
   if (Action != EFI_BROWSER_ACTION_CHANGED && Action != EFI_BROWSER_ACTION_SUBMITTED) {
     return EFI_UNSUPPORTED;
-  }
-
-  return EFI_SUCCESS;
-}
-
-EFI_STATUS
-ExtractString(
-  IN  CHAR8   *OptionalStrStart,
-  IN  UINT8   Index,
-  OUT CHAR16  **String
-  )
-{
-  UINTN  StrSize;
-  CHAR8  *CurrentStrPtr;
-
-  if (String == NULL) {
-    return EFI_INVALID_PARAMETER;
-  }
-  *String = NULL;
-
-  if (Index == 0) {
-    *String = AllocateZeroPool(sizeof(CHAR16));
-    if (*String == NULL) {
-      return EFI_OUT_OF_RESOURCES;
-    }
-    return EFI_SUCCESS;
-  }
-
-  CurrentStrPtr = OptionalStrStart;
-  while (Index > 1 && *CurrentStrPtr != '\0') {
-    CurrentStrPtr += AsciiStrSize(CurrentStrPtr);
-    Index--;
-  }
-
-  if (Index != 1 || *CurrentStrPtr == '\0') {
-    *String = AllocateZeroPool(sizeof(CHAR16));
-    if (*String == NULL) {
-      return EFI_OUT_OF_RESOURCES;
-    }
-    return EFI_NOT_FOUND;
-  }
-
-  StrSize = AsciiStrSize(CurrentStrPtr);
-  *String = AllocatePool(StrSize * sizeof(CHAR16));
-  if (*String == NULL) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  if (EFI_ERROR(AsciiStrToUnicodeStrS(CurrentStrPtr, *String, StrSize))) {
-    FreePool(*String);
-    *String = NULL;
-    return EFI_DEVICE_ERROR;
   }
 
   return EFI_SUCCESS;
@@ -205,213 +153,28 @@ RouteConfig (
   return Status;
 }
 
-EFI_STATUS
-ParseSmbiosTable (VOID) {
-  EFI_SMBIOS_PROTOCOL      *Smbios;
-  EFI_SMBIOS_HANDLE        SmbiosHandle;
-  EFI_SMBIOS_TABLE_HEADER  *Record;
-  EFI_STATUS               Status;
-
-  ZeroMem(&ParsedData, sizeof(SMBIOS_PARSED_DATA));
-  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
-    return Status;
-  }
-
-  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
-  while (TRUE) {
-    Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
-    if (EFI_ERROR(Status)) {
-      break;
-    }
-
-    switch (Record->Type) {
-      case SMBIOS_TYPE_BIOS_INFORMATION: {
-        SMBIOS_TABLE_TYPE0 *Type0 = (SMBIOS_TABLE_TYPE0 *)Record;
-        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosVersion, &ParsedData.BiosVersion);
-        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosReleaseDate, &ParsedData.BiosReleaseDate);
-        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->Vendor, &ParsedData.BiosVendor);
-        break;
-      }
-
-      case SMBIOS_TYPE_SYSTEM_INFORMATION: {
-        SMBIOS_TABLE_TYPE1 *Type1 = (SMBIOS_TABLE_TYPE1 *)Record;
-        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Manufacturer, &ParsedData.SystemManufacturer);
-        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->ProductName, &ParsedData.SystemProductName);
-        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->SerialNumber, &ParsedData.SystemSerialNumber);
-        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Version, &ParsedData.SystemVersion);
-        break;
-      }
-
-      case SMBIOS_TYPE_BASEBOARD_INFORMATION: {
-        SMBIOS_TABLE_TYPE2 *Type2 = (SMBIOS_TABLE_TYPE2 *)Record;
-        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->Manufacturer, &ParsedData.BaseboardManufacturer);
-        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->ProductName, &ParsedData.BaseboardProductName);
-        break;
-      }
-
-      case SMBIOS_TYPE_SYSTEM_ENCLOSURE: {
-        SMBIOS_TABLE_TYPE3 *Type3 = (SMBIOS_TABLE_TYPE3 *)Record;
-        ExtractString((CHAR8 *)((UINT8 *)Type3 + Type3->Hdr.Length), Type3->Manufacturer, &ParsedData.ChassisManufacturer);
-        break;
-      }
-
-      case SMBIOS_TYPE_PROCESSOR_INFORMATION: {
-        SMBIOS_TABLE_TYPE4 *Type4 = (SMBIOS_TABLE_TYPE4 *)Record;
-        ExtractString((CHAR8 *)((UINT8 *)Type4 + Type4->Hdr.Length), Type4->ProcessorVersion, &ParsedData.ProcessorVersion);
-        ParsedData.ProcessorCurrentSpeed = Type4->CurrentSpeed;
-        ParsedData.ProcessorCoreCount = Type4->CoreCount;
-        ParsedData.ProcessorThreadCount = Type4->ThreadCount;
-        break;
-      }
-
-      case SMBIOS_TYPE_CACHE_INFORMATION: {
-        SMBIOS_TABLE_TYPE7 *Type7 = (SMBIOS_TABLE_TYPE7 *)Record;
-        UINT8 RawLevel = (UINT8)(Type7->CacheConfiguration & 0x7);
-        UINT64 CacheSizeInKB = 0;
-
-        if (Record->Length >= 0x18 && Type7->InstalledSize2 != 0) {
-          UINT32 InstalledSizeInBytes = Type7->InstalledSize2;
-          CacheSizeInKB = InstalledSizeInBytes / 1024;
-        } else {
-          UINT16 RawSize = Type7->InstalledSize;
-          if (RawSize & 0x8000) {
-            CacheSizeInKB = ((RawSize & 0x7FFF) * 64ULL);
-          } else {
-            CacheSizeInKB = (RawSize & 0x7FFF);
-          }
-        }
-        CHAR16 *LevelStr;
-        switch (RawLevel) {
-          case 0: LevelStr = L"L1"; break;
-          case 1: LevelStr = L"L2"; break;
-          case 2: LevelStr = L"L3"; break;
-          default: LevelStr = L"Unknown"; break;
-        }
-
-        UINT8 CacheType = Type7->SystemCacheType;
-        CHAR16 *CacheTypeStr = L"Unknown";
-        if (CacheType == CacheTypeInstruction) {
-          CacheTypeStr = L"Instruction";
-        } else if (CacheType == CacheTypeData) {
-          CacheTypeStr = L"Data";
-        } else if (CacheType == CacheTypeUnified) {
-          CacheTypeStr = L"Unified";
-        }
-
-        if (RawLevel == 0) {
-          if (CacheType == CacheTypeInstruction) {
-            ParsedData.L1ICacheSize = (UINT16)CacheSizeInKB;
-          } else if (CacheType == CacheTypeData) {
-            ParsedData.L1DCacheSize = (UINT16)CacheSizeInKB;
-          } else if (CacheType == CacheTypeUnified) {
-            ParsedData.L1ICacheSize = (UINT16)CacheSizeInKB;
-            ParsedData.L1DCacheSize = (UINT16)CacheSizeInKB;
-          }
-        } else if (RawLevel == 1) {
-          ParsedData.L2CacheSize = (UINT16)CacheSizeInKB;
-        } else if (RawLevel == 2) {
-          ParsedData.L3CacheSize = (UINT32)CacheSizeInKB;
-        }
-        break;
-      }
-
-      case SMBIOS_TYPE_BIOS_LANGUAGE_INFORMATION: {
-        SMBIOS_TABLE_TYPE13 *Type13 = (SMBIOS_TABLE_TYPE13 *)Record;
-        ParsedData.InstallableLanguages = Type13->InstallableLanguages;
-        ParsedData.BiosLanguageFlags = Type13->Flags;
-        break;
-      }
-
-      case SMBIOS_TYPE_PHYSICAL_MEMORY_ARRAY: {
-        SMBIOS_TABLE_TYPE16 *Type16 = (SMBIOS_TABLE_TYPE16 *)Record;
-        ParsedData.MemoryArrayLocation = Type16->Location;
-        ParsedData.MemoryArrayUse = Type16->Use;
-        break;
-      }
-
-      case SMBIOS_TYPE_MEMORY_DEVICE: {
-  	    SMBIOS_TABLE_TYPE17 *Type17 = (SMBIOS_TABLE_TYPE17 *)Record;
-
-        ExtractString((CHAR8 *)((UINT8 *)Type17 + Type17->Hdr.Length), Type17->Manufacturer, &ParsedData.MemoryManufacturer);
-        ParsedData.MemorySize = (Type17->Size & 0x7FFF);
-        if (Type17->Size & 0x8000) {
-          ParsedData.MemorySize *= 1024;
-        }
-        ParsedData.ExtendSize = Type17->ExtendedSize;
-        ParsedData.ExtendedSpeed = Type17->ExtendedSpeed;
-        switch (Type17->MemoryType) {
-          case 0x1E:
-            StrCpyS(ParsedData.MemoryType, MAX_STRING_LENGTH, L"LPDDR4");
-            break;
-          case 0x23:
-            StrCpyS(ParsedData.MemoryType, MAX_STRING_LENGTH, L"LPDDR5");
-            break;
-          case 0x18:
-            StrCpyS(ParsedData.MemoryType, MAX_STRING_LENGTH, L"DDR3");
-            break;
-          case 0x1A:
-            StrCpyS(ParsedData.MemoryType, MAX_STRING_LENGTH, L"DDR4");
-            break;
-          default:
-            UnicodeSPrint(ParsedData.MemoryType, MAX_STRING_LENGTH * sizeof(CHAR16), L"Unknown (0x%X)", Type17->MemoryType);
-            break;
-        }
-        ParsedData.MemoryRank = Type17->Attributes & 0x0F;
-        break;
-      }
-
-      case SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS: {
-        SMBIOS_TABLE_TYPE19 *Type19 = (SMBIOS_TABLE_TYPE19 *)Record;
-        ParsedData.MemoryArrayMappedStartingAddress = Type19->StartingAddress;
-        ParsedData.MemoryArrayMappedEndingAddress = Type19->EndingAddress;
-        break;
-      }
-
-      case SMBIOS_TYPE_SYSTEM_BOOT_INFORMATION: {
-        SMBIOS_TABLE_TYPE32 *Type32 = (SMBIOS_TABLE_TYPE32 *)Record;
-        ParsedData.BootStatus = Type32->BootStatus;
-        break;
-      }
-
-      case SMBIOS_TYPE_IPMI_DEVICE_INFORMATION: {
-        SMBIOS_TABLE_TYPE38 *Type38 = (SMBIOS_TABLE_TYPE38 *)Record;
-        ParsedData.IPMIInterfaceType = Type38->InterfaceType;
-        break;
-      }
-
-      default:
-        break;
-    }
-  }
-
-  return EFI_SUCCESS;
-}
-
 VOID
 FillInformationData (
-  IN SMBIOS_PARSED_DATA *ParsedData,
   OUT INFORMATION_DATA *InformationData
 ) {
-  StrCpyS(InformationData->BiosVendor, MAX_STRING_LENGTH, ParsedData->BiosVendor);
-  StrCpyS(InformationData->BiosVersion, MAX_STRING_LENGTH, ParsedData->BiosVersion);
-  StrCpyS(InformationData->BiosReleaseDate, MAX_STRING_LENGTH, ParsedData->BiosReleaseDate);
-  StrCpyS(InformationData->ProcessorVersion, MAX_STRING_LENGTH, ParsedData->ProcessorVersion);
+  StrCpyS(InformationData->BiosVendor, MAX_LENGTH, ParsedData->BiosVendor);
+  StrCpyS(InformationData->BiosVersion, MAX_LENGTH, ParsedData->BiosVersion);
+  StrCpyS(InformationData->BiosReleaseDate, MAX_LENGTH, ParsedData->BiosReleaseDate);
+  StrCpyS(InformationData->ProcessorVersion, MAX_LENGTH, ParsedData->ProcessorVersion);
   InformationData->ProcessorMaxSpeed = ParsedData->ProcessorCurrentSpeed;
   InformationData->L1ICacheSize = ParsedData->L1ICacheSize;
   InformationData->L1DCacheSize = ParsedData->L1DCacheSize;
   InformationData->L2CacheSize = ParsedData->L2CacheSize;
   InformationData->L3CacheSize = ParsedData->L3CacheSize;
-  StrCpyS(InformationData->MemoryType, MAX_STRING_LENGTH, ParsedData->MemoryType);
+  StrCpyS(InformationData->MemoryType, MAX_LENGTH, ParsedData->MemoryType);
   InformationData->ExtendedSpeed = ParsedData->ExtendedSpeed;
   InformationData->MemoryRank = ParsedData->MemoryRank;
   InformationData->ExtendSize = ParsedData->ExtendSize / (1024 * 1024);
-  StrCpyS(InformationData->BoardProductName, MAX_STRING_LENGTH, ParsedData->BaseboardProductName);
-  StrCpyS(InformationData->BoardVersion, MAX_STRING_LENGTH, ParsedData->BaseboardManufacturer);
-  StrCpyS(InformationData->ProductName, MAX_STRING_LENGTH, ParsedData->SystemProductName);
-  StrCpyS(InformationData->ProductVersion, MAX_STRING_LENGTH, ParsedData->SystemVersion);
-  StrCpyS(InformationData->Manufacturer, MAX_STRING_LENGTH, ParsedData->SystemManufacturer);
+  StrCpyS(InformationData->BoardProductName, MAX_LENGTH, ParsedData->BaseboardProductName);
+  StrCpyS(InformationData->BoardVersion, MAX_LENGTH, ParsedData->BaseboardManufacturer);
+  StrCpyS(InformationData->ProductName, MAX_LENGTH, ParsedData->SystemProductName);
+  StrCpyS(InformationData->ProductVersion, MAX_LENGTH, ParsedData->SystemVersion);
+  StrCpyS(InformationData->Manufacturer, MAX_LENGTH, ParsedData->SystemManufacturer);
 }
 
 EFI_STATUS
@@ -468,9 +231,27 @@ InformationInit(
 ) {
   EFI_STATUS Status;
   EFI_HII_CONFIG_ROUTING_PROTOCOL *HiiConfigRouting;
-
-  ParseSmbiosTable();
-  FillInformationData(&ParsedData, &gInformationData);
+  ParsedData = AllocateZeroPool(sizeof(SMBIOS_PARSED_DATA));
+  if (ParsedData == NULL) {
+    DEBUG((DEBUG_ERROR, "Failed to allocate memory for ParsedData\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+  if (ParseSmbiosTable(ParsedData) == -1) {
+     DEBUG((DEBUG_ERROR, "ParseSmbiosTable failed, initializing default values.\n"));
+     StrCpyS(ParsedData->BiosVendor, MAX_LENGTH, L"Unknown");
+     StrCpyS(ParsedData->BiosVersion, MAX_LENGTH, L"Unknown");
+     StrCpyS(ParsedData->BiosReleaseDate, MAX_LENGTH, L"Unknown");
+     ParsedData->ProcessorCurrentSpeed = 0;
+     ParsedData->L1ICacheSize = 0;
+     ParsedData->L1DCacheSize = 0;
+     ParsedData->L2CacheSize = 0;
+     ParsedData->L3CacheSize = 0;
+     StrCpyS(ParsedData->MemoryType, MAX_LENGTH, L"Unknown");
+     ParsedData->ExtendedSpeed = 0;
+     ParsedData->MemoryRank = 0;
+     ParsedData->ExtendSize = 0;
+  }
+  FillInformationData(&gInformationData);
   SyncToVarStore(&gInformationData);
   PrivateData = AllocateZeroPool(sizeof(INFORMATION_PAGE_CALLBACK_DATA));
   if (PrivateData == NULL) {

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.h
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/IniParserLib.h>
 #include <Library/IniParserLib/IniParserUtil.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/SmbiosInformationLib.h>
 #include <Guid/FileInfo.h>
 #include <Guid/MdeModuleHii.h>
 #include <Guid/FileInfo.h>
@@ -84,40 +85,6 @@ typedef struct {
   EFI_HII_CONFIG_ROUTING_PROTOCOL   *HiiConfigRouting;
 } INFORMATION_PAGE_CALLBACK_DATA;
 
-typedef struct {
-  CHAR16 *BiosVendor;
-  CHAR16 *BiosVersion;
-  CHAR16 *BiosReleaseDate;
-  CHAR16 *SystemManufacturer;
-  CHAR16 *SystemProductName;
-  CHAR16 *SystemSerialNumber;
-  CHAR16 *BaseboardManufacturer;
-  CHAR16 *BaseboardProductName;
-  CHAR16 *ChassisManufacturer;
-  CHAR16 *ProcessorVersion;
-  UINT16 ProcessorCurrentSpeed;
-  UINT8  ProcessorCoreCount;
-  UINT8  ProcessorThreadCount;
-  UINT16 L1ICacheSize;
-  UINT16 L1DCacheSize;
-  UINT16 L2CacheSize;
-  UINT32 L3CacheSize;
-  UINT8 InstallableLanguages;
-  UINT8 BiosLanguageFlags;
-  UINT8  MemoryArrayLocation;
-  UINT8  MemoryArrayUse;
-  CHAR16 *MemoryManufacturer;
-  UINT32 MemorySize;
-  UINT32 ExtendSize;
-  UINT16 ExtendedSpeed;
-  UINT8  MemoryRank;
-  CHAR16 MemoryType[MAX_STRING_LENGTH];
-  UINT64 MemoryArrayMappedStartingAddress;
-  UINT64 MemoryArrayMappedEndingAddress;
-  UINT8 BootStatus;
-  UINT8 IPMIInterfaceType;
-  CHAR16 *SystemVersion;
-} SMBIOS_PARSED_DATA;
 
 /**
   This function allows a caller to extract the current configuration for one

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.inf
@@ -44,6 +44,7 @@
   UefiHiiServicesLib
   UefiBootManagerLib
   IniParserLib
+  SmbiosInformationLib
 
 [Guids]
   gEfiIfrTianoGuid                              ## CONSUMES ## GUID (Extended IFR Guid Opcode)

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
@@ -20,8 +20,7 @@
 #define PRODUCT_FORM_ID                0x1005
 #define BOARD_FORM_ID                  0x1006
 #define VAR_INFORMATION_VARID          0x1007
-#define MAX_STRING_LENGTH 	       64
-
+#define MAX_LENGTH                     64
 #pragma pack(2)
 typedef struct {
   UINT16 ProcessorMaxSpeed;
@@ -32,17 +31,17 @@ typedef struct {
   UINT32 ExtendSize;
   UINT16 ExtendedSpeed;
   UINT8  MemoryRank;
-  CHAR16 BiosVersion[MAX_STRING_LENGTH];
-  CHAR16 BiosReleaseDate[MAX_STRING_LENGTH];
-  CHAR16 BiosVendor[MAX_STRING_LENGTH];
-  CHAR16 ProcessorVersion[MAX_STRING_LENGTH];
-  CHAR16 PartNumber[MAX_STRING_LENGTH];
-  CHAR16 MemoryType[MAX_STRING_LENGTH];
-  CHAR16 BoardProductName[MAX_STRING_LENGTH];
-  CHAR16 BoardVersion[MAX_STRING_LENGTH];
-  CHAR16 ProductName[MAX_STRING_LENGTH];
-  CHAR16 ProductVersion[MAX_STRING_LENGTH];
-  CHAR16 Manufacturer[MAX_STRING_LENGTH];
+  CHAR16 BiosVersion[MAX_LENGTH];
+  CHAR16 BiosReleaseDate[MAX_LENGTH];
+  CHAR16 BiosVendor[MAX_LENGTH];
+  CHAR16 ProcessorVersion[MAX_LENGTH];
+  CHAR16 PartNumber[MAX_LENGTH];
+  CHAR16 MemoryType[MAX_LENGTH];
+  CHAR16 BoardProductName[MAX_LENGTH];
+  CHAR16 BoardVersion[MAX_LENGTH];
+  CHAR16 ProductName[MAX_LENGTH];
+  CHAR16 ProductVersion[MAX_LENGTH];
+  CHAR16 Manufacturer[MAX_LENGTH];
 } INFORMATION_DATA;
 #pragma pack()
 #endif

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationVfr.Vfr
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationVfr.Vfr
@@ -54,21 +54,21 @@ formset
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      string varid = InformationData.BiosReleaseDate,
             prompt = STRING_TOKEN(STR_BIOS_RELEASE_DATE),
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      string varid = InformationData.BiosVendor,
             prompt = STRING_TOKEN(STR_BIOS_VENDOR),
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
   endform;
 
@@ -80,7 +80,7 @@ formset
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      numeric varid = InformationData.ProcessorMaxSpeed,
              prompt = STRING_TOKEN(STR_PROCESSOR_MAX_SPEED),
@@ -132,7 +132,7 @@ formset
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      numeric varid = InformationData.ExtendedSpeed,
              prompt = STRING_TOKEN(STR_MEMORY_SPEED),
@@ -168,14 +168,14 @@ formset
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      string varid = InformationData.BoardVersion,
             prompt = STRING_TOKEN(STR_BOARD_VERSION),
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
   endform;
 
@@ -187,21 +187,21 @@ formset
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      string varid = InformationData.ProductVersion,
             prompt = STRING_TOKEN(STR_PRODUCT_VERSION),
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
      string varid = InformationData.Manufacturer,
             prompt = STRING_TOKEN(STR_MANUFACTURER),
             help   = STRING_TOKEN(STR_NULL_STRING),
             flags  = READ_ONLY,
             minsize = 1,
-            maxsize = MAX_STRING_LENGTH,
+            maxsize = MAX_LENGTH,
      endstring;
   endform;
 endformset;


### PR DESCRIPTION
- SmbiosInformation: Extract information from all SMBIOS tables, with the function interface name provided as ParseSmbiosTable.

- SG2044Pkg/Information: Remove the original logic for extracting information in Information, use SmbiosInformationLib, and modify the corresponding display logic.