### PR TITLE
Sophgo: Modify the logic to get DDR size from eFuse

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
@@ -66,13 +66,29 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
           InputData->Attributes = Uint;
       }
       if (UpdateSmbiosFromEfuse(1, 352, 4, &Size) == 0) {
-         UINT32 SizeInGB = Size * 8;
-         UINT32 DefaultSize = 0x4000000;
-	 if (SizeInGB != 64 && SizeInGB != 128) {
-              InputData->ExtendedSize = DefaultSize;
-         } else {
-	      InputData->ExtendedSize = Size;
-	 }
+        if (((Size >> 13) & 0x1) ^ ((Size >> 12) & 0x1)) {
+          UINT32 capacityBits = (Size >> 2) & 0x3;
+          UINT32 dramCapacityMB;
+
+          switch (capacityBits) {
+          case 0:
+            dramCapacityMB = 128 * 1024 * 1024;
+            break;
+          case 1:
+            dramCapacityMB = 64 * 1024 * 1024;
+            break;
+          default:
+            dramCapacityMB = 0;
+            break;
+          }
+          if (dramCapacityMB == 0) {
+            InputData->ExtendedSize = 0x4000000;
+          } else {
+            InputData->ExtendedSize = dramCapacityMB;
+          }
+        } else {
+            InputData->ExtendedSize = 0x4000000;
+        }
       }
       SmbiosPlatformDxeCreateTable (
         (VOID *)&Type17Record,

--- a/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.c
+++ b/Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.c
@@ -22,11 +22,11 @@ UpdateSmbiosFromEfuse (
   }
   Status = EfuseReadBytes(BusNum, Offset, Count, Buffer);
   if (EFI_ERROR(Status)) {
+    FreePool(Buffer);
     DEBUG((DEBUG_ERROR, "Failed to read from eFuse: %r\n", Status));
     return -1;
   }
 
-  *Size = SwapBytes32(*(UINT32 *)Buffer);
   return 0;
 }
 


### PR DESCRIPTION
1.ConfigUtilsLib.c: Based on the corresponding eFuse cell,
  check the values of the 2nd and 3rd bits to determine the current channel rank type,
  and decide the DDR size of the current chip.

2.SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c:Add logic to release the allocated memory
  if reading from eFuse fails to avoid memory leaks.