### PR TITLE
SmbiosInformationLib: Update library functions.

### DIFF
--- a/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
+++ b/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
@@ -1,7 +1,7 @@
 /**
   @file
   This header file defines the SMBIOS_PARSED_DATA structure and the
-  ParseSmbiosTable function, which extracts information from SMBIOS tables.
+  AllocSmbiosData function, which extracts information from SMBIOS tables.
 
   Copyright (c) Sophgo Inc. All rights reserved.
 **/
@@ -56,9 +56,14 @@ typedef struct {
   CHAR16 *SystemVersion;
 } SMBIOS_PARSED_DATA;
 
-INT32
-ParseSmbiosTable(
-  OUT SMBIOS_PARSED_DATA *ParsedData
+SMBIOS_PARSED_DATA *
+AllocSmbiosData (
+  VOID
 );
+
+INT32
+FreeSmbiosData (
+  SMBIOS_PARSED_DATA *ParsedData
+) ;
 
 #endif

--- a/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.c
+++ b/Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.c
@@ -1,8 +1,9 @@
 /**
   @file
-  This library provides functionality to parse SMBIOS tables and extract relevant information.
-  It defines a function ParseSmbiosTable, which retrieves system information from SMBIOS tables
-  and populates the provided SMBIOS_PARSED_DATA structure.
+  This library provides functions to parse the SMBIOS table and extract relevant information.
+  It defines a function AllocSmbiosData, which retrieves system information from the SMBIOS
+  table and fills the SMBIOS_PARSED_DATA structure, returning a structure pointer of type
+  SMBIOS_PARSED_DATA to the caller.
 
   Copyright (c) Sophgo Inc. All rights reserved.
 **/
@@ -61,24 +62,29 @@ ExtractString(
   return EFI_SUCCESS;
 }
 
-INT32
-ParseSmbiosTable (
-  OUT SMBIOS_PARSED_DATA *ParsedData
+SMBIOS_PARSED_DATA *
+AllocSmbiosData (
+  VOID
 ) {
   EFI_SMBIOS_PROTOCOL      *Smbios;
   EFI_SMBIOS_HANDLE        SmbiosHandle;
   EFI_SMBIOS_TABLE_HEADER  *Record;
   EFI_STATUS               Status;
 
+  SMBIOS_PARSED_DATA       *ParsedData;
+  ParsedData = AllocateZeroPool(sizeof(SMBIOS_PARSED_DATA));
+
   if (ParsedData == NULL) {
-    return -1;
+    DEBUG((DEBUG_ERROR, "Failed to allocate memory for ParsedData\n"));
+    return NULL;
   }
 
   ZeroMem(ParsedData, sizeof(SMBIOS_PARSED_DATA));
   Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
   if (EFI_ERROR(Status)) {
     DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
-    return -1;
+    FreePool(ParsedData);
+    return NULL;
   }
 
   SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
@@ -247,5 +253,50 @@ ParseSmbiosTable (
     }
   }
 
-  return EFI_SUCCESS;
+  return ParsedData;
+}
+
+INT32
+FreeSmbiosData (
+  IN SMBIOS_PARSED_DATA *ParsedData
+) {
+  if (ParsedData == NULL) {
+    DEBUG((DEBUG_ERROR, "%a:ParsedData Ptr NULL\n",__func__));
+    return -1;
+  }
+  if (ParsedData->BiosVendor != NULL)
+    FreePool(ParsedData->BiosVendor);
+
+  if (ParsedData->BiosVersion != NULL)
+    FreePool(ParsedData->BiosVersion);
+
+  if (ParsedData->BiosReleaseDate != NULL)
+    FreePool(ParsedData->BiosReleaseDate);
+
+  if (ParsedData->SystemManufacturer != NULL)
+    FreePool(ParsedData->SystemManufacturer);
+
+  if (ParsedData->SystemProductName != NULL)
+    FreePool(ParsedData->SystemProductName);
+
+  if (ParsedData->SystemSerialNumber != NULL)
+    FreePool(ParsedData->SystemSerialNumber);
+
+  if (ParsedData->BaseboardManufacturer != NULL)
+    FreePool(ParsedData->BaseboardManufacturer);
+
+  if (ParsedData->BaseboardProductName != NULL)
+    FreePool(ParsedData->BaseboardProductName);
+
+  if (ParsedData->ChassisManufacturer != NULL)
+    FreePool(ParsedData->ChassisManufacturer);
+
+  if (ParsedData->ProcessorVersion != NULL)
+    FreePool(ParsedData->ProcessorVersion);
+
+  if (ParsedData->MemoryManufacturer != NULL)
+    FreePool(ParsedData->MemoryManufacturer);
+
+  FreePool(ParsedData);
+  return 1;
 }

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/Information.c
@@ -231,25 +231,26 @@ InformationInit(
 ) {
   EFI_STATUS Status;
   EFI_HII_CONFIG_ROUTING_PROTOCOL *HiiConfigRouting;
-  ParsedData = AllocateZeroPool(sizeof(SMBIOS_PARSED_DATA));
+  ParsedData = AllocSmbiosData();
   if (ParsedData == NULL) {
-    DEBUG((DEBUG_ERROR, "Failed to allocate memory for ParsedData\n"));
-    return EFI_OUT_OF_RESOURCES;
-  }
-  if (ParseSmbiosTable(ParsedData) == -1) {
-     DEBUG((DEBUG_ERROR, "ParseSmbiosTable failed, initializing default values.\n"));
-     StrCpyS(ParsedData->BiosVendor, MAX_LENGTH, L"Unknown");
-     StrCpyS(ParsedData->BiosVersion, MAX_LENGTH, L"Unknown");
-     StrCpyS(ParsedData->BiosReleaseDate, MAX_LENGTH, L"Unknown");
-     ParsedData->ProcessorCurrentSpeed = 0;
-     ParsedData->L1ICacheSize = 0;
-     ParsedData->L1DCacheSize = 0;
-     ParsedData->L2CacheSize = 0;
-     ParsedData->L3CacheSize = 0;
-     StrCpyS(ParsedData->MemoryType, MAX_LENGTH, L"Unknown");
-     ParsedData->ExtendedSpeed = 0;
-     ParsedData->MemoryRank = 0;
-     ParsedData->ExtendSize = 0;
+    DEBUG((DEBUG_ERROR, "ParseSmbiosTable failed, initializing default values.\n"));
+    ParsedData = AllocateZeroPool(sizeof(SMBIOS_PARSED_DATA));
+    if (ParsedData == NULL) {
+      DEBUG((DEBUG_ERROR, "Failed to allocate memory for ParsedData\n"));
+      return EFI_OUT_OF_RESOURCES;
+    }
+    StrCpyS(ParsedData->BiosVendor, MAX_LENGTH, L"Unknown");
+    StrCpyS(ParsedData->BiosVersion, MAX_LENGTH, L"Unknown");
+    StrCpyS(ParsedData->BiosReleaseDate, MAX_LENGTH, L"Unknown");
+    ParsedData->ProcessorCurrentSpeed = 0;
+    ParsedData->L1ICacheSize = 0;
+    ParsedData->L1DCacheSize = 0;
+    ParsedData->L2CacheSize = 0;
+    ParsedData->L3CacheSize = 0;
+    StrCpyS(ParsedData->MemoryType, MAX_LENGTH, L"Unknown");
+    ParsedData->ExtendedSpeed = 0;
+    ParsedData->MemoryRank = 0;
+    ParsedData->ExtendSize = 0;
   }
   FillInformationData(&gInformationData);
   SyncToVarStore(&gInformationData);
@@ -317,8 +318,14 @@ InformationUnload(
     HiiRemovePackages(PrivateData->HiiHandle);
   }
 
-  FreePool(PrivateData);
-  PrivateData = NULL;
+  if (PrivateData != NULL) {
+    FreePool(PrivateData);
+    PrivateData = NULL;
+  }
+  if (ParsedData != NULL) {
+    FreeSmbiosData(ParsedData);
+    ParsedData = NULL;
+  }
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
- AllocSmbiosData:Returns a pointer to the SMBIOS_PARSED_DATA structure type, which stores the parsed smbios information.
- FreeSmbiosData:The inverse function of the AllocSmbiosData function is used to release memory.