### PR TITLE
SG2044Pkg: Modify MENU layout and add BMC support

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Drivers/BmcLanConfigDxe/BmcLanConfigNv.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/BmcLanConfigDxe/BmcLanConfigNv.h
@@ -10,7 +10,7 @@ Copyright (c) 2025  Sophgo Corporation. All rights reserved.<BR>
 
 #define BMC_FORMSET_GUID                    { 0x84618f61, 0xed56, 0x430d, { 0x9a, 0xea, 0x7a, 0xa4, 0x8e, 0x01, 0x21, 0xf4 } }
 #define VAR_BMC_DATA_GUID                   { 0x11a0dfca, 0x0cf7, 0x4d03, { 0xb5, 0x2a, 0x97, 0xe6, 0x9a, 0xdb, 0xc6, 0xbc } }
-#define BMC_FORM_ID                         0x1006
+#define BMC_FORM_ID                         0x3200
 #define DHCP_QUESTION_ID                    0x1001
 #define VAR_BMC_VARID                       0x1010
 #define NETWORK_SET_FORM_ID                 0x1235

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/Information/InformationNVDataStruc.h
@@ -12,16 +12,16 @@
 #define CONFIG_INI_FORMSET_GUID        {0x4a618233, 0x07f9, 0x4d73, {0x91, 0x53, 0x51, 0x1f, 0x28, 0x93, 0xa0, 0x1e}}
 #define LABEL_START		       0x1000
 #define LABEL_END                      0xffff
-#define CONFIG_FORM_ID                 0x1000
-#define BIOS_INFORMATION_FORM_ID       0x1001
-#define DDR_FORM_ID                    0x1002
-#define CPU_FORM_ID                    0x1003
-#define CHASSIS_FORM_ID                0x1004
-#define PRODUCT_FORM_ID                0x1005
-#define BOARD_FORM_ID                  0x1006
-#define VAR_INFORMATION_VARID          0x1007
+#define CONFIG_FORM_ID                 0x3300
+#define BIOS_INFORMATION_FORM_ID       0x3301
+#define DDR_FORM_ID                    0x3302
+#define CPU_FORM_ID                    0x3303
+#define CHASSIS_FORM_ID                0x3304
+#define PRODUCT_FORM_ID                0x3305
+#define BOARD_FORM_ID                  0x3306
+#define VAR_INFORMATION_VARID          0x3307
 #define MAX_LENGTH                     64
-#pragma pack(2)
+#pragma pack(4)
 typedef struct {
   UINT16 ProcessorMaxSpeed;
   UINT32 L1ICacheSize;

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigData.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigData.h
@@ -23,7 +23,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define VARSTORE_ID_PASSWORD_CONFIG              0x9100
 #define PASSWORD_PRIV                            L"PasswordPriv"
 
-#pragma pack(2)
+#pragma pack(4)
 typedef struct {
   UINT8         UserPasswordEnable;
   UINT8         AdminPasswordEnable;

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigFormGuid.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/PasswordConfigDxe/PasswordConfigFormGuid.h
@@ -11,14 +11,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define  PASSWORD_CONFIG_VARIABLE          L"PasswordConfigSetup"
 
-#define  FORM_PASSWORDCONFIG_ID            0x9001
+#define  FORM_PASSWORDCONFIG_ID            0x3400
 
-#define  TRIGGER_ID                        0x9101
+#define  TRIGGER_ID                        0x3401
 
-#define  FORM_USER_PASSWD_OPEN               0x9f05
-#define  FORM_ADMIN_PASSWD_OPEN              0x9f06
-#define  FORM_CLEAN_USER_PASSWORD            0x9f07
-#define  FORM_USER_PASSWD_ENABLE             0x9f08
+#define  FORM_USER_PASSWD_OPEN               0x3405
+#define  FORM_ADMIN_PASSWD_OPEN              0x3406
+#define  FORM_CLEAN_USER_PASSWORD            0x3407
+#define  FORM_USER_PASSWD_ENABLE             0x3408
 
 #define  LABEL_FORM_PASSWORDCONFIG_START   0xff0c
 #define  LABEL_FORM_PASSWORDCONFIG_END     0xff0d

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/SetDateAndTime/SetDateAndTimeNv.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/SetDateAndTime/SetDateAndTimeNv.h
@@ -10,16 +10,16 @@ Copyright (c) 2024, Sophgo Corporation. All rights reserved.<BR>
 
 #define TIME_SET_FORMSET_GUID { 0x308a3744, 0x6aa6, 0x4f37,{ 0xae, 0x9d, 0xfd, 0xc3, 0xc6, 0xb0, 0xd6, 0x86 } }
 #define VAR_TIME_DATA_GUID { 0x2dc2c423, 0xae8f, 0x4283, { 0x94, 0x30, 0xc4, 0xd5, 0xd8, 0xbc, 0xe0, 0xe8 } }
-#define TIME_SET_FORM_ID 0x8000
+#define TIME_SET_FORM_ID 0x3500
 #define LABEL_TIME 	 0x1000
 #define LABEL_END  	 0xffff
-#define QUESTION_ID_TIME 0x8005
-#define QUESTION_ID_DATE 0x8004
+#define QUESTION_ID_TIME 0x3505
+#define QUESTION_ID_DATE 0x3504
 #define VAR_DYNAMIC_TIME_VARID 0x1004
 //
 // NV Data Structure Definition
 //
-#pragma pack(1)
+#pragma pack(4)
 typedef struct {
   UINT16 Year;
   UINT8  Month;

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.h
@@ -35,10 +35,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "FrontPageCustomizedUiSupport.h"
 #include <Library/PasswordRead.h>
 #include <Library/RestoreDefaults.h>
+#include <Library/SmbiosInformationLib.h>
 
 #define PRINTABLE_LANGUAGE_NAME_STRING_ID  0x0001
-#define FRONT_PAGE_FORM_ID  0x1000
-#define CONFIG_FORM_ID         0x1000
 #define FRONT_PAGE_CALLBACK_DATA_SIGNATURE  SIGNATURE_32 ('F', 'P', 'C', 'B')
 #define EFI_FP_CALLBACK_DATA_FROM_THIS(a) \
   CR (a, \
@@ -50,7 +49,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 extern UINT8  FrontPageVfrBin[];
 extern EFI_FORM_BROWSER2_PROTOCOL  *gFormBrowser2;
-
+extern EFI_GUID mFrontPageGuid;
 typedef struct {
   UINTN                             Signature;
   EFI_HII_HANDLE                    HiiHandle;

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageCustomizedUi.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageCustomizedUi.c
@@ -31,7 +31,6 @@ UiCustomizeFrontPage (
   // Find third party drivers which need to be shown in the front page.
   //
   UiListThirdPartyDrivers (HiiHandle, &gEfiIfrFrontPageGuid, NULL, StartOpCodeHandle);
-
   //
   // Create empty line.
   //

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
@@ -16,26 +16,32 @@
 #define FORMSET_GUID                      { 0xadf98142, 0x42c4, 0x429c, { 0x9f, 0xa4, 0x62, 0x3f, 0xf9, 0x94, 0xa1, 0x40 } }
 #define TIME_SET_FORMSET_GUID             { 0x308a3744, 0x6aa6, 0x4f37, { 0xae, 0x9d, 0xfd, 0xc3, 0xc6, 0xb0, 0xd6, 0x86 } }
 #define CONFIG_INI_FORMSET_GUID           { 0x4a618233, 0x07f9, 0x4d73, { 0x91, 0x53, 0x51, 0x1f, 0x28, 0x93, 0xa0, 0x1e } }
-#define PASSWORD_TOGGLE_VARSTORE_GUID      { 0x570cf83d, 0x5a8d, 0x4f79, { 0x91, 0xa9, 0xba, 0x82, 0x8f, 0x05, 0x79, 0xf6 } }
+#define PASSWORD_TOGGLE_VARSTORE_GUID     { 0x570cf83d, 0x5a8d, 0x4f79, { 0x91, 0xa9, 0xba, 0x82, 0x8f, 0x05, 0x79, 0xf6 } }
+#define BMC_FORMSET_GUID                  { 0x84618f61, 0xed56, 0x430d, { 0x9a, 0xea, 0x7a, 0xa4, 0x8e, 0x01, 0x21, 0xf4 } }
 #define FRONT_PAGE_FORM_ID             0x1000
-#define NEW_FORM_ID                    0x1000
-#define TIME_SET_ID                    0x8000
-#define LABEL_TIME_START               0xfffe
-#define LABEL_LANGUAGE                 0x1004
-#define LABEL_MANAGER                  0x1000
-#define LABEL_END                      0xffff
-#define CONFIG_FORM_ID                 0x1000
-#define LABEL_CONFIG_START             0x1000
-#define LABEL_CONFIG_END               0xffff
-#define FORM_PASSWORDCONFIG_ID         0x9001
-#define VARSTORE_ID_PASSWORD_CHECK     0x1005
-#define RESTORE_DEFAULTS_QUESTION_ID   0x3001
+#define SYSTEM_INFORMATION_ID          0x3000
+#define SYSTEM_SETTING_ID              0x3100
+#define BMC_FORM_ID                    0x3200
+#define INFORMATION_FORM_ID            0x3300
+#define FORM_PASSWORDCONFIG_ID         0x3400
+#define TIME_SET_ID                    0x3500
+#define SERIAL_PORT_FORM_ID            0x3600
+#define VARSTORE_ID_PASSWORD_CHECK     0x4000
+#define RESTORE_DEFAULTS_QUESTION_ID   0x4001
+#define SERIAL_PORT_QUESTION_ID        0x5000
 
+#define LABEL_TIME_START               0x2000
+#define LABEL_LANGUAGE                 0x2001
+#define LABEL_END                      0x2FFF
+#define LABEL_MANAGER                  0x2002
+#pragma pack(4)
 typedef struct {
   UINT8 PasswordCheckEnabled;
   UINT8 IsFirst;
   UINT8 UserPriv;
+  UINT8 IsEvb;
 } PASSWORD_TOGGLE_DATA;
+#pragma pack()
 #endif
 
 

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
@@ -76,4 +76,11 @@
 #string STR_RESET_SUCCESS_PROMPT       #language en-US "Defaults restored successfully."
 #string STR_SHUTDOWN_STRING_HELP       #language en-US "Power off"
 #string STR_SHUTDOWN_STRING            #language en-US "Power off"
-
+#string STR_SYSTEM_INFORMATION_PROMPT  #language en-US "System Information"
+#string STR_SYSTEM_INFORMATION_HELP    #language en-US "String identifier for displaying the prompt of system information."
+#string STR_SYSTEM_INFORMATION_TITLE #language en-US "System Information"
+#string STR_SYSTEM_SETTING_PROMPT    #language en-US "System Setting"
+#string STR_SYSTEM_SETTING_HELP      #language en-US "String identifier for providing help text related to system settings."
+#string STR_SYSTEM_SETTING_TITLE     #language en-US "System Setting"
+#string STR_GOTO_BMC                 #language en-US "BMC Config"
+#string STR_GOTO_BMC_HELP            #language en-US "BMC configuration settings."

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
@@ -21,40 +21,28 @@ formset
     label LABEL_END;
     label LABEL_LANGUAGE;
     label LABEL_END;
-    goto
-      formsetguid = CONFIG_INI_FORMSET_GUID,
-      formid  = NEW_FORM_ID,
-      question = NEW_FORM_ID,
-      prompt  = STRING_TOKEN(STR_GOTO_DYNAMIC),
-      help    = STRING_TOKEN(STR_GOTO_HELP),
-      flags   = INTERACTIVE;
-    goto
-      formsetguid = PASSWORDCONFIG_FORMSET_GUID,
-      formid  =  FORM_PASSWORDCONFIG_ID,
-      question = FORM_PASSWORDCONFIG_ID,
-      prompt  = STRING_TOKEN(STR_GOTO_PASSWORD),
-      help    = STRING_TOKEN(STR_GOTO_PASSWORD_HELP),
-      flags   = INTERACTIVE;
-    goto
-      formsetguid = TIME_SET_FORMSET_GUID,
-      formid  = TIME_SET_ID,
-      question = TIME_SET_ID,
-      prompt  = STRING_TOKEN(STR_GOTO_TIME_SET),
-      help    = STRING_TOKEN(STR_GOTO_TIME_SET_HELP),
-      flags   = INTERACTIVE;
-    goto 0x1234,
-      prompt  = STRING_TOKEN(STR_SERIALPORT),
-      help    = STRING_TOKEN(STR_SERIALPORT_HELP),
+    goto SYSTEM_INFORMATION_ID,
+      prompt  = STRING_TOKEN(STR_SYSTEM_INFORMATION_PROMPT),
+      help    = STRING_TOKEN(STR_SYSTEM_INFORMATION_HELP),
       flags   = INTERACTIVE,
-      key     = 0x1234;
+      key     = SYSTEM_INFORMATION_ID;
+    goto SYSTEM_SETTING_ID,
+      prompt  = STRING_TOKEN(STR_SYSTEM_SETTING_PROMPT),
+      help    = STRING_TOKEN(STR_SYSTEM_SETTING_HELP),
+      flags   = INTERACTIVE,
+      key     = SYSTEM_SETTING_ID;
+   suppressif ideqval PASSWORD_TOGGLE_DATA.IsEvb == 1;
+    goto
+          formsetguid = BMC_FORMSET_GUID,
+          formid  = BMC_FORM_ID,
+          question = BMC_FORM_ID,
+          prompt  = STRING_TOKEN(STR_GOTO_BMC),
+          help    = STRING_TOKEN(STR_GOTO_BMC_HELP),
+          flags   = INTERACTIVE;
+   endif;
     label LABEL_MANAGER;
     label LABEL_END;
    grayoutif ideqval PASSWORD_TOGGLE_DATA.IsFirst == 1 AND ideqval PASSWORD_TOGGLE_DATA.UserPriv == 0 AND ideqval PASSWORD_TOGGLE_DATA.PasswordCheckEnabled == 1;
-    text
-       help     = STRING_TOKEN(STR_RESET_TO_DEFAULTS_HELP),
-       text   = STRING_TOKEN(STR_RESET_TO_DEFAULTS_PROMPT),
-       flags    = INTERACTIVE,
-       key      = RESTORE_DEFAULTS_QUESTION_ID;
     oneof varid  = PASSWORD_TOGGLE_DATA.PasswordCheckEnabled,
       prompt = STRING_TOKEN(STR_PASSWORD_CHECK_PROMPT),
       help   = STRING_TOKEN(STR_PASSWORD_CHECK_HELP),
@@ -62,9 +50,47 @@ formset
       option text = STRING_TOKEN(STR_DISABLE), value = 0x0, flags = DEFAULT;
       option text = STRING_TOKEN(STR_ENABLE), value = 0x1, flags = 0;
     endoneof;
-  endif;
+   endif;
   endform;
-
+  form formid = SYSTEM_INFORMATION_ID,
+        title = STRING_TOKEN(STR_SYSTEM_INFORMATION_TITLE);
+        goto
+          formsetguid = CONFIG_INI_FORMSET_GUID,
+          formid  = INFORMATION_FORM_ID,
+          question = INFORMATION_FORM_ID,
+          prompt  = STRING_TOKEN(STR_GOTO_DYNAMIC),
+          help    = STRING_TOKEN(STR_GOTO_HELP),
+          flags   = INTERACTIVE;
+        goto 0x1234,
+          prompt  = STRING_TOKEN(STR_SERIALPORT),
+          help    = STRING_TOKEN(STR_SERIALPORT_HELP),
+          flags   = INTERACTIVE,
+          key     = 0x1234;
+  endform;
+  form formid = SYSTEM_SETTING_ID,
+        title = STRING_TOKEN(STR_SYSTEM_SETTING_TITLE);
+        goto
+         formsetguid = PASSWORDCONFIG_FORMSET_GUID,
+         formid  =  FORM_PASSWORDCONFIG_ID,
+         question = FORM_PASSWORDCONFIG_ID,
+         prompt  = STRING_TOKEN(STR_GOTO_PASSWORD),
+         help    = STRING_TOKEN(STR_GOTO_PASSWORD_HELP),
+         flags   = INTERACTIVE;
+        goto
+         formsetguid = TIME_SET_FORMSET_GUID,
+         formid  = TIME_SET_ID,
+         question = TIME_SET_ID,
+         prompt  = STRING_TOKEN(STR_GOTO_TIME_SET),
+         help    = STRING_TOKEN(STR_GOTO_TIME_SET_HELP),
+         flags   = INTERACTIVE;
+        grayoutif ideqval PASSWORD_TOGGLE_DATA.IsFirst == 1 AND ideqval PASSWORD_TOGGLE_DATA.UserPriv == 0 AND ideqval PASSWORD_TOGGLE_DATA.PasswordCheckEnabled == 1;
+         text
+           help     = STRING_TOKEN(STR_RESET_TO_DEFAULTS_HELP),
+           text   = STRING_TOKEN(STR_RESET_TO_DEFAULTS_PROMPT),
+           flags    = INTERACTIVE,
+           key      = RESTORE_DEFAULTS_QUESTION_ID;
+        endif;
+  endform;
   form formid = 0x1234,
         title = STRING_TOKEN(STR_SERIALPORT_TITLE);
         text

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
@@ -50,6 +50,7 @@
   UefiHiiServicesLib
   UefiBootManagerLib
   ResetSystemLib
+  SmbiosInformationLib
 
 [Guids]
   gEfiIfrTianoGuid                              ## CONSUMES ## GUID (Extended IFR Guid Opcode)
@@ -76,6 +77,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSetupVideoVerticalResolution    ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVersionString           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                     ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdServerNamePrefix                         ## CONSUMES
 
 [UserExtensions.TianoCore."ExtraFiles"]
   UiAppExtra.uni


### PR DESCRIPTION
- BmcLanConfigDxe/BmcLanConfigNv.h: Align BMC form ID with MENU settings.

- UiApp: Update MENU layout:
  - Merge product information and serial port configuration into one screen.
  - Merge time settings, password settings, and restore default settings into a single interface.

- Standardize Varstore structure to 4-byte alignment, including these files: InformationNVDataStruc.h; PasswordConfigData.h; SetDateAndTimeNv.h.