### PR TITLE
SG2044Pkg/Ds1307RealTimeClockLib: Add a RTC I2C bus

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -493,7 +493,8 @@
   gSophgoTokenSpaceGuid.PcdIniFileRamAddress|0x89000000
   gSophgoTokenSpaceGuid.PcdIniFileMaxSize|8192
   gSophgoTokenSpaceGuid.PcdMisa|0x00B4112F
-  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum|2
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum0|2
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum1|3
   gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|3
 
   gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency|50000000

--- a/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.inf
+++ b/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.inf
@@ -31,7 +31,8 @@
   UefiRuntimeLib
 
 [Pcd]
-  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum   ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum0   ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum1   ## CONSUMES
 
 [Protocols]
   gSophgoI2cMasterProtocolGuid            ## CONSUMES

--- a/Silicon/Sophgo/Sophgo.dec
+++ b/Silicon/Sophgo/Sophgo.dec
@@ -47,22 +47,23 @@
   gSophgoTokenSpaceGuid.PcdTrngBase|0x0|UINT64|0x00001009
   gSophgoTokenSpaceGuid.PcdSpifmcDmmrEnable|FALSE|BOOLEAN|0x0000100A
   gSophgoTokenSpaceGuid.PcdFlashPartitionTableAddress|0x0|UINT64|0x0000100B
-  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum|0x0|UINT32|0x0000100C
-  gSophgoTokenSpaceGuid.PcdPhyResetGpio|FALSE|BOOLEAN|0x0000100D
-  gSophgoTokenSpaceGuid.PcdPhyResetGpioPin|0x0|UINT8|0x0000100E
-  gSophgoTokenSpaceGuid.PcdDwMac4DefaultMacAddress|0x0|UINT64|0x0000100F
-  gSophgoTokenSpaceGuid.PcdEfuseControllerNum|0x0|UINT32|0x00001010
-  gSophgoTokenSpaceGuid.PcdEfuse0Base|0x0|UINT64|0x00001011
-  gSophgoTokenSpaceGuid.PcdEfuse1Base|0x0|UINT64|0x00001012
-  gSophgoTokenSpaceGuid.PcdEfuseNumAddrBits|0x0|UINT32|0x00001013
-  gSophgoTokenSpaceGuid.PcdEfuseNumCells|0x0|UINT32|0x00001014
-  gSophgoTokenSpaceGuid.PcdEfuseCellWidth|0x0|UINT32|0x00001015
-  gSophgoTokenSpaceGuid.PcdEfuseWriteEnableGpio|FALSE|BOOLEAN|0x00001016
-  gSophgoTokenSpaceGuid.PcdEfuseWriteEnableGpioPin|0x0|UINT8|0x00001017
-  gSophgoTokenSpaceGuid.PcdEfuseIsGpioHighToEnableWrite|FALSE|BOOLEAN|0x00001018
-  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|0x0|UINT32|0x00001019
-  gSophgoTokenSpaceGuid.PcdServerNamePrefix|L"SR"|VOID*|0x0000101A
-  gSophgoTokenSpaceGuid.PcdFdOffset|0x0|UINT64|0x0000101B
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum0|0x0|UINT32|0x0000100C
+  gSophgoTokenSpaceGuid.PcdRtcI2cBusNum1|0x0|UINT32|0x0000100D
+  gSophgoTokenSpaceGuid.PcdPhyResetGpio|FALSE|BOOLEAN|0x0000100E
+  gSophgoTokenSpaceGuid.PcdPhyResetGpioPin|0x0|UINT8|0x0000100F
+  gSophgoTokenSpaceGuid.PcdDwMac4DefaultMacAddress|0x0|UINT64|0x00001010
+  gSophgoTokenSpaceGuid.PcdEfuseControllerNum|0x0|UINT32|0x00001011
+  gSophgoTokenSpaceGuid.PcdEfuse0Base|0x0|UINT64|0x00001012
+  gSophgoTokenSpaceGuid.PcdEfuse1Base|0x0|UINT64|0x00001013
+  gSophgoTokenSpaceGuid.PcdEfuseNumAddrBits|0x0|UINT32|0x00001014
+  gSophgoTokenSpaceGuid.PcdEfuseNumCells|0x0|UINT32|0x00001015
+  gSophgoTokenSpaceGuid.PcdEfuseCellWidth|0x0|UINT32|0x00001016
+  gSophgoTokenSpaceGuid.PcdEfuseWriteEnableGpio|FALSE|BOOLEAN|0x00001017
+  gSophgoTokenSpaceGuid.PcdEfuseWriteEnableGpioPin|0x0|UINT8|0x00001018
+  gSophgoTokenSpaceGuid.PcdEfuseIsGpioHighToEnableWrite|FALSE|BOOLEAN|0x00001019
+  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|0x0|UINT32|0x0000101A
+  gSophgoTokenSpaceGuid.PcdServerNamePrefix|L"SR"|VOID*|0x0000101B
+  gSophgoTokenSpaceGuid.PcdFdOffset|0x0|UINT64|0x0000101C
 
 [PcdsDynamic]
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x0|UINT64|0x00001003


### PR DESCRIPTION
Use two Pcd variables to store I2C bus numbers used by RTC.

Signed-off-by: zhouwei.zhang <zhouwei.zhang@sophgo.com>