### PR TITLE
Sophgo: Update IpmiBootEntry() and BmcLanConfigEntry()

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Drivers/BmcLanConfigDxe/BmcLanConfig.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/BmcLanConfigDxe/BmcLanConfig.c
@@ -883,8 +883,8 @@ BmcLanConfigEntry(
 
   if (!IsServerProduct())
   {
-    DEBUG((DEBUG_INFO, "%a:  is not server board\n", __func__));
-    return EFI_OUT_OF_RESOURCES;
+    DEBUG((DEBUG_INFO, "%a: Non-server board detected. Skipping server-specific initialization.\n", __func__));
+    return EFI_SUCCESS;
   }
 
   PrivateData = AllocateZeroPool(sizeof(NET_PRIVATE_DATA));

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.c
@@ -774,8 +774,8 @@ IpmiBootEntry (
 
   if (!IsServerProduct())
   {
-    DEBUG((DEBUG_INFO, "%a:  is not server board\n", __func__));
-    return RETURN_INVALID_PARAMETER;
+    DEBUG((DEBUG_INFO, "%a: Non-server board detected. Skipping server-specific initialization.\n", __func__));
+    return EFI_SUCCESS;
   }
 
   Status = RestoreBootOrder ();


### PR DESCRIPTION
- Updated debug messages in both IpmiBootEntry and BmcLanConfigEntry to clarify that a non-server board was detected and that server-specific initialization is being skipped.

- Changed the return value in both functions from an error code to EFI_SUCCESS when a non-server product is detected, indicating that the function completed successfully without attempting server-specific operations.