### PR TITLE
UiApp: Add new functionality for the ACPI disable control

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
@@ -41,6 +41,7 @@ typedef struct {
   UINT8 IsFirst;
   UINT8 UserPriv;
   UINT8 IsEvb;
+  UINT8 DefaultAcpi;
 } PASSWORD_TOGGLE_DATA;
 #pragma pack()
 #endif

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
@@ -41,11 +41,13 @@ formset
    endif;
     label LABEL_MANAGER;
     label LABEL_END;
+   suppressif ideqval PASSWORD_TOGGLE_DATA.DefaultAcpi == 1;
     text
            help  = STRING_TOKEN(STR_ACPI_HELP),
            text  = STRING_TOKEN(STR_ACPI_PROMPT),
            flags = INTERACTIVE,
            key   = ACPI_DISABLE_QUESTION_ID;
+   endif;
   endform;
   form formid = SYSTEM_INFORMATION_ID,
         title = STRING_TOKEN(STR_SYSTEM_INFORMATION_TITLE);


### PR DESCRIPTION
- If booting from DTB is the default, do not display the ACPI disable control on the menu interface.