### PR TITLE
SG2044Pkg/SdCard: Fix write fails and read timeout

### DIFF
--- a/Silicon/Sophgo/Drivers/MmcDxe/Mmc.c
+++ b/Silicon/Sophgo/Drivers/MmcDxe/Mmc.c
@@ -520,7 +520,7 @@ MmcDxeInitialize (
 
   Status = gBS->SetTimer (gCheckCardsEvent,
                   TimerPeriodic,
-                  (UINT64)(10 * 1000 * 200)); // 200 ms
+                  EFI_TIMER_PERIOD_MILLISECONDS (200)); // 200 ms
   ASSERT_EFI_ERROR (Status);
 
   return Status;

--- a/Silicon/Sophgo/Drivers/MmcDxe/MmcBlockIo.c
+++ b/Silicon/Sophgo/Drivers/MmcDxe/MmcBlockIo.c
@@ -76,6 +76,8 @@ ValidateWrittenBlockCount (
 
   MmcHost = MmcHostInstance->MmcHost;
 
+  MmcHost->Prepare (MmcHost, 0, 4, (UINTN)Data);
+
   Status  = MmcHost->SendCommand (MmcHost, MMC_CMD55,
                       MmcHostInstance->CardInfo.RCA << 16, MMC_RESPONSE_R1, Response);
   if (EFI_ERROR (Status)) {

--- a/Silicon/Sophgo/Drivers/SdHostDxe/Readme.md
+++ b/Silicon/Sophgo/Drivers/SdHostDxe/Readme.md
@@ -1,0 +1,58 @@
+# 1 Overview
+To perform stress testing on the read/write function of an SD card driver, the method in the current file can be employed.
+
+# 2 HowTo
+## 2.1 Generate The Test File on Linux
+Use the command below to create the test file for read/write test:
+```bash
+sudo dd if=/dev/random of=testbin bs=1M count=20 status=progress
+```  
+This command generates a 20 MB file named `testbin`. Adjust the `count` parameter to modify the file size for varying test loads.
+
+## 2.2 Create EDK2-Compatible Test Script
+Save the following code as `rwtest.nsh`, which can be executed by the EDK2 shell:
+
+```nsh
+echo -off
+if %1 == "" then
+  echo "Error: Missing loop count parameter!"
+  echo "Usage: %0 <loop_count>"
+  exit /b
+endif
+
+for %i run (1 %1)
+  echo "Loop: %i/%1"
+  echo "Start cp after 5s"
+  stall 5000000
+  cp testbin cpbin
+
+  echo "Start compare 2 files after 5s"
+  stall 5000000
+  comp testbin cpbin
+
+  echo "Start rm after 5s"
+  stall 5000000
+  rm cpbin
+endfor
+
+echo "Test completed!"
+```
+
+## 2.3 Prepare the SD Card
+Copy both `testbin` and `rwtest.nsh` to the FAT partition of the SD card configured with the EDK2 boot environment.
+
+## 2.4 Execute the Script in EDK2 Shell environment
+Boot into the EDK2 Shell environment and execute the script:  
+- Navigate to the test file directory (e.g., `fs0:` followed by `cd <directory>`).
+- Run the script with the desired loop count (e.g., `rwtest.nsh 200` for 200 iterations).
+
+By modifying the first parameter passed to the test script, the number of test loops can be altered.
+
+## 2.5 Test Workflow
+The testing content of this script includes:
+1. Copying `testbin` to `cpbin`.
+2. Verifying file integrity by comparing `testbin` and `cpbin`.
+3. Deleting `cpbin`.
+4. Repeating steps 1–3 until the specified loop count is reached.
+
+If the test fails, analyze the logs printed during execution to identify issues in the read/write operations.

--- a/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.h
+++ b/Silicon/Sophgo/Drivers/SdHostDxe/SdHci.h
@@ -156,6 +156,16 @@
 
 #define SD_USE_PIO                    0x1
 
+#define DEBUG_MMCHOST_SD              DEBUG_VERBOSE
+#define DEBUG_MMCHOST_SD_INFO         DEBUG_INFO
+#define DEBUG_MMCHOST_SD_ERROR        DEBUG_ERROR
+
+#define FLAG_RESPONSE_MSK             0b11
+#define TIMEOUT_CMD_COMPLETE          100000
+#define TIMEOUT_BUFFER_READ           100000
+#define TIMEOUT_BUFFER_WRITE          250000
+#define TIMEOUT_SET_CLK               150000
+
 /**
   card detect status
   -1: haven't check the card detect register
@@ -182,9 +192,9 @@ typedef struct {
   INT32   BusWidth;
   UINT32  Flags;
   INT32   CardIn;
-} BM_SD_PARAMS;
+} DWC_SD_PARAMS;
 
-extern BM_SD_PARAMS BmParams;
+extern DWC_SD_PARAMS DwcParams;
 
 /**
   SD card sends command.
@@ -201,7 +211,7 @@ extern BM_SD_PARAMS BmParams;
 **/
 EFI_STATUS
 EFIAPI
-BmSdSendCmd (
+DwcSdSendCmd (
   IN  UINT32 Idx,
   IN  UINT32 Arg,
   IN  UINT32 RespType,
@@ -218,7 +228,7 @@ BmSdSendCmd (
 
 **/
 INT32
-BmSdCardDetect (
+DwcSdCardDetect (
   VOID
   );
 
@@ -233,7 +243,7 @@ BmSdCardDetect (
 
 **/
 EFI_STATUS
-BmSdSetIos (
+DwcSdSetIos (
   IN UINT32 Clk,
   IN UINT32 Width
   );
@@ -251,7 +261,7 @@ BmSdSetIos (
 
 **/
 EFI_STATUS
-BmSdPrepare (
+DwcSdPrepare (
   IN INT32 Lba,
   IN UINTN Buf,
   IN UINTN Size
@@ -269,7 +279,7 @@ BmSdPrepare (
 
 **/
 EFI_STATUS
-BmSdRead (
+DwcSdRead (
   IN INT32   Lba,
   IN UINT32* Buf,
   IN UINTN   Size
@@ -287,7 +297,7 @@ BmSdRead (
 
 **/
 EFI_STATUS
-BmSdWrite (
+DwcSdWrite (
   IN INT32   Lba,
   IN UINT32* Buf,
   IN UINTN   Size


### PR DESCRIPTION
Fix the bug causing write operation failures and occasional read operation timeouts.
The modifications in the current commit are based on the following reasons：
  1. All writable fields in NORMAL_INT_STAT_R(0x30) are W1C. Clearing a specific interrupt must not affect other fields.
  2. Set CMD_TYPE to 0x3 when issuing Abort CMD (CMD12).
  3. Poll PSTATE_REG.CMD_INHIBIT_DAT before sending ADTC commands to ensure it is 0 (0 for ready).
  4. ACMD22 is an ADTC command with 4-byte data transfer. Configure blocksize and blockcount registers before sending it.
  5. Update the command-sending code to support ACMD22.
  6. Poll BUF_RD_ENABLE and BUF_WR_ENABLE in PSTATE_REG(0x24) to determine when data registers are accessible.
  7. Set read and write timeouts to 100ms and 250ms, respectively.
  8. Add Readme.md to guide SD card read/write stress testing.

Signed-off-by: zhouwei.zhang <zhouwei.zhang@sophgo.com>