### PR TITLE
Sophgo: Fix dmidecode Display Errors for Cache and DDR Size

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SmbiosPlatformDxe/Type17/PlatformMemoryDeviceFunction.c
@@ -17,6 +17,10 @@
 
 #include "SmbiosPlatformDxe.h"
 
+#define MAX_SIZE 0x7FFF
+#define DEFAULT_DDR_SIZE 0x10000
+#define EFUSE_DDR_OFFSET 352
+
 SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
   EFI_STATUS           Status;
   STR_TOKEN_INFO       *InputStrToken;
@@ -65,7 +69,9 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
           }
           InputData->Attributes = Uint;
       }
-      if (UpdateSmbiosFromEfuse(1, 352, 4, &Size) == 0) {
+      InputData->Size = MAX_SIZE;
+      InputData->ExtendedSize = DEFAULT_DDR_SIZE;
+      if (UpdateSmbiosFromEfuse(1, EFUSE_DDR_OFFSET, 4, &Size) == 0) {
         if (((Size >> 13) & 0x1) ^ ((Size >> 12) & 0x1)) {
           UINT32 capacityBits = (Size >> 2) & 0x3;
           UINT32 dramCapacityMB;
@@ -82,12 +88,10 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
             break;
           }
           if (dramCapacityMB == 0) {
-            InputData->ExtendedSize = 0x4000000;
+            InputData->ExtendedSize = DEFAULT_DDR_SIZE;
           } else {
             InputData->ExtendedSize = dramCapacityMB;
           }
-        } else {
-            InputData->ExtendedSize = 0x4000000;
         }
       }
       SmbiosPlatformDxeCreateTable (

--- a/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
+++ b/Silicon/Sophgo/Include/Library/SmbiosInformationLib.h
@@ -35,9 +35,9 @@ typedef struct {
   UINT16 ProcessorCurrentSpeed;
   UINT8  ProcessorCoreCount;
   UINT8  ProcessorThreadCount;
-  UINT16 L1ICacheSize;
-  UINT16 L1DCacheSize;
-  UINT16 L2CacheSize;
+  UINT32 L1ICacheSize;
+  UINT32 L1DCacheSize;
+  UINT32 L2CacheSize;
   UINT32 L3CacheSize;
   UINT8 InstallableLanguages;
   UINT8 BiosLanguageFlags;

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.c
@@ -171,7 +171,7 @@ FillInformationData (
   StrCpyS(InformationData->MemoryType, MAX_LENGTH, ParsedData->MemoryType);
   InformationData->ExtendedSpeed = ParsedData->ExtendedSpeed;
   InformationData->MemoryRank = ParsedData->MemoryRank;
-  InformationData->ExtendSize = ParsedData->ExtendSize / (1024 * 1024);
+  InformationData->ExtendSize = ParsedData->ExtendSize / 1024;
   StrCpyS(InformationData->BoardProductName, MAX_LENGTH, ParsedData->BaseboardProductName);
   StrCpyS(InformationData->BoardVersion, MAX_LENGTH, ParsedData->BaseboardManufacturer);
   StrCpyS(InformationData->ProductName, MAX_LENGTH, ParsedData->SystemProductName);


### PR DESCRIPTION
- Type07: Modify the logic for filling Type 7 InstalledSize and InstalledSize2 according to the SMBIOS 3.1 specification and dmidecode source code to ensure that dmidecode correctly parses the cache size.

- Type17: Modify the logic for filling Type 17 Size and ExtendedSize according to the SMBIOS 3.1 specification. Additionally, update the menu display logic for DDR size conversion to align with dmidecode.