### PR TITLE
SG2044Pkg: Add iPXE binary as PXE service

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -43,7 +43,7 @@
   DEFINE NETWORK_ISCSI_ENABLE     = FALSE
 
   DEFINE FLASH_ENABLE             = TRUE
-  DEFINE ETH_ENABLE               = TRUE
+  DEFINE ETH_ENABLE               = FALSE
   DEFINE ACPI_ENABLE              = TRUE
 
   #
@@ -752,6 +752,12 @@
   Drivers/ASpeed/ASpeedGopBinPkg/ASpeedAst2500GopDxe.inf
 
   #
+  # iPXE Application
+  #
+  Silicon/Sophgo/SG2044/Ipxe/Ipxe.inf
+  MdeModulePkg/Universal/LoadFileOnFv2/LoadFileOnFv2.inf
+
+  #
   # ipmi ssif smbus driver
   #
   Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcDxe.inf
@@ -767,13 +773,6 @@
   MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
   MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
   MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
-
-  #
-  # Update Firmware in Nor Flash (whole chip)
-  #
-!if $(FLASH_ENABLE) == TRUE
-  Silicon/Sophgo/Applications/FirmwareUpdate/FirmwareUpdate.inf
-!endif
 
   #
   # UEFI Application (Shell Embedded Boot Loader)

--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf
@@ -185,6 +185,12 @@ INF  MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 INF  Drivers/ASpeed/ASpeedGopBinPkg/ASpeedAst2500GopDxe.inf
 
 #
+# iPXE Application
+#
+INF  Silicon/Sophgo/SG2044/Ipxe/Ipxe.inf
+INF  MdeModulePkg/Universal/LoadFileOnFv2/LoadFileOnFv2.inf
+
+#
 # Multiple Console IO support
 #
 INF  MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatformDxe.inf
@@ -212,13 +218,6 @@ INF  MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIoDxe.inf
 INF  MdeModulePkg/Universal/Disk/PartitionDxe/PartitionDxe.inf
 INF  MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
 INF  MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
-
-#
-# Update Firmware in Nor Flash (whole chip)
-#
-!if $(FLASH_ENABLE) == TRUE
-INF  Silicon/Sophgo/Applications/FirmwareUpdate/FirmwareUpdate.inf
-!endif
 
 #
 # UEFI application (Shell Embedded Boot Loader)


### PR DESCRIPTION
SG2044 support PXE by embedded iPXE into BIOS.
Customers can select PXE boot by entering 'Boot Manager', then select iPXE boot option.