### PR TITLE
Sophgo/PeilessSec: update FPDT record of Reset End

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -366,17 +366,16 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSupportUefiDecompress|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutGopSupport|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdConOutUgaSupport|FALSE
+  #
+  # Activate AcpiSdtProtocol
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
 
 [PcdsFeatureFlag.common]
   ## Indicates if S3 performance data will be supported in ACPI FPDT table.
   #   TRUE  - S3 performance data will be supported in ACPI FPDT table.
   #   FALSE - S3 performance data will not be supported in ACPI FPDT table.
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwarePerformanceDataTableS3Support|FALSE
-
-  #
-  # Activate AcpiSdtProtocol
-  #
-  gEfiMdeModulePkgTokenSpaceGuid.PcdInstallAcpiSdtProtocol|TRUE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE

--- a/Silicon/Sophgo/PeilessSec/PeilessSec.c
+++ b/Silicon/Sophgo/PeilessSec/PeilessSec.c
@@ -26,10 +26,19 @@ SecInitializePlatform (
   )
 {
   EFI_STATUS  Status;
+  FIRMWARE_SEC_PERFORMANCE      Performance;
+  UINT64                        StartTimeStamp;
 
   MemoryPeimInitialization ();
 
   CpuPeimInitialization ();
+
+  // Store timer value logged at the beginning of firmware image execution
+  StartTimeStamp = GetPerformanceCounter();
+  Performance.ResetEnd = GetTimeInNanoSecond (StartTimeStamp);
+
+  // Build SEC Performance Data Hob
+  BuildGuidDataHob (&gEfiFirmwarePerformanceGuid, &Performance, sizeof (Performance));
 
   // Set the Boot Mode
   SetBootMode (BOOT_WITH_FULL_CONFIGURATION);

--- a/Silicon/Sophgo/PeilessSec/PeilessSec.h
+++ b/Silicon/Sophgo/PeilessSec/PeilessSec.h
@@ -31,6 +31,9 @@
 #include <Library/PrePiHobListPointerLib.h>
 #include <Library/SerialPortLib.h>
 #include <Register/RiscV64/RiscVImpl.h>
+#include <Library/PerformanceLib.h>
+#include <Ppi/SecPerformance.h>
+#include <Library/TimerLib.h>
 
 /**
   Entry point to the C language phase of SEC. After the SEC assembly

--- a/Silicon/Sophgo/PeilessSec/PeilessSec.inf
+++ b/Silicon/Sophgo/PeilessSec/PeilessSec.inf
@@ -57,7 +57,8 @@
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                       ## CONSUMES
 
 [Guids]
-  gFdtHobGuid      ## PRODUCES
+  gFdtHobGuid                           ## PRODUCES
+  gEfiFirmwarePerformanceGuid           ## PRODUCES
 
 [BuildOptions]
   GCC:*_*_*_PP_FLAGS = -D__ASSEMBLY__


### PR DESCRIPTION
 - Definition of "Reset End" field: timer value logged at the beginning of firmware image execution. This may not always be zero or near zero.

 - For us, it means the total time from zsbl to opensbi, and then to the beginning of firmware image execution.