### PR TITLE
SG2044: Fix bug in Ds1307RealTimeClockLib

### DIFF
--- a/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
+++ b/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
@@ -455,6 +455,11 @@ I2cXfer (
 {
   EFI_STATUS Status;
   DW_I2C     *DwI2c;
+  if (I2c >= mI2cNum) {
+    DEBUG ((DEBUG_ERROR, "Error, I2c bus number must be less than %u!\n", mI2cNum));
+    return EFI_INVALID_PARAMETER;
+  }
+
   DwI2c = (VOID *)&mI2cInfo[I2c].Dev;
 
   DwI2cEnable (DwI2c->Regs, TRUE);
@@ -764,7 +769,7 @@ GetI2cInfoByFdt (
   }
 
   for (UINT32 Index = 0; Index < I2cNum; Index++) {
-    DEBUG ((DEBUG_ERROR,
+    DEBUG ((DEBUG_VERBOSE,
       "  [I2c%d base: 0x%lx, freq: %lu, speed: %lu ]\n",
       Index,
       I2cInformation[Index].Base,

--- a/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
+++ b/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
@@ -135,7 +135,7 @@ LibGetTime (
     DEBUG ((DEBUG_ERROR, "%a: I2c smbus read error, Status: %r.\n", __func__, Status));
     return EFI_DEVICE_ERROR;
   } else if (TimeBcd[0] & DS1307_SEC_BIT_CH) {
-    DEBUG ((DEBUG_ERROR, "%a: Warning, RTC oscillator has stopped\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Error, RTC oscillator has stopped!\n", __func__));
     return EFI_DEVICE_ERROR;
   }
 
@@ -196,10 +196,10 @@ LibSetTime (
     DEBUG ((DEBUG_ERROR, "%a: I2c smbus read error, Status: %r.\n", __func__, Status));
     return EFI_DEVICE_ERROR;
   } else if (Second & DS1307_SEC_BIT_CH) {
-    DEBUG ((DEBUG_ERROR, "%a: Warning, RTC oscillator has stopped\n", __func__));
+    DEBUG ((DEBUG_ERROR, "%a: Error, RTC oscillator has stopped\n", __func__));
     return EFI_DEVICE_ERROR;
   } else if (Time->Year < START_YEAR || Time->Year >= END_YEAR) {
-    DEBUG ((DEBUG_ERROR, "%a: WARNING, Year should be between %d and %d!\n",
+    DEBUG ((DEBUG_ERROR, "%a: Error, Year should be between %d and %d!\n",
             __func__, START_YEAR, (END_YEAR - 1)));
     return EFI_INVALID_PARAMETER;
   }
@@ -295,8 +295,8 @@ FindOneRtcSlave (
   I2cBusNums[0] = FixedPcdGet32 (PcdRtcI2cBusNum0);
   I2cBusNums[1] = FixedPcdGet32 (PcdRtcI2cBusNum1);
 
-  for (BusIndex = 0; BusIndex < sizeof (I2cBusNums); ++BusIndex){
-    for (SlaveIndex = 0; SlaveIndex < sizeof (mRtcSlaveAddrs); ++SlaveIndex) {
+  for (BusIndex = 0; BusIndex < sizeof (I2cBusNums) / sizeof (I2cBusNums[0]); ++BusIndex){
+    for (SlaveIndex = 0; SlaveIndex < sizeof (mRtcSlaveAddrs) / sizeof (mRtcSlaveAddrs[0]); ++SlaveIndex) {
       Status = mI2cMasterProtocol->ReadByte (mI2cMasterProtocol,
                                              I2cBusNums[BusIndex],
                                              mRtcSlaveAddrs[SlaveIndex],
@@ -373,7 +373,8 @@ LibRtcInitialize (
 
   Status = FindOneRtcSlave ();
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Failed to find a RTC slave!\n"));
+    DEBUG ((DEBUG_ERROR, "Error! Unable to find a RTC slave!\n"));
+    ASSERT (FALSE);
     return Status;
   }
 


### PR DESCRIPTION
1. Fix array out of bounds issue.
2. Add code to DwI2cDxe to avoid accessing non-existent I2C buses.

Signed-off-by: zhouwei.zhang <zhouwei.zhang@sophgo.com>