### PR TITLE
PeilessSec: Fixbug sec assert if DxeCore too large

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf.inc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf.inc
@@ -10,8 +10,14 @@
 [Defines]
 DEFINE BLOCK_SIZE        = 0x1000
 DEFINE FW_BASE_ADDRESS   = 0x80200000
-DEFINE FW_SIZE           = 0x00900000
-DEFINE FW_BLOCKS         = 0x900
+DEFINE FW_SIZE           = 0x00e00000
+DEFINE FW_BLOCKS         = 0xe00
+
+DEFINE EFI_MEMORY_SIZE    = 64 * 1024 * 1024
+DEFINE EFI_STACK_SIZE     = 64 * 1024
+DEFINE EFI_MEMORY_BOTTOM  = $(FW_BASE_ADDRESS) + $(FW_SIZE)
+DEFINE EFI_MEMORY_TOP     = $(EFI_MEMORY_BOTTOM) + $(EFI_MEMORY_SIZE)
+DEFINE EFI_STACK_BASE     = $(EFI_MEMORY_TOP) - $(EFI_STACK_SIZE)
 
 #
 # 0x000000-0x7FFFFF code
@@ -45,5 +51,6 @@ DEFINE VARS_FTW_SPARE_OFFSET         = $(VARS_FTW_WORKING_OFFSET) + $(VARS_FTW_W
 DEFINE VARS_FTW_SPARE_SIZE           = 0x00010000
 
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdVariableFdBlockSize               = $(BLOCK_SIZE)
-SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamBase                  = $(CODE_BASE_ADDRESS) + $(FW_SIZE) + 0x1FF0000
-SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                  = 0x10000
+SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamBase                  = $(EFI_STACK_BASE)
+SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                  = $(EFI_STACK_SIZE)
+SET gSophgoTokenSpaceGuid.PcdEfiMemoryBottom                                 = $(EFI_MEMORY_BOTTOM)

--- a/Silicon/Sophgo/MemoryInitPei/MemoryInitPeiLib.c
+++ b/Silicon/Sophgo/MemoryInitPei/MemoryInitPeiLib.c
@@ -265,7 +265,7 @@ MemoryPeimInitialization (
   }
 
   DeviceTreeAddress = (VOID *)FirmwareContext->FlattenedDeviceTree;
-  UefiMemoryBase = (UINT64)FixedPcdGet32 (PcdTemporaryRamBase) + FixedPcdGet32 (PcdTemporaryRamSize) - SIZE_32MB;
+  UefiMemoryBase = FixedPcdGet64 (PcdEfiMemoryBottom);
   FwMemBase      = PcdGet32 (PcdRiscVDxeFvBase);
   FwMemSize      = PcdGet32 (PcdRiscVDxeFvSize);
   LowestMemBase  = 0;

--- a/Silicon/Sophgo/MemoryInitPei/MemoryInitPeiLib.inf
+++ b/Silicon/Sophgo/MemoryInitPei/MemoryInitPeiLib.inf
@@ -22,6 +22,7 @@
   MdeModulePkg/MdeModulePkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   Platform/RISC-V/PlatformPkg/RiscVPlatformPkg.dec
+  Silicon/Sophgo/Sophgo.dec
 
 [LibraryClasses]
   FdtLib
@@ -35,6 +36,7 @@
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdRiscVDxeFvSize                         ## CONSUMES
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamBase                       ## CONSUMES
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                       ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdEfiMemoryBottom					## CONSUMES
 
 [Guids]
   gFdtHobGuid      ## PRODUCES

--- a/Silicon/Sophgo/PeilessSec/PeilessSec.c
+++ b/Silicon/Sophgo/PeilessSec/PeilessSec.c
@@ -93,12 +93,30 @@ SecStartup (
 
   StackBase      = (UINT64)FixedPcdGet32 (PcdTemporaryRamBase);
   StackSize      = FixedPcdGet32 (PcdTemporaryRamSize);
-  UefiMemoryBase = StackBase + StackSize - SIZE_32MB;
+  UefiMemoryBase = FixedPcdGet64 (PcdEfiMemoryBottom);
+
+  /*
+   *  --------  --> Stack Top, EfiMemoryTop, EfiFreeMemoryTop (PcdTemporaryRamBase)
+   * |        |
+   * | Stack  |
+   * |        |
+   *  --------  --> Stack Base (PcdTemporaryRamSize)
+   * |        |
+   * |        |
+   * | EfiMem |
+   * |        |
+   * |        |
+   *  --------  --> EfiMemoryBottom, EfiFreeMemoryBottom (PcdEfiMemoryBottom)
+   * |        |
+   * |   FW   |
+   * |        |
+   *  --------  --> FW_BASE_ADDRESS, typically after opensbi
+   */
 
   // Declare the PI/UEFI memory region
   HobList = HobConstructor (
               (VOID *)UefiMemoryBase,
-              SIZE_32MB,
+              StackBase + StackSize - UefiMemoryBase,
               (VOID *)UefiMemoryBase,
               (VOID *)StackBase // The top of the UEFI Memory is reserved for the stacks
               );

--- a/Silicon/Sophgo/PeilessSec/PeilessSec.inf
+++ b/Silicon/Sophgo/PeilessSec/PeilessSec.inf
@@ -55,6 +55,7 @@
 [FixedPcd]
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamBase                       ## CONSUMES
   gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize                       ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdEfiMemoryBottom                                      ## CONSUMES
 
 [Guids]
   gFdtHobGuid                           ## PRODUCES

--- a/Silicon/Sophgo/Sophgo.dec
+++ b/Silicon/Sophgo/Sophgo.dec
@@ -69,6 +69,7 @@
   gSophgoTokenSpaceGuid.PcdServerNamePrefix|L"SR"|VOID*|0x0000101B
   gSophgoTokenSpaceGuid.PcdFdOffset|0x0|UINT64|0x0000101C
   gSophgoTokenSpaceGuid.PcdMCUI2cBus|0x0|UINT32|0x0000101D
+  gSophgoTokenSpaceGuid.PcdEfiMemoryBottom|0x0|UINT64|0x0000101E
 
 [PcdsDynamic]
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x0|UINT64|0x00001003


### PR DESCRIPTION
Allocate memory failed when decompress first fv.
No enough free memory in heap.
Enlarging EfiMemory from 32MiB to 64MiB fixs this bug.