### PR TITLE
SG2044/Library: Add SmbiosInformationLib

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -198,7 +198,7 @@
   VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   IniParserLib|Silicon/Sophgo/Library/IniParserLib/IniParserLib.inf
   ConfigUtilsLib|Silicon/Sophgo/Library/ConfigUtilsLib/ConfigUtilsLib.inf
-  SmbiosInformationLib|Silicon/Sophgo/Library/SmbiosInformation/SmbiosInformationLib.inf
+  SmbiosInformationLib|Silicon/Sophgo/SG2044Pkg/Library/SmbiosInformation/SmbiosInformationLib.inf
 !ifdef $(SOURCE_DEBUG_ENABLE)
   PeCoffExtraActionLib|SourceLevelDebugPkg/Library/PeCoffExtraActionLibDebug/PeCoffExtraActionLibDebug.inf
   DebugCommunicationLib|SourceLevelDebugPkg/Library/DebugCommunicationLibSerialPort/DebugCommunicationLibSerialPort.inf

--- a/Silicon/Sophgo/SG2044Pkg/Library/SmbiosInformation/SmbiosInformationLib.c
+++ b/Silicon/Sophgo/SG2044Pkg/Library/SmbiosInformation/SmbiosInformationLib.c
@@ -1,0 +1,529 @@
+/**
+  @file
+  This library provides functions to parse the SMBIOS table and extract relevant information.
+  It defines a function AllocSmbiosData, which retrieves system information from the SMBIOS
+  table and fills the SMBIOS_PARSED_DATA structure, returning a structure pointer of type
+  SMBIOS_PARSED_DATA to the caller.
+
+  Copyright (c) Sophgo Inc. All rights reserved.
+**/
+
+#include <Library/SmbiosInformationLib.h>
+
+#define TYPE07_LENGTH 0x18
+
+EFI_STATUS
+ExtractString(
+  IN  CHAR8   *OptionalStrStart,
+  IN  UINT8   Index,
+  OUT CHAR16  **String
+  )
+{
+  UINTN  StrSize;
+  CHAR8  *CurrentStrPtr;
+
+  if (String == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+  *String = NULL;
+
+  if (Index == 0) {
+    *String = AllocateZeroPool(sizeof(CHAR16));
+    if (*String == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+    return EFI_SUCCESS;
+  }
+
+  CurrentStrPtr = OptionalStrStart;
+  while (Index > 1 && *CurrentStrPtr != '\0') {
+    CurrentStrPtr += AsciiStrSize(CurrentStrPtr);
+    Index--;
+  }
+
+  if (Index != 1 || *CurrentStrPtr == '\0') {
+    return EFI_NOT_FOUND;
+  }
+
+  StrSize = AsciiStrSize(CurrentStrPtr);
+  *String = AllocatePool(StrSize * sizeof(CHAR16));
+  if (*String == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  if (EFI_ERROR(AsciiStrToUnicodeStrS(CurrentStrPtr, *String, StrSize))) {
+    FreePool(*String);
+    *String = NULL;
+    return EFI_DEVICE_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+SMBIOS_PARSED_DATA *
+AllocSmbiosData (
+  VOID
+) {
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE        SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  EFI_STATUS               Status;
+
+  SMBIOS_PARSED_DATA       *ParsedData;
+  ParsedData = AllocateZeroPool(sizeof(SMBIOS_PARSED_DATA));
+
+  if (ParsedData == NULL) {
+    DEBUG((DEBUG_ERROR, "Failed to allocate memory for ParsedData\n"));
+    return NULL;
+  }
+
+  ZeroMem(ParsedData, sizeof(SMBIOS_PARSED_DATA));
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+    FreePool(ParsedData);
+    return NULL;
+  }
+
+  SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+  while (TRUE) {
+    Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+    if (EFI_ERROR(Status)) {
+      break;
+    }
+
+    switch (Record->Type) {
+      case SMBIOS_TYPE_BIOS_INFORMATION: {
+        SMBIOS_TABLE_TYPE0 *Type0 = (SMBIOS_TABLE_TYPE0 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosVersion, &ParsedData->BiosVersion);
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosReleaseDate, &ParsedData->BiosReleaseDate);
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->Vendor, &ParsedData->BiosVendor);
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_INFORMATION: {
+        SMBIOS_TABLE_TYPE1 *Type1 = (SMBIOS_TABLE_TYPE1 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Manufacturer, &ParsedData->SystemManufacturer);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->ProductName, &ParsedData->SystemProductName);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->SerialNumber, &ParsedData->SystemSerialNumber);
+        ExtractString((CHAR8 *)((UINT8 *)Type1 + Type1->Hdr.Length), Type1->Version, &ParsedData->SystemVersion);
+        break;
+      }
+
+      case SMBIOS_TYPE_BASEBOARD_INFORMATION: {
+        SMBIOS_TABLE_TYPE2 *Type2 = (SMBIOS_TABLE_TYPE2 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->Manufacturer, &ParsedData->BaseboardManufacturer);
+        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->ProductName, &ParsedData->BaseboardProductName);
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_ENCLOSURE: {
+        SMBIOS_TABLE_TYPE3 *Type3 = (SMBIOS_TABLE_TYPE3 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type3 + Type3->Hdr.Length), Type3->Manufacturer, &ParsedData->ChassisManufacturer);
+        break;
+      }
+
+      case SMBIOS_TYPE_PROCESSOR_INFORMATION: {
+        SMBIOS_TABLE_TYPE4 *Type4 = (SMBIOS_TABLE_TYPE4 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type4 + Type4->Hdr.Length), Type4->ProcessorVersion, &ParsedData->ProcessorVersion);
+        ParsedData->ProcessorCurrentSpeed = Type4->CurrentSpeed;
+        ParsedData->ProcessorCoreCount = Type4->CoreCount;
+        ParsedData->ProcessorThreadCount = Type4->ThreadCount;
+        //SerialNumber Type4->SerialNumber
+        // ExtractString((CHAR8 *)((UINT8 *)Type4 + Type4->Hdr.Length), Type4->SerialNumber, &ParsedData->SerialNumber);
+        break;
+      }
+
+      case SMBIOS_TYPE_CACHE_INFORMATION: {
+        SMBIOS_TABLE_TYPE7 *Type7 = (SMBIOS_TABLE_TYPE7 *)Record;
+        UINT8 RawLevel = (UINT8)(Type7->CacheConfiguration & 0x7);
+        UINT32 CacheSizeInKB = 0;
+
+        if (Record->Length >= TYPE07_LENGTH && Type7->InstalledSize2 != 0) {
+          UINT32 InstalledSizeInBytes = Type7->InstalledSize2;
+          if (InstalledSizeInBytes & SIZE_2GB) {
+            CacheSizeInKB = ((InstalledSizeInBytes & 0x7FFFFFFF) << 6);
+          } else {
+            CacheSizeInKB = InstalledSizeInBytes;
+          }
+        }
+        CHAR16 *LevelStr;
+        switch (RawLevel) {
+          case 0: LevelStr = L"L1"; break;
+          case 1: LevelStr = L"L2"; break;
+          case 2: LevelStr = L"L3"; break;
+          default: LevelStr = L"Unknown"; break;
+        }
+
+        UINT8 CacheType = Type7->SystemCacheType;
+        CHAR16 *CacheTypeStr = L"Unknown";
+        if (CacheType == CacheTypeInstruction) {
+          CacheTypeStr = L"Instruction";
+        } else if (CacheType == CacheTypeData) {
+          CacheTypeStr = L"Data";
+        } else if (CacheType == CacheTypeUnified) {
+          CacheTypeStr = L"Unified";
+        }
+
+        if (RawLevel == 0) {
+          if (CacheType == CacheTypeInstruction) {
+            ParsedData->L1ICacheSize = CacheSizeInKB;
+          } else if (CacheType == CacheTypeData) {
+            ParsedData->L1DCacheSize = CacheSizeInKB;
+          } else if (CacheType == CacheTypeUnified) {
+            ParsedData->L1ICacheSize = CacheSizeInKB;
+            ParsedData->L1DCacheSize = CacheSizeInKB;
+          }
+        } else if (RawLevel == 1) {
+          ParsedData->L2CacheSize = CacheSizeInKB;
+        } else if (RawLevel == 2) {
+          ParsedData->L3CacheSize = CacheSizeInKB;
+        }
+        break;
+      }
+
+      case SMBIOS_TYPE_BIOS_LANGUAGE_INFORMATION: {
+        SMBIOS_TABLE_TYPE13 *Type13 = (SMBIOS_TABLE_TYPE13 *)Record;
+        ParsedData->InstallableLanguages = Type13->InstallableLanguages;
+        ParsedData->BiosLanguageFlags = Type13->Flags;
+        break;
+      }
+
+      case SMBIOS_TYPE_PHYSICAL_MEMORY_ARRAY: {
+        SMBIOS_TABLE_TYPE16 *Type16 = (SMBIOS_TABLE_TYPE16 *)Record;
+        ParsedData->MemoryArrayLocation = Type16->Location;
+        ParsedData->MemoryArrayUse = Type16->Use;
+        break;
+      }
+
+      case SMBIOS_TYPE_MEMORY_DEVICE: {
+  	SMBIOS_TABLE_TYPE17 *Type17 = (SMBIOS_TABLE_TYPE17 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type17 + Type17->Hdr.Length), Type17->Manufacturer, &ParsedData->MemoryManufacturer);
+        ParsedData->MemorySize = (Type17->Size & 0x7FFF);
+        if (Type17->Size & 0x8000) {
+          ParsedData->MemorySize *= 1024;
+        }
+        ParsedData->ExtendSize = Type17->ExtendedSize;
+        ParsedData->ExtendedSpeed = Type17->ExtendedSpeed;
+        switch (Type17->MemoryType) {
+          case 0x1E:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"LPDDR4");
+            break;
+          case 0x23:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"LPDDR5X");
+            break;
+          case 0x18:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"DDR3");
+            break;
+          case 0x1A:
+            StrCpyS(ParsedData->MemoryType, MAX_STRING_LENGTH, L"DDR4");
+            break;
+          default:
+            UnicodeSPrint(ParsedData->MemoryType, MAX_STRING_LENGTH * sizeof(CHAR16), L"Unknown (0x%X)", Type17->MemoryType);
+            break;
+        }
+        ParsedData->MemoryRank = Type17->Attributes & 0x0F;
+        break;
+      }
+
+      case SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS: {
+        SMBIOS_TABLE_TYPE19 *Type19 = (SMBIOS_TABLE_TYPE19 *)Record;
+        ParsedData->MemoryArrayMappedStartingAddress = Type19->StartingAddress;
+        ParsedData->MemoryArrayMappedEndingAddress = Type19->EndingAddress;
+        break;
+      }
+
+      case SMBIOS_TYPE_SYSTEM_BOOT_INFORMATION: {
+        SMBIOS_TABLE_TYPE32 *Type32 = (SMBIOS_TABLE_TYPE32 *)Record;
+        ParsedData->BootStatus = Type32->BootStatus;
+        break;
+      }
+
+      case SMBIOS_TYPE_IPMI_DEVICE_INFORMATION: {
+        SMBIOS_TABLE_TYPE38 *Type38 = (SMBIOS_TABLE_TYPE38 *)Record;
+        ParsedData->IPMIInterfaceType = Type38->InterfaceType;
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  return ParsedData;
+}
+
+INT32
+FreeSmbiosData (
+  IN SMBIOS_PARSED_DATA *ParsedData
+) {
+  if (ParsedData == NULL) {
+    DEBUG((DEBUG_ERROR, "%a:ParsedData Ptr NULL\n",__func__));
+    return -1;
+  }
+  if (ParsedData->BiosVendor != NULL)
+    FreePool(ParsedData->BiosVendor);
+
+  if (ParsedData->BiosVersion != NULL)
+    FreePool(ParsedData->BiosVersion);
+
+  if (ParsedData->BiosReleaseDate != NULL)
+    FreePool(ParsedData->BiosReleaseDate);
+
+  if (ParsedData->SystemManufacturer != NULL)
+    FreePool(ParsedData->SystemManufacturer);
+
+  if (ParsedData->SystemProductName != NULL)
+    FreePool(ParsedData->SystemProductName);
+
+  if (ParsedData->SystemSerialNumber != NULL)
+    FreePool(ParsedData->SystemSerialNumber);
+
+  if (ParsedData->BaseboardManufacturer != NULL)
+    FreePool(ParsedData->BaseboardManufacturer);
+
+  if (ParsedData->BaseboardProductName != NULL)
+    FreePool(ParsedData->BaseboardProductName);
+
+  if (ParsedData->ChassisManufacturer != NULL)
+    FreePool(ParsedData->ChassisManufacturer);
+
+  if (ParsedData->ProcessorVersion != NULL)
+    FreePool(ParsedData->ProcessorVersion);
+
+  if (ParsedData->MemoryManufacturer != NULL)
+    FreePool(ParsedData->MemoryManufacturer);
+
+  FreePool(ParsedData);
+  return 1;
+}
+
+BOOLEAN
+IsServerProduct(
+    VOID
+  )
+{
+  BOOLEAN                   IsServerBoard;
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE         SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  EFI_STATUS                Status;
+  CONST CHAR16             *ServerNamePrefix;
+  UINTN                     PrefixLength;
+  CHAR16                   *ProductName;
+
+  IsServerBoard = FALSE;
+  ProductName   = NULL;
+
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+  } else {
+    //
+    // Instantiate the ProductName pointer
+    //
+    SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+    while (TRUE) {
+      Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+      if (EFI_ERROR(Status)) {
+        break;
+      }
+      if (Record->Type == SMBIOS_TYPE_BASEBOARD_INFORMATION) {
+        SMBIOS_TABLE_TYPE2 *Type2 = (SMBIOS_TABLE_TYPE2 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type2 + Type2->Hdr.Length), Type2->ProductName, &ProductName);
+        break;
+      }
+    }
+    //
+    //Determine whether the ProductName string prefix is PcdServerNamePrefix
+    //
+    if (ProductName != NULL) {
+      ServerNamePrefix = PcdGetPtr(PcdServerNamePrefix);
+      PrefixLength = StrLen(ServerNamePrefix);
+      DEBUG((DEBUG_VERBOSE, "ProductName : %s,ServerNamePrefix: %s, StrLen: %d\n", ProductName, ServerNamePrefix, PrefixLength));
+      if (StrnCmp(ProductName, ServerNamePrefix, PrefixLength) == 0)
+      {
+        IsServerBoard = TRUE;
+      } else {
+        IsServerBoard = FALSE;
+      }
+      FreePool(ProductName);
+    }
+  }
+
+  return IsServerBoard;
+}
+
+EFI_STATUS
+EFIAPI
+GetBiosFmVersion(
+  OUT CHAR16 *BiosFmVersion
+)
+{
+  EFI_STATUS                Status;
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE         SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  CHAR16                   *TmpBiosFmVersion;
+
+  if(BiosFmVersion == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  TmpBiosFmVersion = NULL;
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+  } else {
+    SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+    while (TRUE) {
+      Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+      if (EFI_ERROR(Status)) {
+        break;
+      }
+      if (Record->Type == SMBIOS_TYPE_BIOS_INFORMATION) {
+        SMBIOS_TABLE_TYPE0 *Type0 = (SMBIOS_TABLE_TYPE0 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type0 + Type0->Hdr.Length), Type0->BiosVersion, &TmpBiosFmVersion);
+        break;
+      }
+    }
+
+    if (TmpBiosFmVersion != NULL) {
+      DEBUG((DEBUG_VERBOSE, "BiosFmVersion16:%s,Len: %d\n", TmpBiosFmVersion, StrLen(TmpBiosFmVersion)));
+      CopyMem(BiosFmVersion, TmpBiosFmVersion, (StrLen(TmpBiosFmVersion) +1)*sizeof(CHAR16));
+      FreePool(TmpBiosFmVersion);
+    }
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+GetCpuSnAndSpeed(
+  OUT CHAR16 *CpuSerialNumber,
+  OUT CHAR16 *CpuSpeed
+)
+{
+  EFI_STATUS                Status;
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE         SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  CHAR16                   *TmpCpuSerialNumber;
+  UINT8                    CpuSnLen;
+
+  if(CpuSerialNumber == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  TmpCpuSerialNumber = NULL;
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+  } else {
+    SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+    while (TRUE) {
+      Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+      if (EFI_ERROR(Status)) {
+        break;
+      }
+      if (Record->Type == SMBIOS_TYPE_PROCESSOR_INFORMATION) {
+        SMBIOS_TABLE_TYPE4 *Type4 = (SMBIOS_TABLE_TYPE4 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type4 + Type4->Hdr.Length), Type4->SerialNumber, &TmpCpuSerialNumber);
+        *CpuSpeed = Type4->CurrentSpeed;
+        break;
+      }
+    }
+
+    if (TmpCpuSerialNumber != NULL) {
+      CpuSnLen = StrLen(TmpCpuSerialNumber);
+      if (CpuSnLen < CPU_SERIALNUM_MAX_LEN) {
+        DEBUG((DEBUG_VERBOSE, "CpuSerialNumber16:%s,Len: %d\n", TmpCpuSerialNumber, CpuSnLen));
+        CopyMem(CpuSerialNumber, TmpCpuSerialNumber, (StrLen(TmpCpuSerialNumber) +1)*sizeof(CHAR16));
+      } else {
+        Status = EFI_OUT_OF_RESOURCES;
+      }
+      FreePool(TmpCpuSerialNumber);
+    }
+  }
+
+  return Status;
+}
+
+
+EFI_STATUS
+EFIAPI
+GetMemoryInfo(
+  OUT CHAR16 *MemoryManufacturer,
+  OUT UINT8  *MemoryType,
+  OUT UINT32 *MemorySize, //MB
+  OUT UINT8  *MemoryRank,
+  OUT UINT16 *MemorySpeed
+)
+{
+  EFI_STATUS                Status;
+  EFI_SMBIOS_PROTOCOL      *Smbios;
+  EFI_SMBIOS_HANDLE         SmbiosHandle;
+  EFI_SMBIOS_TABLE_HEADER  *Record;
+  CHAR16                   *TmpMemoryManufacturer;
+  UINT8                    MemManuLen;
+
+  if(MemoryManufacturer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  TmpMemoryManufacturer = NULL;
+  Status = gBS->LocateProtocol(&gEfiSmbiosProtocolGuid, NULL, (VOID **)&Smbios);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_ERROR, "Failed to locate SMBIOS protocol: %r\n", Status));
+  } else {
+    SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+    while (TRUE) {
+      Status = Smbios->GetNext(Smbios, &SmbiosHandle, NULL, &Record, NULL);
+      if (EFI_ERROR(Status)) {
+        break;
+      }
+      if (Record->Type == SMBIOS_TYPE_MEMORY_DEVICE) {
+        SMBIOS_TABLE_TYPE17 *Type17 = (SMBIOS_TABLE_TYPE17 *)Record;
+        ExtractString((CHAR8 *)((UINT8 *)Type17 + Type17->Hdr.Length), Type17->Manufacturer, &TmpMemoryManufacturer);
+        *MemoryType = Type17->MemoryType;
+
+        if (!(Type17->Size & 0x8000)) {
+          if (Type17->Size == 0x7FFF) {
+            *MemorySize = Type17->ExtendedSize;
+          } else if (Type17->Size == 0) {
+            *MemorySize = 0;
+          } else if (Type17->Size == 0xFFFF) {
+            *MemorySize = 128 * 1024;//128*1024 MB
+          } else {
+            *MemorySize = Type17->Size;//MB
+          }
+        } else {
+          if ((Type17->Size & 0x7FFF) == 0x7FFF) {
+            *MemorySize = Type17->ExtendedSize / 1024; //KB to MB
+          } else if (Type17->Size == 0xFFFF) {
+            *MemorySize = 128 * 1024;//128*1024 MB
+          } else {
+            *MemorySize = Type17->Size / 1024;//KB to MB
+          }
+        }
+        *MemoryRank  =  Type17->Attributes & 0x0F;
+        *MemorySpeed = Type17->ExtendedSpeed;
+
+        DEBUG((DEBUG_VERBOSE, "GetMemoryInfo:Type17->Size:0x%04x, Type17->ExtendedSize:0x%08x,MemorySize:0x%x,MemorySpeed:0x%x, MemoryRank:0x%x\n", Type17->Size, Type17->ExtendedSize, *MemorySize, *MemorySpeed, *MemoryRank));
+        break;
+      }
+    }
+
+    if (TmpMemoryManufacturer != NULL) {
+      MemManuLen = StrLen(TmpMemoryManufacturer);
+      if (MemManuLen < MEM_MANUFACTURER_MAX_LEN) {
+        DEBUG((DEBUG_VERBOSE, "MemoryManufacturer16:%s,Len: %d\n", TmpMemoryManufacturer, MemManuLen));
+        CopyMem(MemoryManufacturer, TmpMemoryManufacturer, (StrLen(TmpMemoryManufacturer) +1)*sizeof(CHAR16));
+      } else {
+        DEBUG((DEBUG_VERBOSE, "MemoryManufacturer16:%s,Len= %d, ERROR!\n", TmpMemoryManufacturer, MemManuLen));
+        Status = EFI_OUT_OF_RESOURCES;
+      }
+      FreePool(TmpMemoryManufacturer);
+    }
+  }
+
+  return Status;
+}

--- a/Silicon/Sophgo/SG2044Pkg/Library/SmbiosInformation/SmbiosInformationLib.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Library/SmbiosInformation/SmbiosInformationLib.inf
@@ -1,0 +1,43 @@
+##
+#  @file
+#  This INF file describes the SmbiosInformationLib library, which provides
+#  functionality to parse SMBIOS tables and extract relevant system information.
+#
+#  Copyright (c) Sophgo Inc. All rights reserved.
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001000A
+  BASE_NAME                      = SmbiosInformationLib
+  FILE_GUID                      = E3371385-436E-2310-CB61-CF8B5B093DBA
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmbiosInformationLib
+
+[Sources]
+  SmbiosInformationLib.c
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Sophgo/SG2044Pkg/SG2044Pkg.dec
+  Silicon/Sophgo/Sophgo.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  UefiBootServicesTableLib
+  UefiLib
+  MemoryAllocationLib
+  DevicePathLib
+
+[Protocols]
+  gEfiSmbiosProtocolGuid                         ## CONSUMES
+
+[Pcd]
+  gSophgoTokenSpaceGuid.PcdServerNamePrefix
+
+[Depex]
+  TRUE
+


### PR DESCRIPTION
 - The library provides functions to parse the SMBIOS table and extract relevant information.

 - SMBIOS TPYE17 don't support "LPDDR5X", but SG2044 platform's ddr type is "LPDDR5X". So we set "LPDDR5X" string in ddr information of BIOS Menu for workaround temporarily.