### PR TITLE
SG2044Pkg: Only support ACPI

### DIFF
--- a/Silicon/Sophgo/Include/Guid/VendorGlobalVariables.h
+++ b/Silicon/Sophgo/Include/Guid/VendorGlobalVariables.h
@@ -93,13 +93,6 @@ extern EFI_GUID  gEfiSophgoGlobalVariableGuid;
 #define FORCE_UIAPP_VARIABLE_NAME  L"ForceUiApp"
 
 //
-// This variable is used to inidicate the ACPI enable status.
-//   0: Disable ACPI
-//   1: Enable ACPI
-//
-#define EFI_ACPI_ENABLE_VARIABLE_NAME  L"AcpiEnable"
-
-//
 // This variable is used to inidicate the Root Key which is used to verify PK.
 //
 #define EFI_RK_VARIABLE_NAME  L"RK"

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
@@ -879,92 +879,6 @@ UpdateAcpiDsdtTable (
 }
 
 /**
-  Unload ACPI tables if ACPI is disabled.
-
-  @retval EFI_SUCCESS           Operation completed
-  @retval EFI_INVALID_PARAMETER Invalid system state
-  @retval Others                Error during operation
-**/
-EFI_STATUS
-EFIAPI
-UnloadAcpiTables (
-  VOID
-  )
-{
-  EFI_STATUS  Status;
-  VOID        *AcpiTable;
-  VOID        *Acpi10Table;
-
-  //
-  // Save current ACPI tables before removing them
-  //
-  Status = EfiGetSystemConfigurationTable (&gEfiAcpiTableGuid, &AcpiTable);
-  if (!EFI_ERROR (Status) && AcpiTable != NULL) {
-    DEBUG ((DEBUG_INFO, "Found ACPI 2.0+ table at 0x%lx\n", (UINT64)(UINTN)AcpiTable));
-    // Remove ACPI 2.0 table
-    Status = gBS->InstallConfigurationTable (&gEfiAcpiTableGuid, NULL);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Failed to remove ACPI 2.0+ table: %r\n", Status));
-    }
-  }
-
-  Status = EfiGetSystemConfigurationTable (&gEfiAcpi10TableGuid, &Acpi10Table);
-  if (!EFI_ERROR (Status) && Acpi10Table != NULL) {
-    DEBUG ((DEBUG_INFO, "Found ACPI 1.0 table at 0x%lx\n", (UINT64)(UINTN)Acpi10Table));
-    // Remove ACPI 1.0 table
-    Status = gBS->InstallConfigurationTable (&gEfiAcpi10TableGuid, NULL);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Failed to remove ACPI 1.0 table: %r\n", Status));
-    }
-  }
-
-  DEBUG ((DEBUG_INFO, "Successfully removed ACPI tables\n"));
-
-  return EFI_SUCCESS;
-}
-
-/**
-  Finalize ACPI/DTS configuration before exiting boot services.
-
-  @param[in]  Event     ExitBootServices event
-  @param[in]  Context   Unused context pointer
-**/
-VOID
-EFIAPI
-UpdateAcpiOnExitBootServices (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  UINTN       VarSize;
-  EFI_STATUS  Status;
-  BOOLEAN     AcpiEnabled;
-
-  //
-  // Get current ACPI status from variable
-  //
-  VarSize = sizeof (BOOLEAN);
-  Status = gRT->GetVariable (
-                  EFI_ACPI_ENABLE_VARIABLE_NAME,
-                  &gEfiSophgoGlobalVariableGuid,
-                  NULL,
-                  &VarSize,
-                  &AcpiEnabled
-                  );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "[ACPI] Failed to get ACPI state: %r\n", Status));
-    return;
-  }
-
-  if (!AcpiEnabled) {
-    DEBUG ((DEBUG_INFO, "[ACPI] Disabled, finalizing DTB setup...\n"));
-    Status = UnloadAcpiTables ();
-    DEBUG ((Status == EFI_SUCCESS ? DEBUG_INFO : DEBUG_ERROR,
-           "[ACPI] UnloadAcpiTables status: %r\n", Status));
-  }
-}
-
-/**
   Entry point of the ACPI platform driver.
 
   @param[in] ImageHandle    Image handle of this driver.
@@ -991,39 +905,10 @@ AcpiPlatformDxeEntryPoint (
   UINTN                          TableSize;
   UINTN                          Size;
   EFI_ACPI_DESCRIPTION_HEADER    *TableHeader;
-  BOOLEAN                        AcpiEnabled;
-  EFI_EVENT                      ExitBootServicesEvent;
 
   Instance     = 0;
   CurrentTable = NULL;
   TableHandle  = 0;
-
-  //
-  // Create event for ExitBootServices
-  //
-  Status = gBS->CreateEvent (
-                  EVT_SIGNAL_EXIT_BOOT_SERVICES,
-                  TPL_NOTIFY,
-                  UpdateAcpiOnExitBootServices,
-                  NULL,
-                  &ExitBootServicesEvent
-                  );
-  ASSERT_EFI_ERROR (Status);
-
-  //
-  // Set initial ACPI enabled state
-  //
-  AcpiEnabled = TRUE;
-  Status = gRT->SetVariable (
-                  EFI_ACPI_ENABLE_VARIABLE_NAME,
-                  &gEfiSophgoGlobalVariableGuid,
-                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
-                  sizeof (BOOLEAN),
-                  &AcpiEnabled
-                  );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Failed to set initial ACPI state: %r\n", Status));
-  }
 
   //
   // Find the AcpiTable protocol

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -40,8 +40,6 @@
 
 [Guids]
   gEfiSophgoGlobalVariableGuid                              ## CONSUMES ## GUID
-  gEfiAcpiTableGuid                                         ## CONSUMES ## GUID
-  gEfiAcpi10TableGuid                                       ## CONSUMES ## GUID
 
 [Protocols]
   gEfiAcpiTableProtocolGuid                                 ## CONSUMES

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPage.c
@@ -86,65 +86,6 @@ HII_VENDOR_DEVICE_PATH  mFrontPageHiiVendorDevicePath0 = {
 };
 
 BOOLEAN
-GetAcpiTable (
-  VOID
-  )
-{
-  EFI_STATUS                                    Status;
-  EFI_ACPI_3_0_ROOT_SYSTEM_DESCRIPTION_POINTER  *Rsdp;
-
-  //
-  // Get the ACPI table from the system table.
-  //
-  Status = EfiGetSystemConfigurationTable (&gEfiAcpiTableGuid, (VOID **)&Rsdp);
-  if (EFI_ERROR (Status)) {
-    Status = EfiGetSystemConfigurationTable (&gEfiAcpi10TableGuid, (VOID **)&Rsdp);
-  }
-
-  if (!EFI_ERROR (Status) &&
-      (Rsdp != NULL) &&
-      (Rsdp->Revision >= EFI_ACPI_6_5_ROOT_SYSTEM_DESCRIPTION_POINTER_REVISION) &&
-      (Rsdp->RsdtAddress != 0))
-  {
-    return TRUE;
-  }
-
-  return FALSE;
-}
-
-EFI_STATUS
-InstallFdt (
-  VOID
-  )
-{
-  EFI_RISCV_FIRMWARE_CONTEXT  *FirmwareContext;
-  VOID                        *FdtAddress;
-  EFI_STATUS                  Status;
-
-  FirmwareContext = NULL;
-  GetFirmwareContextPointer (&FirmwareContext);
-
-  if (FirmwareContext == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Firmware Context is NULL\n", __func__));
-    return EFI_UNSUPPORTED;
-  }
-
-  FdtAddress = (VOID *)FirmwareContext->FlattenedDeviceTree;
-  if (FdtAddress == NULL) {
-    DEBUG ((DEBUG_ERROR, "FdtAddress is NULL!\n"));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status = gBS->InstallConfigurationTable (&gFdtTableGuid, FdtAddress);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "Failed to install FDT: %r\n", Status));
-    return Status;
-  }
-
-  return EFI_SUCCESS;
-}
-
-BOOLEAN
 ConfirmResetDefaults (
   CHAR16 *ConfirmPrompt
   )
@@ -253,7 +194,6 @@ FrontPageCallback (
   )
 {
   EFI_STATUS    Status;
-  BOOLEAN       AcpiEnabled;
   CHAR16        *ConfirmResetPrompt = NULL;
 
   if ((This == NULL) || (ActionRequest == NULL)) {
@@ -281,38 +221,6 @@ FrontPageCallback (
         DEBUG ((DEBUG_ERROR, "Failed to restore factory defaults: %r\n", Status));
         return Status;
       }
-    }
-  }
-
-  if (Action == EFI_BROWSER_ACTION_CHANGING) {
-    switch (QuestionId) {
-      case ACPI_DISABLE_QUESTION_ID:
-        // Convert Value->u8 to boolean (0 = disabled, 1 = enabled)
-        AcpiEnabled = (Value->u8 != 0);
-
-        // Save ACPI state to variable
-        Status = gRT->SetVariable (
-                       EFI_ACPI_ENABLE_VARIABLE_NAME,
-                       &gEfiSophgoGlobalVariableGuid,
-                       EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
-                       sizeof (BOOLEAN),
-                       &AcpiEnabled
-                       );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_ERROR, "Failed to save ACPI state: %r\n", Status));
-          return Status;
-        }
-
-        if (!AcpiEnabled) {
-          // If ACPI is being disabled, remove ACPI tables now
-          Status = InstallFdt ();
-          if (EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_ERROR, "Failed to install FDT\n"));
-            return Status;
-          }
-        }
-
-        break;
     }
   }
 
@@ -377,7 +285,6 @@ InitializePasswordToggleVariable (
       PassWordToggleData.IsFirst = 0;
       PassWordToggleData.UserPriv = 0;
       PassWordToggleData.IsEvb = 0;
-      PassWordToggleData.DefaultAcpi = 0;
       Status = gRT->SetVariable (
 		      EFI_PASSWORD_TOGGLE_VARIABLE_NAME,
 		      &gEfiSophgoGlobalVariableGuid,
@@ -1374,14 +1281,6 @@ InitializeUserInterface (
 
   InitializeStringSupport ();
   InitializePasswordToggleVariable ();
-  PassWordToggleData.DefaultAcpi = GetAcpiTable () ? 1 : 0;
-  if (PassWordToggleData.DefaultAcpi == 0) {
-    Status = InstallFdt ();
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "Failed to install FDT\n"));
-      return Status;
-    }
-  }
   PassWordToggleData.IsEvb = IsServerBoard ? 0 : 1;
   Status = gRT->SetVariable (
 		  EFI_PASSWORD_TOGGLE_VARIABLE_NAME,

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageNVDataStruc.h
@@ -43,7 +43,6 @@ typedef struct {
   UINT8 IsFirst;
   UINT8 UserPriv;
   UINT8 IsEvb;
-  UINT8 DefaultAcpi;
 } PASSWORD_TOGGLE_DATA;
 #pragma pack()
 #endif

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageStrings.uni
@@ -83,5 +83,3 @@
 #string STR_SYSTEM_SETTING_TITLE     #language en-US "System Setting"
 #string STR_GOTO_BMC                 #language en-US "BMC Config"
 #string STR_GOTO_BMC_HELP            #language en-US "BMC configuration settings."
-#string STR_ACPI_PROMPT              #language en-US "Enable ACPI"
-#string STR_ACPI_HELP                #language en-US "Choose to whether use ACPI to boot kernel"

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/FrontPageVfr.Vfr
@@ -41,16 +41,6 @@ formset
    endif;
     label LABEL_MANAGER;
     label LABEL_END;
-   grayoutif ideqval PASSWORD_TOGGLE_DATA.DefaultAcpi == 0;
-     oneof varid  = PASSWORD_TOGGLE_DATA.DefaultAcpi,
-          questionid = ACPI_DISABLE_QUESTION_ID,
-          prompt = STRING_TOKEN(STR_ACPI_PROMPT),
-          help   = STRING_TOKEN(STR_ACPI_HELP),
-          flags  = INTERACTIVE,
-          option text = STRING_TOKEN(STR_DISABLE), value = 0x0, flags = 0;
-          option text = STRING_TOKEN(STR_ENABLE), value = 0x1, flags = DEFAULT;
-     endoneof;
-   endif;
   endform;
   form formid = SYSTEM_INFORMATION_ID,
         title = STRING_TOKEN(STR_SYSTEM_INFORMATION_TITLE);

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/UiApp/UiApp.inf
@@ -58,9 +58,6 @@
   gEfiIfrTianoGuid                              ## CONSUMES ## GUID (Extended IFR Guid Opcode)
   gEfiIfrFrontPageGuid                          ## CONSUMES ## GUID
   gEfiSophgoGlobalVariableGuid                  ## CONSUMES ## GUID
-  gFdtTableGuid                                 ## CONSUMES ## GUID
-  gEfiAcpiTableGuid                             ## CONSUMES ## GUID
-  gEfiAcpi10TableGuid                           ## CONSUMES ## GUID
 
 [Protocols]
   gEfiSmbiosProtocolGuid                        ## CONSUMES


### PR DESCRIPTION
 - Previously, we used dynamic ACPI contorl mechanism, and provided a selection in BIOS Menu to switch between ACPI and DTB.

 - Now, it is adjusted to support only ACPI by default, and no longer need DTB. So, we delete the switching capability for ACPI/DTB selection in BIOS Menu and delete related functions such as "UnloadAcpiTables", "InstallFdt", "GetAcpiTable", etc.