### PR TITLE
Sophgo: Add Tpm modules for SG2044

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SG2044.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.dsc
@@ -32,6 +32,7 @@
   #
   DEFINE SECURE_BOOT_ENABLE      = TRUE
   DEFINE DEBUG_ON_SERIAL_PORT    = TRUE
+  DEFINE TPM2_ENABLE             = TRUE
 
   #
   # Network definition
@@ -232,6 +233,11 @@
   ManageabilityTransportLib|edk2-platforms/Silicon/Sophgo/Library/SophgoManageabilityTransportSerialLib/Dxe/DxeManageabilityTransportSerial.inf
   SophgoNs16550Lib|edk2-platforms/Silicon/Sophgo/Library/SophgoNs16550Lib/SophgoNs16550.inf
 
+!if $(TPM2_ENABLE) == TRUE  
+  Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+  Tcg2PpVendorLib|SecurityPkg/Library/Tcg2PpVendorLibNull/Tcg2PpVendorLibNull.inf
+!endif
+
 [LibraryClasses.common]
   #
   # Secure Boot dependencies
@@ -297,6 +303,7 @@
 
   ResetSystemLib|OvmfPkg/RiscVVirt/Library/ResetSystemLib/BaseResetSystemLib.inf
   DmaLib|EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
+
 [LibraryClasses.common.SEC]
   ReportStatusCodeLib|MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/BaseExtractGuidedSectionLib/BaseExtractGuidedSectionLib.inf
@@ -325,7 +332,7 @@
 !endif
 
 [LibraryClasses.common.PEIM]
-  FirmwareContextProcessorSpecificLib|Platform/RISC-V/PlatformPkg/Library/FirmwareContextProcessorSpecificLib/FirmwareContextProcessorSpecificLib.inf
+  PcdLib|MdePkg/Library/PeiPcdLib/PeiPcdLib.inf
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
   MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
   PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
@@ -555,6 +562,7 @@
   gSophgoTokenSpaceGuid.PcdPhyResetGpioPin|28
   gSophgoTokenSpaceGuid.PcdDwMac4DefaultMacAddress|0x12345678ABCD
 !endif
+
 [PcdsFixedAtBuild.common]
   gSophgoTokenSpaceGuid.PcdSDIOSourceClockFrequency|400000000
   gSophgoTokenSpaceGuid.PcdSDIOTransmissionClockFrequency|25000000
@@ -562,8 +570,22 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x7030001000
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialClockRate|500000000
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialBaudRate|115200
-
   gSophgoTokenSpaceGuid.PcdServerNamePrefix|L"SR"
+
+!if $(TPM2_ENABLE) == TRUE  
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmPlatformClass|0x02
+  gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice|0x010E0000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2InitializationPolicy|1
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2SelfTestPolicy|1
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2ScrtmPolicy|0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmAutoDetection|FALSE
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision|0
+  gEfiMdeModulePkgTokenSpaceGuid.PcdImageProtectionPolicy|0x00000000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmPhysicalPresence|TRUE
+  gSophgoTokenSpaceGuid.PcdTpm2GpioBaseAddress|0x704000b000
+  gSophgoTokenSpaceGuid.PcdTpm2SpiBaseAddress|0x7030004000
+  gSophgoTokenSpaceGuid.PcdTopBaseAddress|0x7050000000
+!endif
 
 ################################################################################
 #
@@ -600,6 +622,21 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareBase64|0x0
 !endif
 
+!if $(TPM2_ENABLE) == TRUE  
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy|1
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid|{0x5a, 0xf2, 0x6b, 0x28, 0xc3, 0xc2, 0x8c, 0x40, 0xb3, 0xb4, 0x25, 0xe6, 0x75, 0x8b, 0x73, 0x17}
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress|0xFED40000
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|"1.3"
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev|3
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2CurrentIrqNum|0
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType|0x0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLaml|0
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLasa|0
+  gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized|FALSE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0x00000002
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap|3
+!endif
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform.
@@ -629,15 +666,40 @@
   }
 
   MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf  {
-    <LibraryClasses>  
+    <LibraryClasses>
+    PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
     ExtractGuidedSectionLib|MdePkg/Library/PeiExtractGuidedSectionLib/PeiExtractGuidedSectionLib.inf
   }
 
   Platform/RISC-V/PlatformPkg/Universal/Pei/PlatformPei/PlatformPei.inf  {
     <LibraryClasses>
+    PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
     PeiResourcePublicationLib|MdePkg/Library/PeiResourcePublicationLib/PeiResourcePublicationLib.inf
     RiscVCoreplexInfoLib|Platform/RISC-V/PlatformPkg/Library/PeiCoreInfoHobLibNull/PeiCoreInfoHobLib.inf  
   }
+
+  MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+  MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
+  MdeModulePkg/Universal/PCD/Pei/Pcd.inf  {
+    <LibraryClasses>
+    PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  }
+
+!if $(TPM2_ENABLE) == TRUE
+  SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf  {
+    <LibraryClasses>
+    Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
+    NULL|Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmPei.inf
+    HashLib|SecurityPkg/Library/HashLibTpm2/HashLibTpm2.inf
+  }
+  Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.inf {
+    <LibraryClasses>
+    MmUnblockMemoryLib|MdePkg/Library/MmUnblockMemoryLib/MmUnblockMemoryLibNull.inf
+    Tpm12CommandLib|SecurityPkg/Library/Tpm12CommandLib/Tpm12CommandLib.inf
+    Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
+  }
+  SecurityPkg/Tcg/PhysicalPresencePei/PhysicalPresencePei.inf
+!endif
 
   #
   # DXE Phase modules
@@ -872,6 +934,24 @@
       NULL|SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.inf
 !endif
   }
+
+!if $(TPM2_ENABLE) == TRUE  
+  Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.inf  {
+    <LibraryClasses>
+    Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
+    NULL|Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.inf
+    HashLib|SecurityPkg/Library/HashLibTpm2/HashLibTpm2.inf
+    PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+    Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+  }
+  Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.inf {
+    <LibraryClasses>
+    Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
+    NULL|Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.inf
+    PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+    Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
+  }
+!endif
 
 !if $(SECURE_BOOT_ENABLE) == TRUE
   SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigDxe.inf

--- a/Platform/Sophgo/SG2044Pkg/SG2044.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SG2044.fdf
@@ -263,6 +263,14 @@ INF Features/ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfig.inf
 
+#
+# TPM2 Dxe
+#
+!if $(TPM2_ENABLE) == TRUE
+  INF Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.inf
+  INF Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.inf
+!endif
+
 ################################################################################
 
 [FV.FVMAIN_COMPACT]
@@ -286,8 +294,24 @@ FvNameGuid         = 02CBA7CB-BDE9-4934-A182-9043BE539261
 
 INF Silicon/Sophgo/Core/Sec/PeilessSec.inf
 INF Silicon/Sophgo/Core/Pei/PeiMain.inf
-INF Platform/RISC-V/PlatformPkg/Universal/Pei/PlatformPei/PlatformPei.inf 
+
+#
+#Pei phase modules
+#
+INF Platform/RISC-V/PlatformPkg/Universal/Pei/PlatformPei/PlatformPei.inf
+INF MdeModulePkg/Universal/PCD/Pei/Pcd.inf
+INF MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+INF MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.inf
 INF MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+
+#
+#TPM2 modules
+#
+!if $(TPM2_ENABLE) == TRUE
+  INF SecurityPkg/Tcg/Tcg2Pei/Tcg2Pei.inf
+  INF Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.inf
+  INF SecurityPkg/Tcg/PhysicalPresencePei/PhysicalPresencePei.inf
+!endif
 
 FILE FV_IMAGE = 9E21FD93-9C72-4c15-8C4B-E77F1DB2D792 {
    SECTION GUIDED EE4E5898-3914-4259-9D6E-DC7BD79403CF PROCESSING_REQUIRED = TRUE {

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2Config.vfr
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2Config.vfr
@@ -1,0 +1,246 @@
+/** @file
+  VFR file used by the TCG2 configuration component.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Tcg2ConfigNvData.h"
+
+formset
+  guid      = TCG2_CONFIG_FORM_SET_GUID,
+  title     = STRING_TOKEN(STR_TCG2_TITLE),
+  help      = STRING_TOKEN(STR_TCG2_HELP),
+  classguid = EFI_HII_PLATFORM_SETUP_FORMSET_GUID,
+
+  efivarstore TCG2_CONFIGURATION_INFO,
+    varid = TCG2_CONFIGURATION_INFO_VARSTORE_ID,
+    attribute = 0x02,  // EFI variable attributes  EFI_VARIABLE_BOOTSERVICE_ACCESS
+    name  = TCG2_CONFIGURATION_INFO,
+    guid  = TCG2_CONFIG_FORM_SET_GUID;
+
+  efivarstore TCG2_CONFIGURATION,
+    varid = TCG2_CONFIGURATION_VARSTORE_ID,
+    attribute = 0x03,  // EFI variable attributes  EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE
+    name  = TCG2_CONFIGURATION,
+    guid  = TCG2_CONFIG_FORM_SET_GUID;
+
+  efivarstore TCG2_VERSION,
+    varid = TCG2_VERSION_VARSTORE_ID,
+    attribute = 0x03,  // EFI variable attributes  EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE
+    name  = TCG2_VERSION,
+    guid  = TCG2_CONFIG_FORM_SET_GUID;
+
+  form formid = TCG2_CONFIGURATION_FORM_ID,
+    title = STRING_TOKEN(STR_TCG2_TITLE);
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_DEVICE_STATE_HELP),
+      text   = STRING_TOKEN(STR_TCG2_DEVICE_STATE_PROMPT),
+        text   = STRING_TOKEN(STR_TCG2_DEVICE_STATE_CONTENT);
+
+    oneof varid  = TCG2_CONFIGURATION.TpmDevice,
+          questionid = KEY_TPM_DEVICE,
+          prompt = STRING_TOKEN(STR_TCG2_DEVICE_PROMPT),
+          help   = STRING_TOKEN(STR_TCG2_DEVICE_HELP),
+          flags  = INTERACTIVE,
+            option text = STRING_TOKEN(STR_TCG2_TPM_1_2),          value = TPM_DEVICE_1_2,          flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_TPM_2_0_DTPM),     value = TPM_DEVICE_2_0_DTPM,     flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
+    endoneof;
+
+    suppressif ideqvallist TCG2_CONFIGURATION.TpmDevice == TPM_DEVICE_NULL TPM_DEVICE_1_2;
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+
+    text
+      help   = STRING_TOKEN(STR_TPM2_ACPI_HID_HELP),
+      text   = STRING_TOKEN(STR_TPM2_ACPI_HID_PROMPT),
+        text   = STRING_TOKEN(STR_TPM2_ACPI_HID_CONTENT);
+
+    text
+      help   = STRING_TOKEN(STR_TPM2_ACPI_REVISION_STATE_HELP),
+      text   = STRING_TOKEN(STR_TPM2_ACPI_REVISION_STATE_PROMPT),
+        text   = STRING_TOKEN(STR_TPM2_ACPI_REVISION_STATE_CONTENT);
+
+    oneof varid  = TCG2_VERSION.Tpm2AcpiTableRev,
+          questionid = KEY_TPM2_ACPI_REVISION,
+          prompt = STRING_TOKEN(STR_TPM2_ACPI_REVISION_PROMPT),
+          help   = STRING_TOKEN(STR_TPM2_ACPI_REVISION_HELP),
+          flags  = INTERACTIVE,
+            option text = STRING_TOKEN(STR_TPM2_ACPI_REVISION_3),     value = TPM2_ACPI_REVISION_3,     flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TPM2_ACPI_REVISION_4),     value = TPM2_ACPI_REVISION_4,     flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
+    endoneof;
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_STATE_HELP),
+      text   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_STATE_PROMPT),
+        text   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_CAPABILITY_HELP),
+      text   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_CAPABILITY_PROMPT),
+        text   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT);
+
+    suppressif ideqval TCG2_CONFIGURATION_INFO.TpmDeviceInterfacePtpFifoSupported == 0
+            OR ideqval TCG2_CONFIGURATION_INFO.TpmDeviceInterfacePtpCrbSupported == 0;
+    oneof varid  = TCG2_CONFIGURATION_INFO.TpmDeviceInterfaceAttempt,
+          questionid = KEY_TPM_DEVICE_INTERFACE,
+          prompt = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_PROMPT),
+          help   = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_HELP),
+          flags  = INTERACTIVE,
+            option text = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_TIS),          value = TPM_DEVICE_INTERFACE_TIS,          flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_PTP_FIFO),     value = TPM_DEVICE_INTERFACE_PTP_FIFO,     flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_DEVICE_INTERFACE_PTP_CRB),      value = TPM_DEVICE_INTERFACE_PTP_CRB,      flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
+    endoneof;
+    endif;
+
+    endif;
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+
+    suppressif ideqvallist TCG2_CONFIGURATION.TpmDevice == TPM_DEVICE_NULL TPM_DEVICE_1_2;
+    text
+      help   = STRING_TOKEN(STR_TPM2_ACTIVE_HASH_ALGO_HELP),
+      text   = STRING_TOKEN(STR_TPM2_ACTIVE_HASH_ALGO),
+        text   = STRING_TOKEN(STR_TPM2_ACTIVE_HASH_ALGO_CONTENT);
+    text
+      help   = STRING_TOKEN(STR_TPM2_SUPPORTED_HASH_ALGO_HELP),
+      text   = STRING_TOKEN(STR_TPM2_SUPPORTED_HASH_ALGO),
+        text   = STRING_TOKEN(STR_TPM2_SUPPORTED_HASH_ALGO_CONTENT);
+    text
+      help   = STRING_TOKEN(STR_BIOS_HASH_ALGO_HELP),
+      text   = STRING_TOKEN(STR_BIOS_HASH_ALGO),
+        text   = STRING_TOKEN(STR_BIOS_HASH_ALGO_CONTENT);
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+    subtitle text = STRING_TOKEN(STR_TCG2_PP_OPERATION);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_PPI_VERSION_STATE_HELP),
+      text   = STRING_TOKEN(STR_TCG2_PPI_VERSION_STATE_PROMPT),
+        text   = STRING_TOKEN(STR_TCG2_PPI_VERSION_STATE_CONTENT);
+
+    oneof varid  = TCG2_VERSION.PpiVersion,
+          questionid = KEY_TCG2_PPI_VERSION,
+          prompt = STRING_TOKEN(STR_TCG2_PPI_VERSION_PROMPT),
+          help   = STRING_TOKEN(STR_TCG2_PPI_VERSION_HELP),
+          flags  = INTERACTIVE,
+            option text = STRING_TOKEN(STR_TCG2_PPI_VERSION_1_2), value = TCG2_PPI_VERSION_1_2, flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_PPI_VERSION_1_3), value = TCG2_PPI_VERSION_1_3, flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
+    endoneof;
+
+    oneof name = Tpm2Operation,
+          questionid = KEY_TPM2_OPERATION,
+          prompt = STRING_TOKEN(STR_TCG2_OPERATION),
+          help   = STRING_TOKEN(STR_TCG2_OPERATION_HELP),
+          flags  = INTERACTIVE | NUMERIC_SIZE_1,
+            option text = STRING_TOKEN(STR_TCG2_NO_ACTION), value = TCG2_PHYSICAL_PRESENCE_NO_ACTION, flags = DEFAULT | MANUFACTURING | RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_ENABLE), value = TCG2_PHYSICAL_PRESENCE_ENABLE, flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_DISABLE), value = TCG2_PHYSICAL_PRESENCE_DISABLE, flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_CLEAR), value = TCG2_PHYSICAL_PRESENCE_CLEAR, flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_SET_PCD_BANKS), value = TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS, flags = RESET_REQUIRED;
+            suppressif ideqval TCG2_CONFIGURATION_INFO.ChangeEPSSupported == 0;
+            option text = STRING_TOKEN(STR_TCG2_CHANGE_EPS), value = TCG2_PHYSICAL_PRESENCE_CHANGE_EPS, flags = RESET_REQUIRED;
+            endif
+            option text = STRING_TOKEN(STR_TCG2_LOG_ALL_DIGESTS), value = TCG2_PHYSICAL_PRESENCE_LOG_ALL_DIGESTS, flags = RESET_REQUIRED;
+            option text = STRING_TOKEN(STR_TCG2_DISABLE_ENDORSEMENT_ENABLE_STORAGE_HIERARCHY), value = TCG2_PHYSICAL_PRESENCE_DISABLE_ENDORSEMENT_ENABLE_STORAGE_HIERARCHY, flags = RESET_REQUIRED;
+    endoneof;
+
+    suppressif NOT questionref(Tpm2Operation) == TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS;
+    numeric name = Tpm2OperationParameter,
+            questionid = KEY_TPM2_OPERATION_PARAMETER,
+            prompt  = STRING_TOKEN(STR_TCG2_OPERATION_PARAMETER),
+            help    = STRING_TOKEN(STR_TCG2_OPERATION_PARAMETER_HELP),
+            flags   = DISPLAY_UINT_HEX | INTERACTIVE | NUMERIC_SIZE_4,
+            minimum = 0,
+            maximum = 0xFFFFFFFF,
+            step    = 0,
+            default = 0,
+    endnumeric;
+    endif;
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+    subtitle text = STRING_TOKEN(STR_TCG2_CONFIGURATION);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT_HELP),
+      text   = STRING_TOKEN(STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT),
+        text   = STRING_TOKEN(STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT_CONTENT);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_HASH_ALGO_BITMAP_HELP),
+      text   = STRING_TOKEN(STR_TCG2_HASH_ALGO_BITMAP),
+        text   = STRING_TOKEN(STR_TCG2_HASH_ALGO_BITMAP_CONTENT);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_NUMBER_OF_PCR_BANKS_HELP),
+      text   = STRING_TOKEN(STR_TCG2_NUMBER_OF_PCR_BANKS),
+        text   = STRING_TOKEN(STR_TCG2_NUMBER_OF_PCR_BANKS_CONTENT);
+
+    text
+      help   = STRING_TOKEN(STR_TCG2_ACTIVE_PCR_BANKS_HELP),
+      text   = STRING_TOKEN(STR_TCG2_ACTIVE_PCR_BANKS),
+        text   = STRING_TOKEN(STR_TCG2_ACTIVE_PCR_BANKS_CONTENT);
+
+    subtitle text = STRING_TOKEN(STR_NULL);
+
+  suppressif ideqval TCG2_CONFIGURATION_INFO.Sha1Supported == 0;
+    checkbox name = TCG2ActivatePCRBank0,
+            questionid = KEY_TPM2_PCR_BANKS_REQUEST_0,
+            prompt     = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA1),
+            help       = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA1_HELP),
+            flags      = INTERACTIVE | RESET_REQUIRED,
+            default    = 1,
+    endcheckbox;
+  endif;
+
+  suppressif ideqval TCG2_CONFIGURATION_INFO.Sha256Supported == 0;
+    checkbox name = TCG2ActivatePCRBank1,
+            questionid = KEY_TPM2_PCR_BANKS_REQUEST_1,
+            prompt     = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA256),
+            help       = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA256_HELP),
+            flags      = INTERACTIVE | RESET_REQUIRED,
+            default    = 0,
+    endcheckbox;
+  endif;
+
+  suppressif ideqval TCG2_CONFIGURATION_INFO.Sha384Supported == 0;
+    checkbox name = TCG2ActivatePCRBank2,
+            questionid = KEY_TPM2_PCR_BANKS_REQUEST_2,
+            prompt     = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA384),
+            help       = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA384_HELP),
+            flags      = INTERACTIVE | RESET_REQUIRED,
+            default    = 0,
+    endcheckbox;
+  endif;
+
+  suppressif ideqval TCG2_CONFIGURATION_INFO.Sha512Supported == 0;
+    checkbox name = TCG2ActivatePCRBank3,
+            questionid = KEY_TPM2_PCR_BANKS_REQUEST_3,
+            prompt     = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA512),
+            help       = STRING_TOKEN(STR_TCG2_PCR_BANK_SHA512_HELP),
+            flags      = INTERACTIVE | RESET_REQUIRED,
+            default    = 0,
+    endcheckbox;
+  endif;
+
+  suppressif ideqval TCG2_CONFIGURATION_INFO.Sm3Supported == 0;
+    checkbox name = TCG2ActivatePCRBank4,
+            questionid = KEY_TPM2_PCR_BANKS_REQUEST_4,
+            prompt     = STRING_TOKEN(STR_TCG2_PCR_BANK_SM3_256),
+            help       = STRING_TOKEN(STR_TCG2_PCR_BANK_SM3_256_HELP),
+            flags      = INTERACTIVE | RESET_REQUIRED,
+            default    = 0,
+    endcheckbox;
+  endif;
+
+    endif;
+
+  endform;
+
+endformset;

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDriver.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDriver.c
@@ -1,0 +1,463 @@
+/** @file
+  The module entry point for Tcg2 configuration module.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Tcg2ConfigImpl.h"
+
+extern TPM_INSTANCE_ID  mTpmInstanceId[TPM_DEVICE_MAX + 1];
+
+/**
+  Update default PCR banks data.
+
+  @param[in]  HiiPackage        HII Package.
+  @param[in]  HiiPackageSize    HII Package size.
+  @param[in]  PCRBanks          PCR Banks data.
+
+**/
+VOID
+UpdateDefaultPCRBanks (
+  IN VOID    *HiiPackage,
+  IN UINTN   HiiPackageSize,
+  IN UINT32  PCRBanks
+  )
+{
+  EFI_HII_PACKAGE_HEADER  *HiiPackageHeader;
+  EFI_IFR_OP_HEADER       *IfrOpCodeHeader;
+  EFI_IFR_CHECKBOX        *IfrCheckBox;
+  EFI_IFR_DEFAULT         *IfrDefault;
+
+  HiiPackageHeader = (EFI_HII_PACKAGE_HEADER *)HiiPackage;
+
+  switch (HiiPackageHeader->Type) {
+    case EFI_HII_PACKAGE_FORMS:
+      IfrOpCodeHeader = (EFI_IFR_OP_HEADER *)(HiiPackageHeader + 1);
+      while ((UINTN)IfrOpCodeHeader < (UINTN)HiiPackageHeader + HiiPackageHeader->Length) {
+        switch (IfrOpCodeHeader->OpCode) {
+          case EFI_IFR_CHECKBOX_OP:
+            IfrCheckBox = (EFI_IFR_CHECKBOX *)IfrOpCodeHeader;
+            if ((IfrCheckBox->Question.QuestionId >= KEY_TPM2_PCR_BANKS_REQUEST_0) && (IfrCheckBox->Question.QuestionId <= KEY_TPM2_PCR_BANKS_REQUEST_4)) {
+              IfrDefault = (EFI_IFR_DEFAULT *)(IfrCheckBox + 1);
+              ASSERT (IfrDefault->Header.OpCode == EFI_IFR_DEFAULT_OP);
+              ASSERT (IfrDefault->Type == EFI_IFR_TYPE_BOOLEAN);
+              IfrDefault->Value.b = (BOOLEAN)((PCRBanks >> (IfrCheckBox->Question.QuestionId - KEY_TPM2_PCR_BANKS_REQUEST_0)) & 0x1);
+            }
+
+            break;
+        }
+
+        IfrOpCodeHeader = (EFI_IFR_OP_HEADER *)((UINTN)IfrOpCodeHeader + IfrOpCodeHeader->Length);
+      }
+
+      break;
+  }
+
+  return;
+}
+
+/**
+  Initialize TCG2 version information.
+
+  This function will initialize efi varstore configuration data for
+  TCG2_VERSION_NAME variable, check the value of related PCD with
+  the variable value and set string for the version state content
+  according to the PCD value.
+
+  @param[in] PrivateData    Points to TCG2 configuration private data.
+
+**/
+VOID
+InitializeTcg2VersionInfo (
+  IN TCG2_CONFIG_PRIVATE_DATA  *PrivateData
+  )
+{
+  EFI_STATUS    Status;
+  EFI_STRING    ConfigRequestHdr;
+  BOOLEAN       ActionFlag;
+  TCG2_VERSION  Tcg2Version;
+  UINTN         DataSize;
+  UINT64        PcdTcg2PpiVersion;
+  UINT8         PcdTpm2AcpiTableRev;
+
+  //
+  // Get the PCD value before initializing efi varstore configuration data.
+  //
+  PcdTcg2PpiVersion = 0;
+  CopyMem (
+    &PcdTcg2PpiVersion,
+    PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+    AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
+    );
+
+  PcdTpm2AcpiTableRev = PcdGet8 (PcdTpm2AcpiTableRev);
+
+  //
+  // Initialize efi varstore configuration data.
+  //
+  ZeroMem (&Tcg2Version, sizeof (Tcg2Version));
+  ConfigRequestHdr = HiiConstructConfigHdr (
+                       &gTcg2ConfigFormSetGuid,
+                       TCG2_VERSION_NAME,
+                       PrivateData->DriverHandle
+                       );
+  ASSERT (ConfigRequestHdr != NULL);
+  DataSize = sizeof (Tcg2Version);
+  Status   = gRT->GetVariable (
+                    TCG2_VERSION_NAME,
+                    &gTcg2ConfigFormSetGuid,
+                    NULL,
+                    &DataSize,
+                    &Tcg2Version
+                    );
+  if (!EFI_ERROR (Status)) {
+    //
+    // EFI variable does exist and validate current setting.
+    //
+    ActionFlag = HiiValidateSettings (ConfigRequestHdr);
+    if (!ActionFlag) {
+      //
+      // Current configuration is invalid, reset to defaults.
+      //
+      ActionFlag = HiiSetToDefaults (ConfigRequestHdr, EFI_HII_DEFAULT_CLASS_STANDARD);
+      ASSERT (ActionFlag);
+      //
+      // Get the default values from variable.
+      //
+      DataSize = sizeof (Tcg2Version);
+      Status   = gRT->GetVariable (
+                        TCG2_VERSION_NAME,
+                        &gTcg2ConfigFormSetGuid,
+                        NULL,
+                        &DataSize,
+                        &Tcg2Version
+                        );
+      ASSERT_EFI_ERROR (Status);
+    }
+  } else {
+    //
+    // EFI variable doesn't exist or variable size is not expected.
+    //
+
+    //
+    // Store zero data Buffer Storage to EFI variable.
+    //
+    Status = gRT->SetVariable (
+                    TCG2_VERSION_NAME,
+                    &gTcg2ConfigFormSetGuid,
+                    EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                    sizeof (Tcg2Version),
+                    &Tcg2Version
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_VERSION_NAME\n"));
+      return;
+    } else {
+      //
+      // Build this variable based on default values stored in IFR.
+      //
+      ActionFlag = HiiSetToDefaults (ConfigRequestHdr, EFI_HII_DEFAULT_CLASS_STANDARD);
+      ASSERT (ActionFlag);
+      //
+      // Get the default values from variable.
+      //
+      DataSize = sizeof (Tcg2Version);
+      Status   = gRT->GetVariable (
+                        TCG2_VERSION_NAME,
+                        &gTcg2ConfigFormSetGuid,
+                        NULL,
+                        &DataSize,
+                        &Tcg2Version
+                        );
+      ASSERT_EFI_ERROR (Status);
+      if (PcdTcg2PpiVersion != Tcg2Version.PpiVersion) {
+        DEBUG ((DEBUG_WARN, "WARNING: PcdTcgPhysicalPresenceInterfaceVer default value is not same with the default value in VFR\n"));
+        DEBUG ((DEBUG_WARN, "WARNING: The default value in VFR has be chosen\n"));
+      }
+
+      if (PcdTpm2AcpiTableRev != Tcg2Version.Tpm2AcpiTableRev) {
+        DEBUG ((DEBUG_WARN, "WARNING: PcdTpm2AcpiTableRev default value is not same with the default value in VFR\n"));
+        DEBUG ((DEBUG_WARN, "WARNING: The default value in VFR has be chosen\n"));
+      }
+    }
+  }
+
+  FreePool (ConfigRequestHdr);
+
+  //
+  // Get the PCD value again.
+  // If the PCD value is not equal to the value in variable,
+  // the PCD is not DynamicHii type and does not map to the setup option.
+  //
+  PcdTcg2PpiVersion = 0;
+  CopyMem (
+    &PcdTcg2PpiVersion,
+    PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+    AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
+    );
+  if (PcdTcg2PpiVersion != Tcg2Version.PpiVersion) {
+    DEBUG ((DEBUG_WARN, "WARNING: PcdTcgPhysicalPresenceInterfaceVer is not DynamicHii type and does not map to TCG2_VERSION.PpiVersion\n"));
+    DEBUG ((DEBUG_WARN, "WARNING: The TCG2 PPI version configuring from setup page will not work\n"));
+  }
+
+  switch (PcdTcg2PpiVersion) {
+    case TCG2_PPI_VERSION_1_2:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_PPI_VERSION_STATE_CONTENT), L"1.2", NULL);
+      break;
+    case TCG2_PPI_VERSION_1_3:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_PPI_VERSION_STATE_CONTENT), L"1.3", NULL);
+      break;
+    default:
+      ASSERT (FALSE);
+      break;
+  }
+
+  //
+  // Get the PcdTpm2AcpiTableRev value again.
+  // If the PCD value is not equal to the value in variable,
+  // the PCD is not DynamicHii type and does not map to TCG2_VERSION Variable.
+  //
+  PcdTpm2AcpiTableRev = PcdGet8 (PcdTpm2AcpiTableRev);
+  if (PcdTpm2AcpiTableRev != Tcg2Version.Tpm2AcpiTableRev) {
+    DEBUG ((DEBUG_WARN, "WARNING: PcdTpm2AcpiTableRev is not DynamicHii type and does not map to TCG2_VERSION.Tpm2AcpiTableRev\n"));
+    DEBUG ((DEBUG_WARN, "WARNING: The Tpm2 ACPI Revision configuring from setup page will not work\n"));
+  }
+
+  switch (PcdTpm2AcpiTableRev) {
+    case EFI_TPM2_ACPI_TABLE_REVISION_3:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_ACPI_REVISION_STATE_CONTENT), L"Rev 3", NULL);
+      break;
+    case EFI_TPM2_ACPI_TABLE_REVISION_4:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_ACPI_REVISION_STATE_CONTENT), L"Rev 4", NULL);
+      break;
+    default:
+      ASSERT (FALSE);
+      break;
+  }
+}
+
+/**
+  The entry point for Tcg2 configuration driver.
+
+  @param[in]  ImageHandle        The image handle of the driver.
+  @param[in]  SystemTable        The system table.
+
+  @retval EFI_ALREADY_STARTED    The driver already exists in system.
+  @retval EFI_OUT_OF_RESOURCES   Fail to execute entry point due to lack of resources.
+  @retval EFI_SUCCESS            All the related protocols are installed on the driver.
+  @retval Others                 Fail to install protocols as indicated.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2ConfigDriverEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                    Status;
+  TCG2_CONFIG_PRIVATE_DATA      *PrivateData;
+  TCG2_CONFIGURATION            Tcg2Configuration;
+  TCG2_DEVICE_DETECTION         Tcg2DeviceDetection;
+  UINTN                         Index;
+  UINTN                         DataSize;
+  EDKII_VARIABLE_LOCK_PROTOCOL  *VariableLockProtocol;
+  UINT32                        CurrentActivePCRBanks;
+
+  DEBUG ((DEBUG_INFO, "Tcg2ConfigDriverEntryPoint\n"));
+
+  Status = gBS->OpenProtocol (
+                  ImageHandle,
+                  &gEfiCallerIdGuid,
+                  NULL,
+                  ImageHandle,
+                  ImageHandle,
+                  EFI_OPEN_PROTOCOL_TEST_PROTOCOL
+                  );
+  if (!EFI_ERROR (Status)) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  //
+  // Create a private data structure.
+  //
+  PrivateData = AllocateCopyPool (sizeof (TCG2_CONFIG_PRIVATE_DATA), &mTcg2ConfigPrivateDateTemplate);
+  ASSERT (PrivateData != NULL);
+  mTcg2ConfigPrivateDate = PrivateData;
+  //
+  // Install private GUID.
+  //
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &ImageHandle,
+                  &gEfiCallerIdGuid,
+                  PrivateData,
+                  NULL
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = gBS->LocateProtocol (&gEfiTcg2ProtocolGuid, NULL, (VOID **)&PrivateData->Tcg2Protocol);
+  ASSERT_EFI_ERROR (Status);
+
+  PrivateData->ProtocolCapability.Size = sizeof (PrivateData->ProtocolCapability);
+  Status                               = PrivateData->Tcg2Protocol->GetCapability (
+                                                                      PrivateData->Tcg2Protocol,
+                                                                      &PrivateData->ProtocolCapability
+                                                                      );
+  ASSERT_EFI_ERROR (Status);
+
+  DataSize = sizeof (Tcg2Configuration);
+  Status   = gRT->GetVariable (
+                    TCG2_STORAGE_NAME,
+                    &gTcg2ConfigFormSetGuid,
+                    NULL,
+                    &DataSize,
+                    &Tcg2Configuration
+                    );
+  if (EFI_ERROR (Status)) {
+    //
+    // Variable not ready, set default value
+    //
+    Tcg2Configuration.TpmDevice = TPM_DEVICE_DEFAULT;
+  }
+
+  //
+  // Validation
+  //
+  if ((Tcg2Configuration.TpmDevice > TPM_DEVICE_MAX) || (Tcg2Configuration.TpmDevice < TPM_DEVICE_MIN)) {
+    Tcg2Configuration.TpmDevice = TPM_DEVICE_DEFAULT;
+  }
+
+  //
+  // Set value for Tcg2CurrentActivePCRBanks
+  // Search Tcg2ConfigBin[] and update default value there
+  //
+  Status = PrivateData->Tcg2Protocol->GetActivePcrBanks (PrivateData->Tcg2Protocol, &CurrentActivePCRBanks);
+  ASSERT_EFI_ERROR (Status);
+  PrivateData->PCRBanksDesired = CurrentActivePCRBanks;
+  UpdateDefaultPCRBanks (Tcg2ConfigBin + sizeof (UINT32), ReadUnaligned32 ((UINT32 *)Tcg2ConfigBin) - sizeof (UINT32), CurrentActivePCRBanks);
+
+  //
+  // Sync data from PCD to variable, so that we do not need detect again in S3 phase.
+  //
+  Tcg2DeviceDetection.TpmDeviceDetected = TPM_DEVICE_NULL;
+  for (Index = 0; Index < sizeof (mTpmInstanceId)/sizeof (mTpmInstanceId[0]); Index++) {
+    if (CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &mTpmInstanceId[Index].TpmInstanceGuid)) {
+      Tcg2DeviceDetection.TpmDeviceDetected = mTpmInstanceId[Index].TpmDevice;
+      break;
+    }
+  }
+
+  PrivateData->TpmDeviceDetected = Tcg2DeviceDetection.TpmDeviceDetected;
+  Tcg2Configuration.TpmDevice    = Tcg2DeviceDetection.TpmDeviceDetected;
+
+  //
+  // Save to variable so platform driver can get it.
+  //
+  Status = gRT->SetVariable (
+                  TCG2_DEVICE_DETECTION_NAME,
+                  &gTcg2ConfigFormSetGuid,
+                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  sizeof (Tcg2DeviceDetection),
+                  &Tcg2DeviceDetection
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_DEVICE_DETECTION_NAME\n"));
+    Status = gRT->SetVariable (
+                    TCG2_DEVICE_DETECTION_NAME,
+                    &gTcg2ConfigFormSetGuid,
+                    EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                    0,
+                    NULL
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Save to variable so platform driver can get it.
+  //
+  Status = gRT->SetVariable (
+                  TCG2_STORAGE_NAME,
+                  &gTcg2ConfigFormSetGuid,
+                  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  sizeof (Tcg2Configuration),
+                  &Tcg2Configuration
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_NAME\n"));
+  }
+
+  //
+  // We should lock Tcg2DeviceDetection, because it contains information needed at S3.
+  //
+  Status = gBS->LocateProtocol (&gEdkiiVariableLockProtocolGuid, NULL, (VOID **)&VariableLockProtocol);
+  if (!EFI_ERROR (Status)) {
+    Status = VariableLockProtocol->RequestToLock (
+                                     VariableLockProtocol,
+                                     TCG2_DEVICE_DETECTION_NAME,
+                                     &gTcg2ConfigFormSetGuid
+                                     );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Install Tcg2 configuration form
+  //
+  Status = InstallTcg2ConfigForm (PrivateData);
+  if (EFI_ERROR (Status)) {
+    goto ErrorExit;
+  }
+
+  InitializeTcg2VersionInfo (PrivateData);
+
+  return EFI_SUCCESS;
+
+ErrorExit:
+  if (PrivateData != NULL) {
+    UninstallTcg2ConfigForm (PrivateData);
+  }
+
+  return Status;
+}
+
+/**
+  Unload the Tcg2 configuration form.
+
+  @param[in]  ImageHandle         The driver's image handle.
+
+  @retval     EFI_SUCCESS         The Tcg2 configuration form is unloaded.
+  @retval     Others              Failed to unload the form.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2ConfigDriverUnload (
+  IN EFI_HANDLE  ImageHandle
+  )
+{
+  EFI_STATUS                Status;
+  TCG2_CONFIG_PRIVATE_DATA  *PrivateData;
+
+  Status = gBS->HandleProtocol (
+                  ImageHandle,
+                  &gEfiCallerIdGuid,
+                  (VOID **)&PrivateData
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  ASSERT (PrivateData->Signature == TCG2_CONFIG_PRIVATE_DATA_SIGNATURE);
+
+  gBS->UninstallMultipleProtocolInterfaces (
+         ImageHandle,
+         &gEfiCallerIdGuid,
+         PrivateData,
+         NULL
+         );
+
+  UninstallTcg2ConfigForm (PrivateData);
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.inf
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.inf
@@ -1,0 +1,88 @@
+## @file
+#  TPM device configuration for TPM 2.0
+#
+#  By this module, user may select TPM device, clear TPM state, etc.
+#  NOTE: This module is only for reference only, each platform should have its own setup page.
+#
+# Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tcg2ConfigDxe
+  MODULE_UNI_FILE                = Tcg2ConfigDxe.uni
+  FILE_GUID                      = 4D9CBEF0-15A0-4D0C-83DB-5213E710C23F
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = Tcg2ConfigDriverEntryPoint
+  UNLOAD_IMAGE                   = Tcg2ConfigDriverUnload
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  Tcg2ConfigDriver.c
+  Tcg2ConfigImpl.c
+  Tcg2ConfigImpl.h
+  Tcg2Config.vfr
+  Tcg2ConfigStrings.uni
+  Tcg2ConfigNvData.h
+  Tcg2Internal.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  UefiLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  UefiDriverEntryPoint
+  UefiHiiServicesLib
+  DebugLib
+  HiiLib
+  PcdLib
+  PrintLib
+  Tpm2DeviceLib
+  Tpm2CommandLib
+  Tcg2PhysicalPresenceLib
+  IoLib
+
+[Guids]
+  ## PRODUCES           ## HII
+  ## SOMETIMES_PRODUCES ## Variable:L"TCG2_CONFIGURATION"
+  ## SOMETIMES_CONSUMES ## Variable:L"TCG2_CONFIGURATION"
+  ## PRODUCES           ## Variable:L"TCG2_DEVICE_DETECTION"
+  ## SOMETIMES_CONSUMES ## Variable:L"TCG2_DEVICE_DETECTION"
+  gTcg2ConfigFormSetGuid
+
+[Protocols]
+  gEfiHiiConfigAccessProtocolGuid               ## PRODUCES
+  gEfiDevicePathProtocolGuid                    ## PRODUCES
+  gEdkiiVariableLockProtocolGuid                ## SOMETIMES_CONSUMES
+  gEfiTcg2ProtocolGuid                          ## CONSUMES
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid            ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap    ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress             ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer  ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev           ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType     ## CONSUMES
+
+[Depex]
+  gEfiTcg2ProtocolGuid              AND
+  gEfiHiiConfigRoutingProtocolGuid  AND
+  gEfiHiiDatabaseProtocolGuid       AND
+  gEfiVariableArchProtocolGuid      AND
+  gEfiVariableWriteArchProtocolGuid
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  Tcg2ConfigDxeExtra.uni

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxe.uni
@@ -1,0 +1,17 @@
+// /** @file
+// TPM device configuration for TPM 2.0
+//
+// By this module, user may select TPM device, clear TPM state, etc.
+// NOTE: This module is only for reference only, each platform should have its own setup page.
+//
+// Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "TPM device configuration for TPM 2.0"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "By this module, user may select TPM device, clear TPM state, etc. NOTE: This module is only for reference only, each platform should have its own setup page."
+

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxeExtra.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigDxeExtra.uni
@@ -1,0 +1,14 @@
+// /** @file
+// Tcg2ConfigDxe Localized Strings and Content
+//
+// Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"TCG2 (Trusted Computing Group) Configuration DXE"
+
+

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigImpl.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigImpl.c
@@ -1,0 +1,1062 @@
+/** @file
+  HII Config Access protocol implementation of TCG2 configuration module.
+  NOTE: This module is only for reference only, each platform should have its own setup page.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2018 Hewlett Packard Enterprise Development LP<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "Tcg2ConfigImpl.h"
+#include <Library/PcdLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/IoLib.h>
+
+#include <Guid/TpmInstance.h>
+
+#include <IndustryStandard/TpmPtp.h>
+
+#define EFI_TCG2_EVENT_LOG_FORMAT_ALL  (EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2 | EFI_TCG2_EVENT_LOG_FORMAT_TCG_2)
+
+TPM_INSTANCE_ID  mTpmInstanceId[TPM_DEVICE_MAX + 1] = TPM_INSTANCE_ID_LIST;
+
+TCG2_CONFIG_PRIVATE_DATA  *mTcg2ConfigPrivateDate;
+TCG2_CONFIG_PRIVATE_DATA  mTcg2ConfigPrivateDateTemplate = {
+  TCG2_CONFIG_PRIVATE_DATA_SIGNATURE,
+  {
+    Tcg2ExtractConfig,
+    Tcg2RouteConfig,
+    Tcg2Callback
+  }
+};
+
+HII_VENDOR_DEVICE_PATH  mTcg2HiiVendorDevicePath = {
+  {
+    {
+      HARDWARE_DEVICE_PATH,
+      HW_VENDOR_DP,
+      {
+        (UINT8)(sizeof (VENDOR_DEVICE_PATH)),
+        (UINT8)((sizeof (VENDOR_DEVICE_PATH)) >> 8)
+      }
+    },
+    TCG2_CONFIG_FORM_SET_GUID
+  },
+  {
+    END_DEVICE_PATH_TYPE,
+    END_ENTIRE_DEVICE_PATH_SUBTYPE,
+    {
+      (UINT8)(END_DEVICE_PATH_LENGTH),
+      (UINT8)((END_DEVICE_PATH_LENGTH) >> 8)
+    }
+  }
+};
+
+UINT8  mCurrentPpRequest;
+
+/**
+  Return if PTP CRB is supported.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @retval TRUE  PTP CRB is supported.
+  @retval FALSE PTP CRB is unsupported.
+**/
+BOOLEAN
+IsPtpCrbSupported (
+  IN VOID  *Register
+  )
+{
+  PTP_CRB_INTERFACE_IDENTIFIER  InterfaceId;
+
+  //
+  // Check interface id
+  //
+  InterfaceId.Uint32 = MmioRead32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+
+  if (((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_CRB) ||
+       (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO)) &&
+      (InterfaceId.Bits.CapCRB != 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Return if PTP FIFO is supported.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @retval TRUE  PTP FIFO is supported.
+  @retval FALSE PTP FIFO is unsupported.
+**/
+BOOLEAN
+IsPtpFifoSupported (
+  IN VOID  *Register
+  )
+{
+  PTP_CRB_INTERFACE_IDENTIFIER  InterfaceId;
+
+  //
+  // Check interface id
+  //
+  InterfaceId.Uint32 = MmioRead32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+
+  if (((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_CRB) ||
+       (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO)) &&
+      (InterfaceId.Bits.CapFIFO != 0))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Set PTP interface type.
+  Do not update PcdActiveTpmInterfaceType here because interface change only happens on next _TPM_INIT
+
+  @param[in] Register                Pointer to PTP register.
+  @param[in] PtpInterface            PTP interface type.
+
+  @retval EFI_SUCCESS                PTP interface type is set.
+  @retval EFI_INVALID_PARAMETER      PTP interface type is invalid.
+  @retval EFI_UNSUPPORTED            PTP interface type is unsupported.
+  @retval EFI_WRITE_PROTECTED        PTP interface is locked.
+**/
+EFI_STATUS
+SetPtpInterface (
+  IN VOID   *Register,
+  IN UINT8  PtpInterface
+  )
+{
+  TPM2_PTP_INTERFACE_TYPE       PtpInterfaceCurrent;
+  PTP_CRB_INTERFACE_IDENTIFIER  InterfaceId;
+
+  PtpInterfaceCurrent = PcdGet8 (PcdActiveTpmInterfaceType);
+  if ((PtpInterfaceCurrent != Tpm2PtpInterfaceFifo) &&
+      (PtpInterfaceCurrent != Tpm2PtpInterfaceCrb))
+  {
+    return EFI_UNSUPPORTED;
+  }
+
+  InterfaceId.Uint32 = MmioRead32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+  if (InterfaceId.Bits.IntfSelLock != 0) {
+    return EFI_WRITE_PROTECTED;
+  }
+
+  switch (PtpInterface) {
+    case Tpm2PtpInterfaceFifo:
+      if (InterfaceId.Bits.CapFIFO == 0) {
+        return EFI_UNSUPPORTED;
+      }
+
+      InterfaceId.Bits.InterfaceSelector = PTP_INTERFACE_IDENTIFIER_INTERFACE_SELECTOR_FIFO;
+      MmioWrite32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId, InterfaceId.Uint32);
+      return EFI_SUCCESS;
+    case Tpm2PtpInterfaceCrb:
+      if (InterfaceId.Bits.CapCRB == 0) {
+        return EFI_UNSUPPORTED;
+      }
+
+      InterfaceId.Bits.InterfaceSelector = PTP_INTERFACE_IDENTIFIER_INTERFACE_SELECTOR_CRB;
+      MmioWrite32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId, InterfaceId.Uint32);
+      return EFI_SUCCESS;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+}
+
+/**
+  This function allows a caller to extract the current configuration for one
+  or more named elements from the target driver.
+
+  @param[in]   This              Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]   Request           A null-terminated Unicode string in
+                                 <ConfigRequest> format.
+  @param[out]  Progress          On return, points to a character in the Request
+                                 string. Points to the string's null terminator if
+                                 request was successful. Points to the most recent
+                                 '&' before the first failing name/value pair (or
+                                 the beginning of the string if the failure is in
+                                 the first name/value pair) if the request was not
+                                 successful.
+  @param[out]  Results           A null-terminated Unicode string in
+                                 <ConfigAltResp> format which has all values filled
+                                 in for the names in the Request string. String to
+                                 be allocated by the called function.
+
+  @retval EFI_SUCCESS            The Results is filled with the requested values.
+  @retval EFI_OUT_OF_RESOURCES   Not enough memory to store the results.
+  @retval EFI_INVALID_PARAMETER  Request is illegal syntax, or unknown name.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2ExtractConfig (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN CONST EFI_STRING                      Request,
+  OUT EFI_STRING                           *Progress,
+  OUT EFI_STRING                           *Results
+  )
+{
+  if ((Progress == NULL) || (Results == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Progress = Request;
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Save TPM request to variable space.
+
+  @param[in] PpRequest             Physical Presence request command.
+
+  @retval    EFI_SUCCESS           The operation is finished successfully.
+  @retval    Others                Other errors as indicated.
+
+**/
+EFI_STATUS
+SaveTcg2PpRequest (
+  IN UINT8  PpRequest
+  )
+{
+  UINT32      ReturnCode;
+  EFI_STATUS  Status;
+
+  ReturnCode = Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (PpRequest, 0);
+  if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
+    mCurrentPpRequest = PpRequest;
+    Status            = EFI_SUCCESS;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE) {
+    Status = EFI_OUT_OF_RESOURCES;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_NOT_IMPLEMENTED) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  return Status;
+}
+
+/**
+  Save TPM request to variable space.
+
+  @param[in] PpRequestParameter    Physical Presence request parameter.
+
+  @retval    EFI_SUCCESS           The operation is finished successfully.
+  @retval    Others                Other errors as indicated.
+
+**/
+EFI_STATUS
+SaveTcg2PpRequestParameter (
+  IN UINT32  PpRequestParameter
+  )
+{
+  UINT32      ReturnCode;
+  EFI_STATUS  Status;
+
+  ReturnCode = Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (mCurrentPpRequest, PpRequestParameter);
+  if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
+    Status = EFI_SUCCESS;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE) {
+    Status = EFI_OUT_OF_RESOURCES;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_NOT_IMPLEMENTED) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  return Status;
+}
+
+/**
+  Save Tcg2 PCR Banks request request to variable space.
+
+  @param[in] PCRBankIndex     PCR Bank Index.
+  @param[in] Enable           Enable or disable this PCR Bank.
+
+  @retval    EFI_SUCCESS           The operation is finished successfully.
+  @retval    Others                Other errors as indicated.
+
+**/
+EFI_STATUS
+SaveTcg2PCRBanksRequest (
+  IN UINTN    PCRBankIndex,
+  IN BOOLEAN  Enable
+  )
+{
+  UINT32      ReturnCode;
+  EFI_STATUS  Status;
+
+  if (Enable) {
+    mTcg2ConfigPrivateDate->PCRBanksDesired |= (0x1 << PCRBankIndex);
+  } else {
+    mTcg2ConfigPrivateDate->PCRBanksDesired &= ~(0x1 << PCRBankIndex);
+  }
+
+  ReturnCode = Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS, mTcg2ConfigPrivateDate->PCRBanksDesired);
+  if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
+    Status = EFI_SUCCESS;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE) {
+    Status = EFI_OUT_OF_RESOURCES;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_NOT_IMPLEMENTED) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  return Status;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param[in]  This               Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]  Configuration      A null-terminated Unicode string in <ConfigResp>
+                                 format.
+  @param[out] Progress           A pointer to a string filled in with the offset of
+                                 the most recent '&' before the first failing
+                                 name/value pair (or the beginning of the string if
+                                 the failure is in the first name/value pair) or
+                                 the terminating NULL if all was successful.
+
+  @retval EFI_SUCCESS            The Results is processed successfully.
+  @retval EFI_INVALID_PARAMETER  Configuration is NULL.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2RouteConfig (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN CONST EFI_STRING                      Configuration,
+  OUT EFI_STRING                           *Progress
+  )
+{
+  if ((Configuration == NULL) || (Progress == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Progress = Configuration;
+
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Get HID string of TPM2 ACPI device object
+
+  @param[in]  Hid               Points to HID String Buffer.
+  @param[in]  Size              HID String size in bytes. Must >= TPM_HID_ACPI_SIZE
+
+  @return                       HID String get status.
+
+**/
+EFI_STATUS
+GetTpm2HID (
+  CHAR8  *Hid,
+  UINTN  Size
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ManufacturerID;
+  UINT32      FirmwareVersion1;
+  UINT32      FirmwareVersion2;
+  BOOLEAN     PnpHID;
+
+  PnpHID = TRUE;
+
+  ZeroMem (Hid, Size);
+
+  //
+  // Get Manufacturer ID
+  //
+  Status = Tpm2GetCapabilityManufactureID (&ManufacturerID);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "TPM_PT_MANUFACTURER 0x%08x\n", ManufacturerID));
+    //
+    // ManufacturerID defined in TCG Vendor ID Registry
+    // may tailed with 0x00 or 0x20
+    //
+    if (((ManufacturerID >> 24) == 0x00) || ((ManufacturerID >> 24) == 0x20)) {
+      //
+      //  HID containing PNP ID "NNN####"
+      //   NNN is uppercase letter for Vendor ID specified by manufacturer
+      //
+      CopyMem (Hid, &ManufacturerID, 3);
+    } else {
+      //
+      //  HID containing ACP ID "NNNN####"
+      //   NNNN is uppercase letter for Vendor ID specified by manufacturer
+      //
+      CopyMem (Hid, &ManufacturerID, 4);
+      PnpHID = FALSE;
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "Get TPM_PT_MANUFACTURER failed %x!\n", Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = Tpm2GetCapabilityFirmwareVersion (&FirmwareVersion1, &FirmwareVersion2);
+  if (!EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "TPM_PT_FIRMWARE_VERSION_1 0x%x\n", FirmwareVersion1));
+    DEBUG ((DEBUG_INFO, "TPM_PT_FIRMWARE_VERSION_2 0x%x\n", FirmwareVersion2));
+    //
+    //   #### is Firmware Version 1
+    //
+    if (PnpHID) {
+      AsciiSPrint (Hid + 3, TPM_HID_PNP_SIZE - 3, "%02d%02d", ((FirmwareVersion1 & 0xFFFF0000) >> 16), (FirmwareVersion1 & 0x0000FFFF));
+    } else {
+      AsciiSPrint (Hid + 4, TPM_HID_ACPI_SIZE - 4, "%02d%02d", ((FirmwareVersion1 & 0xFFFF0000) >> 16), (FirmwareVersion1 & 0x0000FFFF));
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "Get TPM_PT_FIRMWARE_VERSION_X failed %x!\n", Status));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function processes the results of changes in configuration
+  for TCG2 version information.
+
+  @param[in] Action             Specifies the type of action taken by the browser.
+                                ASSERT if the Action is not EFI_BROWSER_ACTION_SUBMITTED.
+  @param[in] QuestionId         A unique value which is sent to the original
+                                exporting driver so that it can identify the type
+                                of data to expect.
+  @param[in] Type               The type of value for the question.
+  @param[in] Value              A pointer to the data being sent to the original
+                                exporting driver.
+
+  @retval EFI_SUCCESS           The callback successfully handled the action.
+
+**/
+EFI_STATUS
+Tcg2VersionInfoCallback (
+  IN EFI_BROWSER_ACTION  Action,
+  IN EFI_QUESTION_ID     QuestionId,
+  IN UINT8               Type,
+  IN EFI_IFR_TYPE_VALUE  *Value
+  )
+{
+  EFI_INPUT_KEY  Key;
+  UINT64         PcdTcg2PpiVersion;
+  UINT8          PcdTpm2AcpiTableRev;
+
+  ASSERT (Action == EFI_BROWSER_ACTION_SUBMITTED);
+
+  if (QuestionId == KEY_TCG2_PPI_VERSION) {
+    //
+    // Get the PCD value after EFI_BROWSER_ACTION_SUBMITTED,
+    // the SetVariable to TCG2_VERSION_NAME should have been done.
+    // If the PCD value is not equal to the value set to variable,
+    // the PCD is not DynamicHii type and does not map to the setup option.
+    //
+    PcdTcg2PpiVersion = 0;
+    CopyMem (
+      &PcdTcg2PpiVersion,
+      PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+      AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
+      );
+    if (PcdTcg2PpiVersion != Value->u64) {
+      CreatePopUp (
+        EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,
+        &Key,
+        L"WARNING: PcdTcgPhysicalPresenceInterfaceVer is not DynamicHii type and does not map to this option!",
+        L"The version configuring by this setup option will not work!",
+        NULL
+        );
+    }
+  } else if (QuestionId == KEY_TPM2_ACPI_REVISION) {
+    //
+    // Get the PCD value after EFI_BROWSER_ACTION_SUBMITTED,
+    // the SetVariable to TCG2_VERSION_NAME should have been done.
+    // If the PCD value is not equal to the value set to variable,
+    // the PCD is not DynamicHii type and does not map to the setup option.
+    //
+    PcdTpm2AcpiTableRev = PcdGet8 (PcdTpm2AcpiTableRev);
+
+    if (PcdTpm2AcpiTableRev != Value->u8) {
+      CreatePopUp (
+        EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,
+        &Key,
+        L"WARNING: PcdTpm2AcpiTableRev is not DynamicHii type and does not map to this option!",
+        L"The Revision configuring by this setup option will not work!",
+        NULL
+        );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param[in]  This               Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]  Action             Specifies the type of action taken by the browser.
+  @param[in]  QuestionId         A unique value which is sent to the original
+                                 exporting driver so that it can identify the type
+                                 of data to expect.
+  @param[in]  Type               The type of value for the question.
+  @param[in]  Value              A pointer to the data being sent to the original
+                                 exporting driver.
+  @param[out] ActionRequest      On return, points to the action requested by the
+                                 callback function.
+
+  @retval EFI_SUCCESS            The callback successfully handled the action.
+  @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the
+                                 variable and its data.
+  @retval EFI_DEVICE_ERROR       The variable could not be saved.
+  @retval EFI_UNSUPPORTED        The specified Action is not supported by the
+                                 callback.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2Callback (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN     EFI_BROWSER_ACTION                Action,
+  IN     EFI_QUESTION_ID                   QuestionId,
+  IN     UINT8                             Type,
+  IN     EFI_IFR_TYPE_VALUE                *Value,
+  OUT EFI_BROWSER_ACTION_REQUEST           *ActionRequest
+  )
+{
+  EFI_STATUS                Status;
+  EFI_INPUT_KEY             Key;
+  CHAR8                     HidStr[16];
+  CHAR16                    UnHidStr[16];
+  TCG2_CONFIG_PRIVATE_DATA  *Private;
+
+  if ((This == NULL) || (Value == NULL) || (ActionRequest == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Private = TCG2_CONFIG_PRIVATE_DATA_FROM_THIS (This);
+
+  if (Action == EFI_BROWSER_ACTION_FORM_OPEN) {
+    //
+    // Update TPM2 HID info
+    //
+    if (QuestionId == KEY_TPM_DEVICE) {
+      Status = GetTpm2HID (HidStr, 16);
+
+      if (EFI_ERROR (Status)) {
+        //
+        //  Fail to get TPM2 HID
+        //
+        HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_TPM2_ACPI_HID_CONTENT), L"Unknown", NULL);
+      } else {
+        AsciiStrToUnicodeStrS (HidStr, UnHidStr, 16);
+        HiiSetString (Private->HiiHandle, STRING_TOKEN (STR_TPM2_ACPI_HID_CONTENT), UnHidStr, NULL);
+      }
+    }
+
+    return EFI_SUCCESS;
+  }
+
+  if (Action == EFI_BROWSER_ACTION_CHANGING) {
+    if (QuestionId == KEY_TPM_DEVICE_INTERFACE) {
+      Status = SetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress), Value->u8);
+      if (EFI_ERROR (Status)) {
+        CreatePopUp (
+          EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE,
+          &Key,
+          L"Error: Fail to set PTP interface!",
+          NULL
+          );
+        return EFI_DEVICE_ERROR;
+      }
+    }
+  }
+
+  if (Action == EFI_BROWSER_ACTION_CHANGED) {
+    if (QuestionId == KEY_TPM_DEVICE) {
+      return EFI_SUCCESS;
+    }
+
+    if (QuestionId == KEY_TPM2_OPERATION) {
+      return SaveTcg2PpRequest (Value->u8);
+    }
+
+    if (QuestionId == KEY_TPM2_OPERATION_PARAMETER) {
+      return SaveTcg2PpRequestParameter (Value->u32);
+    }
+
+    if ((QuestionId >= KEY_TPM2_PCR_BANKS_REQUEST_0) && (QuestionId <= KEY_TPM2_PCR_BANKS_REQUEST_4)) {
+      return SaveTcg2PCRBanksRequest (QuestionId - KEY_TPM2_PCR_BANKS_REQUEST_0, Value->b);
+    }
+  }
+
+  if (Action == EFI_BROWSER_ACTION_SUBMITTED) {
+    if ((QuestionId == KEY_TCG2_PPI_VERSION) || (QuestionId == KEY_TPM2_ACPI_REVISION)) {
+      return Tcg2VersionInfoCallback (Action, QuestionId, Type, Value);
+    }
+  }
+
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Append Buffer With TpmAlgHash.
+
+  @param[in] Buffer               Buffer to be appended.
+  @param[in] BufferSize           Size of buffer.
+  @param[in] TpmAlgHash           TpmAlgHash.
+
+**/
+VOID
+AppendBufferWithTpmAlgHash (
+  IN UINT16  *Buffer,
+  IN UINTN   BufferSize,
+  IN UINT32  TpmAlgHash
+  )
+{
+  switch (TpmAlgHash) {
+    case TPM_ALG_SHA1:
+      if (Buffer[0] != 0) {
+        StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+      }
+
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA1");
+      break;
+    case TPM_ALG_SHA256:
+      if (Buffer[0] != 0) {
+        StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+      }
+
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA256");
+      break;
+    case TPM_ALG_SHA384:
+      if (Buffer[0] != 0) {
+        StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+      }
+
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA384");
+      break;
+    case TPM_ALG_SHA512:
+      if (Buffer[0] != 0) {
+        StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+      }
+
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA512");
+      break;
+    case TPM_ALG_SM3_256:
+      if (Buffer[0] != 0) {
+        StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+      }
+
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SM3_256");
+      break;
+  }
+}
+
+/**
+  Fill Buffer With BootHashAlg.
+
+  @param[in] Buffer               Buffer to be filled.
+  @param[in] BufferSize           Size of buffer.
+  @param[in] BootHashAlg          BootHashAlg.
+
+**/
+VOID
+FillBufferWithBootHashAlg (
+  IN UINT16  *Buffer,
+  IN UINTN   BufferSize,
+  IN UINT32  BootHashAlg
+  )
+{
+  Buffer[0] = 0;
+  if ((BootHashAlg & EFI_TCG2_BOOT_HASH_ALG_SHA1) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA1");
+  }
+
+  if ((BootHashAlg & EFI_TCG2_BOOT_HASH_ALG_SHA256) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA256");
+  }
+
+  if ((BootHashAlg & EFI_TCG2_BOOT_HASH_ALG_SHA384) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA384");
+  }
+
+  if ((BootHashAlg & EFI_TCG2_BOOT_HASH_ALG_SHA512) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SHA512");
+  }
+
+  if ((BootHashAlg & EFI_TCG2_BOOT_HASH_ALG_SM3_256) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"SM3_256");
+  }
+}
+
+/**
+  Set ConfigInfo according to TpmAlgHash and Tcg2HashAlgBitmap.
+
+  @param[in,out] Tcg2ConfigInfo       TCG2 config info.
+  @param[in]     TpmAlgHash           TpmAlgHash.
+  @param[in]     Tcg2HashAlgBitmap    TCG2 Hash Algorithm Bitmap.
+
+**/
+VOID
+SetConfigInfo (
+  IN OUT TCG2_CONFIGURATION_INFO  *Tcg2ConfigInfo,
+  IN UINT32                       TpmAlgHash,
+  IN UINT32                       Tcg2HashAlgBitmap
+  )
+{
+  switch (TpmAlgHash) {
+    case TPM_ALG_SHA1:
+      if ((Tcg2HashAlgBitmap & HASH_ALG_SHA1) != 0) {
+        Tcg2ConfigInfo->Sha1Supported = TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA256:
+      if ((Tcg2HashAlgBitmap & HASH_ALG_SHA256) != 0) {
+        Tcg2ConfigInfo->Sha256Supported = TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA384:
+      if ((Tcg2HashAlgBitmap & HASH_ALG_SHA384) != 0) {
+        Tcg2ConfigInfo->Sha384Supported = TRUE;
+      }
+
+      break;
+    case TPM_ALG_SHA512:
+      if ((Tcg2HashAlgBitmap & HASH_ALG_SHA512) != 0) {
+        Tcg2ConfigInfo->Sha512Supported = TRUE;
+      }
+
+      break;
+    case TPM_ALG_SM3_256:
+      if ((Tcg2HashAlgBitmap & HASH_ALG_SM3_256) != 0) {
+        Tcg2ConfigInfo->Sm3Supported = TRUE;
+      }
+
+      break;
+  }
+}
+
+/**
+  Fill Buffer With TCG2EventLogFormat.
+
+  @param[in] Buffer               Buffer to be filled.
+  @param[in] BufferSize           Size of buffer.
+  @param[in] TCG2EventLogFormat   TCG2EventLogFormat.
+
+**/
+VOID
+FillBufferWithTCG2EventLogFormat (
+  IN UINT16  *Buffer,
+  IN UINTN   BufferSize,
+  IN UINT32  TCG2EventLogFormat
+  )
+{
+  Buffer[0] = 0;
+  if ((TCG2EventLogFormat & EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"TCG_1_2");
+  }
+
+  if ((TCG2EventLogFormat & EFI_TCG2_EVENT_LOG_FORMAT_TCG_2) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"TCG_2");
+  }
+
+  if ((TCG2EventLogFormat & (~EFI_TCG2_EVENT_LOG_FORMAT_ALL)) != 0) {
+    if (Buffer[0] != 0) {
+      StrCatS (Buffer, BufferSize / sizeof (CHAR16), L", ");
+    }
+
+    StrCatS (Buffer, BufferSize / sizeof (CHAR16), L"UNKNOWN");
+  }
+}
+
+/**
+  This function publish the TCG2 configuration Form for TPM device.
+
+  @param[in, out]  PrivateData   Points to TCG2 configuration private data.
+
+  @retval EFI_SUCCESS            HII Form is installed for this network device.
+  @retval EFI_OUT_OF_RESOURCES   Not enough resource for HII Form installation.
+  @retval Others                 Other errors as indicated.
+
+**/
+EFI_STATUS
+InstallTcg2ConfigForm (
+  IN OUT TCG2_CONFIG_PRIVATE_DATA  *PrivateData
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_HII_HANDLE                   HiiHandle;
+  EFI_HANDLE                       DriverHandle;
+  EFI_HII_CONFIG_ACCESS_PROTOCOL   *ConfigAccess;
+  UINTN                            Index;
+  TPML_PCR_SELECTION               Pcrs;
+  CHAR16                           TempBuffer[1024];
+  TCG2_CONFIGURATION_INFO          Tcg2ConfigInfo;
+  TPM2_PTP_INTERFACE_TYPE          TpmDeviceInterfaceDetected;
+  BOOLEAN                          IsCmdImp;
+  EFI_TCG2_EVENT_ALGORITHM_BITMAP  Tcg2HashAlgorithmBitmap;
+
+  DriverHandle = NULL;
+  ConfigAccess = &PrivateData->ConfigAccess;
+  Status       = gBS->InstallMultipleProtocolInterfaces (
+                        &DriverHandle,
+                        &gEfiDevicePathProtocolGuid,
+                        &mTcg2HiiVendorDevicePath,
+                        &gEfiHiiConfigAccessProtocolGuid,
+                        ConfigAccess,
+                        NULL
+                        );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  PrivateData->DriverHandle = DriverHandle;
+
+  //
+  // Publish the HII package list
+  //
+  HiiHandle = HiiAddPackages (
+                &gTcg2ConfigFormSetGuid,
+                DriverHandle,
+                Tcg2ConfigDxeStrings,
+                Tcg2ConfigBin,
+                NULL
+                );
+  if (HiiHandle == NULL) {
+    gBS->UninstallMultipleProtocolInterfaces (
+           DriverHandle,
+           &gEfiDevicePathProtocolGuid,
+           &mTcg2HiiVendorDevicePath,
+           &gEfiHiiConfigAccessProtocolGuid,
+           ConfigAccess,
+           NULL
+           );
+
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  PrivateData->HiiHandle = HiiHandle;
+
+  //
+  // Update static data
+  //
+  switch (PrivateData->TpmDeviceDetected) {
+    case TPM_DEVICE_NULL:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_STATE_CONTENT), L"Not Found", NULL);
+      break;
+    case TPM_DEVICE_1_2:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_STATE_CONTENT), L"TPM 1.2", NULL);
+      break;
+    case TPM_DEVICE_2_0_DTPM:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_STATE_CONTENT), L"TPM 2.0", NULL);
+      break;
+    default:
+      HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_STATE_CONTENT), L"Unknown", NULL);
+      break;
+  }
+
+  Tcg2HashAlgorithmBitmap = PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+
+  ZeroMem (&Tcg2ConfigInfo, sizeof (Tcg2ConfigInfo));
+  Status = Tpm2GetCapabilityPcrs (&Pcrs);
+  if (EFI_ERROR (Status)) {
+    HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_ACTIVE_HASH_ALGO_CONTENT), L"[Unknown]", NULL);
+    HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_SUPPORTED_HASH_ALGO_CONTENT), L"[Unknown]", NULL);
+  } else {
+    TempBuffer[0] = 0;
+    for (Index = 0; Index < Pcrs.count; Index++) {
+      if (!IsZeroBuffer (Pcrs.pcrSelections[Index].pcrSelect, Pcrs.pcrSelections[Index].sizeofSelect)) {
+        AppendBufferWithTpmAlgHash (TempBuffer, sizeof (TempBuffer), Pcrs.pcrSelections[Index].hash);
+      }
+    }
+
+    HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_ACTIVE_HASH_ALGO_CONTENT), TempBuffer, NULL);
+
+    TempBuffer[0] = 0;
+    for (Index = 0; Index < Pcrs.count; Index++) {
+      AppendBufferWithTpmAlgHash (TempBuffer, sizeof (TempBuffer), Pcrs.pcrSelections[Index].hash);
+      SetConfigInfo (&Tcg2ConfigInfo, Pcrs.pcrSelections[Index].hash, Tcg2HashAlgorithmBitmap);
+    }
+
+    HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TPM2_SUPPORTED_HASH_ALGO_CONTENT), TempBuffer, NULL);
+  }
+
+  IsCmdImp = FALSE;
+  Status   = Tpm2GetCapabilityIsCommandImplemented (TPM_CC_ChangeEPS, &IsCmdImp);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityIsCmdImpl fails %r\n", Status));
+  }
+
+  Tcg2ConfigInfo.ChangeEPSSupported = IsCmdImp;
+
+  FillBufferWithBootHashAlg (TempBuffer, sizeof (TempBuffer), Tcg2HashAlgorithmBitmap);
+  HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_BIOS_HASH_ALGO_CONTENT), TempBuffer, NULL);
+
+  //
+  // Tcg2 Capability
+  //
+  FillBufferWithTCG2EventLogFormat (TempBuffer, sizeof (TempBuffer), PrivateData->ProtocolCapability.SupportedEventLogs);
+  HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT_CONTENT), TempBuffer, NULL);
+
+  FillBufferWithBootHashAlg (TempBuffer, sizeof (TempBuffer), PrivateData->ProtocolCapability.HashAlgorithmBitmap);
+  HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_HASH_ALGO_BITMAP_CONTENT), TempBuffer, NULL);
+
+  UnicodeSPrint (TempBuffer, sizeof (TempBuffer), L"%d", PrivateData->ProtocolCapability.NumberOfPCRBanks);
+  HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_NUMBER_OF_PCR_BANKS_CONTENT), TempBuffer, NULL);
+
+  FillBufferWithBootHashAlg (TempBuffer, sizeof (TempBuffer), PrivateData->ProtocolCapability.ActivePcrBanks);
+  HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_ACTIVE_PCR_BANKS_CONTENT), TempBuffer, NULL);
+
+  //
+  // Update TPM device interface type
+  //
+  if (PrivateData->TpmDeviceDetected == TPM_DEVICE_2_0_DTPM) {
+    TpmDeviceInterfaceDetected = PcdGet8 (PcdActiveTpmInterfaceType);
+    switch (TpmDeviceInterfaceDetected) {
+      case Tpm2PtpInterfaceTis:
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"TIS", NULL);
+        break;
+      case Tpm2PtpInterfaceFifo:
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"PTP FIFO", NULL);
+        break;
+      case Tpm2PtpInterfaceCrb:
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"PTP CRB", NULL);
+        break;
+      default:
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT), L"Unknown", NULL);
+        break;
+    }
+
+    Tcg2ConfigInfo.TpmDeviceInterfaceAttempt = TpmDeviceInterfaceDetected;
+    switch (TpmDeviceInterfaceDetected) {
+      case Tpm2PtpInterfaceTis:
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported = FALSE;
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported  = FALSE;
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT), L"TIS", NULL);
+        break;
+      case Tpm2PtpInterfaceFifo:
+      case Tpm2PtpInterfaceCrb:
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported = IsPtpFifoSupported ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported  = IsPtpCrbSupported ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+        TempBuffer[0]                                     = 0;
+        if (Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported) {
+          if (TempBuffer[0] != 0) {
+            StrCatS (TempBuffer, sizeof (TempBuffer) / sizeof (CHAR16), L", ");
+          }
+
+          StrCatS (TempBuffer, sizeof (TempBuffer) / sizeof (CHAR16), L"PTP FIFO");
+        }
+
+        if (Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported) {
+          if (TempBuffer[0] != 0) {
+            StrCatS (TempBuffer, sizeof (TempBuffer) / sizeof (CHAR16), L", ");
+          }
+
+          StrCatS (TempBuffer, sizeof (TempBuffer) / sizeof (CHAR16), L"PTP CRB");
+        }
+
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT), TempBuffer, NULL);
+        break;
+      default:
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpFifoSupported = FALSE;
+        Tcg2ConfigInfo.TpmDeviceInterfacePtpCrbSupported  = FALSE;
+        HiiSetString (PrivateData->HiiHandle, STRING_TOKEN (STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT), L"Unknown", NULL);
+        break;
+    }
+  }
+
+  //
+  // Set ConfigInfo, to control the check box.
+  //
+  Status = gRT->SetVariable (
+                  TCG2_STORAGE_INFO_NAME,
+                  &gTcg2ConfigFormSetGuid,
+                  EFI_VARIABLE_BOOTSERVICE_ACCESS,
+                  sizeof (Tcg2ConfigInfo),
+                  &Tcg2ConfigInfo
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tcg2ConfigDriver: Fail to set TCG2_STORAGE_INFO_NAME\n"));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function removes TCG2 configuration Form.
+
+  @param[in, out]  PrivateData   Points to TCG2 configuration private data.
+
+**/
+VOID
+UninstallTcg2ConfigForm (
+  IN OUT TCG2_CONFIG_PRIVATE_DATA  *PrivateData
+  )
+{
+  //
+  // Uninstall HII package list
+  //
+  if (PrivateData->HiiHandle != NULL) {
+    HiiRemovePackages (PrivateData->HiiHandle);
+    PrivateData->HiiHandle = NULL;
+  }
+
+  //
+  // Uninstall HII Config Access Protocol
+  //
+  if (PrivateData->DriverHandle != NULL) {
+    gBS->UninstallMultipleProtocolInterfaces (
+           PrivateData->DriverHandle,
+           &gEfiDevicePathProtocolGuid,
+           &mTcg2HiiVendorDevicePath,
+           &gEfiHiiConfigAccessProtocolGuid,
+           &PrivateData->ConfigAccess,
+           NULL
+           );
+    PrivateData->DriverHandle = NULL;
+  }
+
+  FreePool (PrivateData);
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigImpl.h
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigImpl.h
@@ -1,0 +1,198 @@
+/** @file
+  The header file of HII Config Access protocol implementation of TCG2
+  configuration module.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __TCG2_CONFIG_IMPL_H__
+#define __TCG2_CONFIG_IMPL_H__
+
+#include <Uefi.h>
+
+#include <IndustryStandard/Tpm2Acpi.h>
+
+#include <Protocol/HiiConfigAccess.h>
+#include <Protocol/HiiConfigRouting.h>
+#include <Protocol/Tcg2Protocol.h>
+#include <Protocol/VariableLock.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/UefiHiiServicesLib.h>
+#include <Library/UefiLib.h>
+#include <Library/HiiLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/Tcg2PhysicalPresenceLib.h>
+
+#include <Guid/MdeModuleHii.h>
+
+#include "Tcg2ConfigNvData.h"
+#include "Tcg2Internal.h"
+
+#define TCG2_PROTOCOL_VERSION_DEFAULT  0x0001
+
+//
+// Tool generated IFR binary data and String package data
+//
+extern UINT8  Tcg2ConfigBin[];
+extern UINT8  Tcg2ConfigDxeStrings[];
+
+///
+/// HII specific Vendor Device Path definition.
+///
+typedef struct {
+  VENDOR_DEVICE_PATH          VendorDevicePath;
+  EFI_DEVICE_PATH_PROTOCOL    End;
+} HII_VENDOR_DEVICE_PATH;
+
+typedef struct {
+  UINTN                               Signature;
+
+  EFI_HII_CONFIG_ACCESS_PROTOCOL      ConfigAccess;
+  EFI_HII_HANDLE                      HiiHandle;
+  EFI_HANDLE                          DriverHandle;
+
+  UINT8                               TpmDeviceDetected;
+  EFI_TCG2_PROTOCOL                   *Tcg2Protocol;
+  EFI_TCG2_BOOT_SERVICE_CAPABILITY    ProtocolCapability;
+  UINT32                              PCRBanksDesired;
+} TCG2_CONFIG_PRIVATE_DATA;
+
+extern TCG2_CONFIG_PRIVATE_DATA  mTcg2ConfigPrivateDateTemplate;
+extern TCG2_CONFIG_PRIVATE_DATA  *mTcg2ConfigPrivateDate;
+#define TCG2_CONFIG_PRIVATE_DATA_SIGNATURE  SIGNATURE_32 ('T', 'r', 'E', 'D')
+#define TCG2_CONFIG_PRIVATE_DATA_FROM_THIS(a)  CR (a, TCG2_CONFIG_PRIVATE_DATA, ConfigAccess, TCG2_CONFIG_PRIVATE_DATA_SIGNATURE)
+
+#define TPM_HID_PNP_SIZE   8
+#define TPM_HID_ACPI_SIZE  9
+
+/**
+  This function publish the TCG2 configuration Form for TPM device.
+
+  @param[in, out]  PrivateData   Points to TCG2 configuration private data.
+
+  @retval EFI_SUCCESS            HII Form is installed for this network device.
+  @retval EFI_OUT_OF_RESOURCES   Not enough resource for HII Form installation.
+  @retval Others                 Other errors as indicated.
+
+**/
+EFI_STATUS
+InstallTcg2ConfigForm (
+  IN OUT TCG2_CONFIG_PRIVATE_DATA  *PrivateData
+  );
+
+/**
+  This function removes TCG2 configuration Form.
+
+  @param[in, out]  PrivateData   Points to TCG2 configuration private data.
+
+**/
+VOID
+UninstallTcg2ConfigForm (
+  IN OUT TCG2_CONFIG_PRIVATE_DATA  *PrivateData
+  );
+
+/**
+  This function allows a caller to extract the current configuration for one
+  or more named elements from the target driver.
+
+  @param[in]   This              Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]   Request           A null-terminated Unicode string in
+                                 <ConfigRequest> format.
+  @param[out]  Progress          On return, points to a character in the Request
+                                 string. Points to the string's null terminator if
+                                 request was successful. Points to the most recent
+                                 '&' before the first failing name/value pair (or
+                                 the beginning of the string if the failure is in
+                                 the first name/value pair) if the request was not
+                                 successful.
+  @param[out]  Results           A null-terminated Unicode string in
+                                 <ConfigAltResp> format which has all values filled
+                                 in for the names in the Request string. String to
+                                 be allocated by the called function.
+
+  @retval EFI_SUCCESS            The Results is filled with the requested values.
+  @retval EFI_OUT_OF_RESOURCES   Not enough memory to store the results.
+  @retval EFI_INVALID_PARAMETER  Request is illegal syntax, or unknown name.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2ExtractConfig (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN CONST EFI_STRING                      Request,
+  OUT EFI_STRING                           *Progress,
+  OUT EFI_STRING                           *Results
+  );
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param[in]  This               Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]  Configuration      A null-terminated Unicode string in <ConfigResp>
+                                 format.
+  @param[out] Progress           A pointer to a string filled in with the offset of
+                                 the most recent '&' before the first failing
+                                 name/value pair (or the beginning of the string if
+                                 the failure is in the first name/value pair) or
+                                 the terminating NULL if all was successful.
+
+  @retval EFI_SUCCESS            The Results is processed successfully.
+  @retval EFI_INVALID_PARAMETER  Configuration is NULL.
+  @retval EFI_NOT_FOUND          Routing data doesn't match any storage in this
+                                 driver.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2RouteConfig (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN CONST EFI_STRING                      Configuration,
+  OUT EFI_STRING                           *Progress
+  );
+
+/**
+  This function processes the results of changes in configuration.
+
+  @param[in]  This               Points to the EFI_HII_CONFIG_ACCESS_PROTOCOL.
+  @param[in]  Action             Specifies the type of action taken by the browser.
+  @param[in]  QuestionId         A unique value which is sent to the original
+                                 exporting driver so that it can identify the type
+                                 of data to expect.
+  @param[in]  Type               The type of value for the question.
+  @param[in]  Value              A pointer to the data being sent to the original
+                                 exporting driver.
+  @param[out] ActionRequest      On return, points to the action requested by the
+                                 callback function.
+
+  @retval EFI_SUCCESS            The callback successfully handled the action.
+  @retval EFI_OUT_OF_RESOURCES   Not enough storage is available to hold the
+                                 variable and its data.
+  @retval EFI_DEVICE_ERROR       The variable could not be saved.
+  @retval EFI_UNSUPPORTED        The specified Action is not supported by the
+                                 callback.
+
+**/
+EFI_STATUS
+EFIAPI
+Tcg2Callback (
+  IN CONST EFI_HII_CONFIG_ACCESS_PROTOCOL  *This,
+  IN     EFI_BROWSER_ACTION                Action,
+  IN     EFI_QUESTION_ID                   QuestionId,
+  IN     UINT8                             Type,
+  IN     EFI_IFR_TYPE_VALUE                *Value,
+  OUT EFI_BROWSER_ACTION_REQUEST           *ActionRequest
+  );
+
+#endif

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigNvData.h
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigNvData.h
@@ -1,0 +1,89 @@
+/** @file
+  Header file for NV data structure definition.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __TCG2_CONFIG_NV_DATA_H__
+#define __TCG2_CONFIG_NV_DATA_H__
+
+#include <Guid/HiiPlatformSetupFormset.h>
+#include <Guid/Tcg2ConfigHii.h>
+#include <IndustryStandard/TcgPhysicalPresence.h>
+
+#define TCG2_CONFIGURATION_VARSTORE_ID       0x0001
+#define TCG2_CONFIGURATION_INFO_VARSTORE_ID  0x0002
+#define TCG2_VERSION_VARSTORE_ID             0x0003
+#define TCG2_CONFIGURATION_FORM_ID           0x0001
+
+#define KEY_TPM_DEVICE                0x2000
+#define KEY_TPM2_OPERATION            0x2001
+#define KEY_TPM2_OPERATION_PARAMETER  0x2002
+#define KEY_TPM2_PCR_BANKS_REQUEST_0  0x2003
+#define KEY_TPM2_PCR_BANKS_REQUEST_1  0x2004
+#define KEY_TPM2_PCR_BANKS_REQUEST_2  0x2005
+#define KEY_TPM2_PCR_BANKS_REQUEST_3  0x2006
+#define KEY_TPM2_PCR_BANKS_REQUEST_4  0x2007
+#define KEY_TPM_DEVICE_INTERFACE      0x2008
+#define KEY_TCG2_PPI_VERSION          0x2009
+#define KEY_TPM2_ACPI_REVISION        0x200A
+
+#define TPM_DEVICE_NULL      0
+#define TPM_DEVICE_1_2       1
+#define TPM_DEVICE_2_0_DTPM  2
+#define TPM_DEVICE_MIN       TPM_DEVICE_1_2
+#define TPM_DEVICE_MAX       TPM_DEVICE_2_0_DTPM
+#define TPM_DEVICE_DEFAULT   TPM_DEVICE_2_0_DTPM
+
+#define TPM2_ACPI_REVISION_3  3
+#define TPM2_ACPI_REVISION_4  4
+
+#define TPM_DEVICE_INTERFACE_TIS       0
+#define TPM_DEVICE_INTERFACE_PTP_FIFO  1
+#define TPM_DEVICE_INTERFACE_PTP_CRB   2
+#define TPM_DEVICE_INTERFACE_MAX       TPM_DEVICE_INTERFACE_PTP_FIFO
+#define TPM_DEVICE_INTERFACE_DEFAULT   TPM_DEVICE_INTERFACE_PTP_CRB
+
+#define TCG2_PPI_VERSION_1_2  0x322E31                    // "1.2"
+#define TCG2_PPI_VERSION_1_3  0x332E31                    // "1.3"
+
+//
+// Nv Data structure referenced by IFR, TPM device user desired
+//
+typedef struct {
+  UINT8    TpmDevice;
+} TCG2_CONFIGURATION;
+
+typedef struct {
+  UINT64    PpiVersion;
+  UINT8     Tpm2AcpiTableRev;
+} TCG2_VERSION;
+
+typedef struct {
+  BOOLEAN    Sha1Supported;
+  BOOLEAN    Sha256Supported;
+  BOOLEAN    Sha384Supported;
+  BOOLEAN    Sha512Supported;
+  BOOLEAN    Sm3Supported;
+  UINT8      TpmDeviceInterfaceAttempt;
+  BOOLEAN    TpmDeviceInterfacePtpFifoSupported;
+  BOOLEAN    TpmDeviceInterfacePtpCrbSupported;
+  BOOLEAN    ChangeEPSSupported;
+} TCG2_CONFIGURATION_INFO;
+
+//
+// Variable saved for S3, TPM detected, only valid in S3 path.
+// This variable is ReadOnly.
+//
+typedef struct {
+  UINT8    TpmDeviceDetected;
+} TCG2_DEVICE_DETECTION;
+
+#define TCG2_STORAGE_NAME           L"TCG2_CONFIGURATION"
+#define TCG2_STORAGE_INFO_NAME      L"TCG2_CONFIGURATION_INFO"
+#define TCG2_DEVICE_DETECTION_NAME  L"TCG2_DEVICE_DETECTION"
+#define TCG2_VERSION_NAME           L"TCG2_VERSION"
+
+#endif

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.inf
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.inf
@@ -1,0 +1,78 @@
+## @file
+#  Set TPM device type
+#
+#  This module initializes TPM device type based on variable and detection.
+#  NOTE: This module is only for reference only, each platform should have its own setup page.
+#
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tcg2ConfigPei
+  MODULE_UNI_FILE                = Tcg2ConfigPei.uni
+  FILE_GUID                      = EADD5061-93EF-4CCC-8450-F78A7F0820F0
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = Tcg2ConfigPeimEntryPoint
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+# [BootMode]
+#   S3_RESUME                 ## SOMETIMES_CONSUMES
+#
+
+[Sources]
+  Tcg2ConfigPeim.c
+  Tcg2ConfigNvData.h
+  Tcg2Internal.h
+  TpmDetection.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  PeiServicesLib
+  PeimEntryPoint
+  DebugLib
+  PcdLib
+  TimerLib
+  Tpm12CommandLib
+  Tpm12DeviceLib
+  HobLib
+  MmUnblockMemoryLib
+
+[Guids]
+  ## SOMETIMES_CONSUMES ## Variable:L"TCG2_CONFIGURATION"
+  ## SOMETIMES_CONSUMES ## Variable:L"TCG2_DEVICE_DETECTION"
+  gTcg2ConfigFormSetGuid
+  gEfiTpmDeviceSelectedGuid           ## PRODUCES             ## GUID    # Used as a PPI GUID
+  gEfiTpmDeviceInstanceNoneGuid       ## SOMETIMES_CONSUMES   ## GUID    # TPM device identifier
+  gEdkiiTpmInstanceHobGuid
+  gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid
+  gEdkiiTcg2AcpiCommunicateBufferHobGuid
+
+[Ppis]
+  gEfiPeiReadOnlyVariable2PpiGuid     ## CONSUMES
+  gPeiTpmInitializationDonePpiGuid    ## SOMETIMES_PRODUCES
+  gEfiPeiMemoryDiscoveredPpiGuid
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                 ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInitializationPolicy         ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmAutoDetection                ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer
+
+[Depex]
+  gEfiPeiMasterBootModePpiGuid AND
+  gEfiPeiReadOnlyVariable2PpiGuid
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  Tcg2ConfigPeiExtra.uni

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPei.uni
@@ -1,0 +1,18 @@
+// /** @file
+// Set TPM device type
+//
+// This module initializes TPM device type based on variable and detection.
+// NOTE: This module is only for reference only, each platform should have its own setup page.
+//
+// Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Set TPM device type"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module initializes TPM device type based on variable and detection.\n"
+                                                        "NOTE: This module is only for reference only, each platform should have its own setup page."
+

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPeiExtra.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPeiExtra.uni
@@ -1,0 +1,14 @@
+// /** @file
+// Tcg2ConfigDxe Localized Strings and Content
+//
+// Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"TCG2 (Trusted Computing Group) Configuration DXE"
+
+

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPeim.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigPeim.c
@@ -1,0 +1,231 @@
+/** @file
+  The module entry point for Tcg2 configuration module.
+
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+
+#include <Guid/TpmInstance.h>
+#include <Guid/Tcg2AcpiCommunicateBuffer.h>
+#include <Guid/TpmNvsMm.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PcdLib.h>
+#include <Library/HobLib.h>
+#include <Library/MmUnblockMemoryLib.h>
+
+#include <Ppi/ReadOnlyVariable2.h>
+#include <Ppi/TpmInitialized.h>
+#include <Protocol/Tcg2Protocol.h>
+
+#include "Tcg2ConfigNvData.h"
+#include "Tcg2Internal.h"
+
+TPM_INSTANCE_ID  mTpmInstanceId[] = TPM_INSTANCE_ID_LIST;
+
+CONST EFI_PEI_PPI_DESCRIPTOR  gTpmSelectedPpi = {
+  (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEfiTpmDeviceSelectedGuid,
+  NULL
+};
+
+EFI_PEI_PPI_DESCRIPTOR  mTpmInitializationDonePpiList = {
+  EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST,
+  &gPeiTpmInitializationDonePpiGuid,
+  NULL
+};
+
+/**
+  This routine check both SetupVariable and real TPM device, and return final TpmDevice configuration.
+
+  @param  SetupTpmDevice  TpmDevice configuration in setup driver
+
+  @return TpmDevice configuration
+**/
+UINT8
+DetectTpmDevice (
+  IN UINT8  SetupTpmDevice
+  );
+
+/**
+  Build gEdkiiTcg2AcpiCommunicateBufferHobGuid.
+
+  @param[in] PeiServices          General purpose services available to every PEIM.
+  @param[in] NotifyDescriptor     The notification structure this PEIM registered on install.
+  @param[in] Ppi                  The memory discovered PPI.  Not used.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval others                  Failed to build Tcg2AcpiCommunicateBuffer Hob.
+
+**/
+EFI_STATUS
+EFIAPI
+BuildTcg2AcpiCommunicateBufferHob (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  )
+{
+  TCG2_ACPI_COMMUNICATE_BUFFER  *Tcg2AcpiCommunicateBufferHob;
+  EFI_STATUS                    Status;
+  EFI_PHYSICAL_ADDRESS          Buffer;
+  UINTN                         Pages;
+
+  Pages  = EFI_SIZE_TO_PAGES (sizeof (TCG_NVS));
+  Status = PeiServicesAllocatePages (
+             EfiACPIMemoryNVS,
+             Pages,
+             &Buffer
+             );
+  ASSERT_EFI_ERROR (Status);
+
+  Status = MmUnblockMemoryRequest (Buffer, Pages);
+  if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Tcg2AcpiCommunicateBufferHob = BuildGuidHob (&gEdkiiTcg2AcpiCommunicateBufferHobGuid, sizeof (TCG2_ACPI_COMMUNICATE_BUFFER));
+  ASSERT (Tcg2AcpiCommunicateBufferHob != NULL);
+  Tcg2AcpiCommunicateBufferHob->Tcg2AcpiCommunicateBuffer = Buffer;
+  Tcg2AcpiCommunicateBufferHob->Pages                     = Pages;
+
+  return EFI_SUCCESS;
+}
+
+EFI_PEI_NOTIFY_DESCRIPTOR  mPostMemNotifyList = {
+  (EFI_PEI_PPI_DESCRIPTOR_NOTIFY_CALLBACK | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
+  &gEfiPeiMemoryDiscoveredPpiGuid,
+  BuildTcg2AcpiCommunicateBufferHob
+};
+
+/**
+  The entry point for Tcg2 configuration driver.
+
+  @param  FileHandle  Handle of the file being invoked.
+  @param  PeiServices Describes the list of possible PEI Services.
+
+  @retval EFI_SUCCESS            Convert variable to PCD successfully.
+  @retval Others                 Fail to convert variable to PCD.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2ConfigPeimEntryPoint (
+  IN       EFI_PEI_FILE_HANDLE  FileHandle,
+  IN CONST EFI_PEI_SERVICES     **PeiServices
+  )
+{
+  UINTN                            Size;
+  EFI_STATUS                       Status;
+  EFI_STATUS                       Status2;
+  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *VariablePpi;
+  TCG2_CONFIGURATION               Tcg2Configuration;
+  UINTN                            Index;
+  UINT8                            TpmDevice;
+  VOID                             *Hob;
+
+  Status = PeiServicesLocatePpi (&gEfiPeiReadOnlyVariable2PpiGuid, 0, NULL, (VOID **)&VariablePpi);
+  ASSERT_EFI_ERROR (Status);
+
+  Size   = sizeof (Tcg2Configuration);
+  Status = VariablePpi->GetVariable (
+                          VariablePpi,
+                          TCG2_STORAGE_NAME,
+                          &gTcg2ConfigFormSetGuid,
+                          NULL,
+                          &Size,
+                          &Tcg2Configuration
+                          );
+  if (EFI_ERROR (Status)) {
+    //
+    // Variable not ready, set default value
+    //
+    Tcg2Configuration.TpmDevice = TPM_DEVICE_DEFAULT;
+  }
+
+  //
+  // Validation
+  //
+  if ((Tcg2Configuration.TpmDevice > TPM_DEVICE_MAX) || (Tcg2Configuration.TpmDevice < TPM_DEVICE_MIN)) {
+    Tcg2Configuration.TpmDevice = TPM_DEVICE_DEFAULT;
+  }
+
+  //
+  // Although we have SetupVariable info, we still need detect TPM device manually.
+  //
+  DEBUG ((DEBUG_INFO, "Tcg2Configuration.TpmDevice from Setup: %x\n", Tcg2Configuration.TpmDevice));
+
+  if (PcdGetBool (PcdTpmAutoDetection)) {
+    TpmDevice = DetectTpmDevice (Tcg2Configuration.TpmDevice);
+    DEBUG ((DEBUG_INFO, "TpmDevice final: %x\n", TpmDevice));
+    if (TpmDevice != TPM_DEVICE_NULL) {
+      Tcg2Configuration.TpmDevice = TpmDevice;
+    }
+  } else {
+    TpmDevice = Tcg2Configuration.TpmDevice;
+  }
+
+  //
+  // Convert variable to PCD.
+  // This is work-around because there is no guarantee DynamicHiiPcd can return correct value in DXE phase.
+  // Using DynamicPcd instead.
+  //
+  // NOTE: Tcg2Configuration variable contains the desired TpmDevice type,
+  // while PcdTpmInstanceGuid PCD contains the real detected TpmDevice type
+  //
+  for (Index = 0; Index < sizeof (mTpmInstanceId)/sizeof (mTpmInstanceId[0]); Index++) {
+    if (TpmDevice == mTpmInstanceId[Index].TpmDevice) {
+      Size   = sizeof (mTpmInstanceId[Index].TpmInstanceGuid);
+      Status = PcdSetPtrS (PcdTpmInstanceGuid, &Size, &mTpmInstanceId[Index].TpmInstanceGuid);
+      ASSERT_EFI_ERROR (Status);
+      DEBUG ((DEBUG_INFO, "TpmDevice PCD: %g\n", &mTpmInstanceId[Index].TpmInstanceGuid));
+      break;
+    }
+  }
+
+  //
+  // Build Hob for PcdTpmInstanceGuid
+  //
+  Hob = BuildGuidDataHob (
+          &gEdkiiTpmInstanceHobGuid,
+          (VOID *)PcdGetPtr (PcdTpmInstanceGuid),
+          sizeof (EFI_GUID)
+          );
+  ASSERT (Hob != NULL);
+
+  //
+  // Build Hob for PcdTcgPhysicalPresenceInterfaceVer
+  //
+  Hob = BuildGuidDataHob (
+          &gEdkiiTcgPhysicalPresenceInterfaceVerHobGuid,
+          (VOID *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer),
+          AsciiStrSize ((CHAR8 *)PcdGetPtr (PcdTcgPhysicalPresenceInterfaceVer))
+          );
+  ASSERT (Hob != NULL);
+
+  PeiServicesNotifyPpi (&mPostMemNotifyList);
+
+  //
+  // Selection done
+  //
+  Status = PeiServicesInstallPpi (&gTpmSelectedPpi);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Even if no TPM is selected or detected, we still need install TpmInitializationDonePpi.
+  // Because TcgPei or Tcg2Pei will not run, but we still need a way to notify other driver.
+  // Other driver can know TPM initialization state by TpmInitializedPpi.
+  //
+  if (CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceNoneGuid)) {
+    Status2 = PeiServicesInstallPpi (&mTpmInitializationDonePpiList);
+    ASSERT_EFI_ERROR (Status2);
+  }
+
+  return Status;
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigStrings.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2ConfigStrings.uni
@@ -1,0 +1,132 @@
+/** @file
+  String definitions for TCG2 configuration form.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#langdef en-US "English"
+
+#string STR_TCG2_TITLE                      #language en-US "TCG2 Configuration"
+#string STR_TCG2_HELP                       #language en-US "Press <Enter> to select TCG2 Setup options."
+
+#string STR_TCG2_DEVICE_STATE_PROMPT        #language en-US "Current TPM Device"
+#string STR_TCG2_DEVICE_STATE_HELP          #language en-US "Current TPM Device: Disable, TPM1.2, or TPM2.0"
+#string STR_TCG2_DEVICE_STATE_CONTENT       #language en-US ""
+
+#string STR_TCG2_DEVICE_PROMPT              #language en-US "Attempt TPM Device"
+#string STR_TCG2_DEVICE_HELP                #language en-US "Attempt TPM Device: TPM1.2, or TPM2.0"
+#string STR_TCG2_DEVICE_CONTENT             #language en-US ""
+
+#string STR_TCG2_PPI_VERSION_STATE_PROMPT   #language en-US "Current PPI Version"
+#string STR_TCG2_PPI_VERSION_STATE_HELP     #language en-US "Current PPI Version: 1.2 or 1.3"
+#string STR_TCG2_PPI_VERSION_STATE_CONTENT  #language en-US ""
+
+#string STR_TCG2_PPI_VERSION_PROMPT         #language en-US "Attempt PPI Version"
+#string STR_TCG2_PPI_VERSION_HELP           #language en-US "Attempt PPI Version: 1.2 or 1.3\n"
+                                                            "PcdTcgPhysicalPresenceInterfaceVer needs to be DynamicHii type and map to this option\n"
+                                                            "Otherwise the version configuring by this setup option will not work"
+
+#string STR_TPM2_ACPI_HID_PROMPT                  #language en-US "HID from TPM2 ACPI Table"
+#string STR_TPM2_ACPI_HID_HELP                    #language en-US "HID from TPM2 ACPI Table: ManufacturerID + FirmwareVersion_1"
+#string STR_TPM2_ACPI_HID_CONTENT                 #language en-US ""
+
+#string STR_TPM2_ACPI_REVISION_STATE_PROMPT   #language en-US "Current Rev of TPM2 ACPI Table"
+#string STR_TPM2_ACPI_REVISION_STATE_HELP     #language en-US "Current Rev of TPM2 ACPI Table: Rev 3 or Rev 4"
+#string STR_TPM2_ACPI_REVISION_STATE_CONTENT  #language en-US ""
+
+#string STR_TPM2_ACPI_REVISION_PROMPT          #language en-US "Attempt Rev of TPM2 ACPI Table"
+#string STR_TPM2_ACPI_REVISION_HELP            #language en-US "Rev 3 or Rev 4 (Rev 4 is defined in TCG ACPI Spec 00.37)"
+                                                               "PcdTpm2AcpiTableRev needs to be DynamicHii type and map to this option\n"
+                                                               "Otherwise the version configuring by this setup option will not work"
+
+#string STR_TCG2_DEVICE_INTERFACE_STATE_PROMPT         #language en-US "Current TPM Device Interface"
+#string STR_TCG2_DEVICE_INTERFACE_STATE_HELP           #language en-US "Current TPM Device Interface: TIS, PTP FIFO, PTP CRB"
+#string STR_TCG2_DEVICE_INTERFACE_STATE_CONTENT        #language en-US ""
+
+#string STR_TCG2_DEVICE_INTERFACE_CAPABILITY_PROMPT    #language en-US "PTP TPM Device Interface Capability"
+#string STR_TCG2_DEVICE_INTERFACE_CAPABILITY_HELP      #language en-US "PTP TPM Device Interface Capability: PTP FIFO, PTP CRB"
+#string STR_TCG2_DEVICE_INTERFACE_CAPABILITY_CONTENT   #language en-US ""
+
+#string STR_TCG2_DEVICE_INTERFACE_PROMPT               #language en-US "Attempt PTP TPM Device Interface"
+#string STR_TCG2_DEVICE_INTERFACE_HELP                 #language en-US "Attempt PTP TPM Device Interface: PTP FIFO, PTP CRB"
+#string STR_TCG2_DEVICE_INTERFACE_CONTENT              #language en-US ""
+
+#string STR_TCG2_DEVICE_INTERFACE_TIS                  #language en-US "TIS"
+#string STR_TCG2_DEVICE_INTERFACE_PTP_FIFO             #language en-US "PTP FIFO"
+#string STR_TCG2_DEVICE_INTERFACE_PTP_CRB              #language en-US "PTP CRB"
+
+#string STR_TCG2_PP_OPERATION              #language en-US "TPM2 Physical Presence Operation"
+
+#string STR_TCG2_OPERATION                 #language en-US "TPM2 Operation"
+#string STR_TCG2_OPERATION_HELP            #language en-US "Select one of the supported operation to change TPM2 state."
+
+#string STR_TCG2_NO_ACTION                 #language en-US "No Action"
+#string STR_TCG2_ENABLE                    #language en-US "TPM2 HierarchyControl (TPM_RH_OWNER YES, TPM_RH_ENDORSEMENT YES)"
+#string STR_TCG2_DISABLE                   #language en-US "TPM2 HierarchyControl (TPM_RH_OWNER NO, TPM_RH_ENDORSEMENT NO)"
+#string STR_TCG2_CLEAR                     #language en-US "TPM2 ClearControl(NO) + Clear"
+#string STR_TCG2_SET_PCD_BANKS             #language en-US "TPM2 PCR_Allocate(Algorithm IDs)"
+#string STR_TCG2_CHANGE_EPS                #language en-US "TPM2 ChangeEPS"
+#string STR_TCG2_LOG_ALL_DIGESTS           #language en-US "TCG2 LogAllDigests"
+#string STR_TCG2_DISABLE_ENDORSEMENT_ENABLE_STORAGE_HIERARCHY   #language en-US "TPM2 HierarchyControl (TPM_RH_OWNER NO, TPM_RH_ENDORSEMENT YES)"
+
+#string STR_TCG2_OPERATION_PARAMETER       #language en-US "TPM2 Operation Parameter"
+#string STR_TCG2_OPERATION_PARAMETER_HELP  #language en-US "Additional TPM2 Operation Parameter need be sent with Operation Code (required for SetPCRBanks)"
+
+#string STR_TCG2_TPM_1_2                   #language en-US "TPM 1.2"
+#string STR_TCG2_TPM_2_0_DTPM              #language en-US "TPM 2.0"
+
+#string STR_TPM2_ACPI_REVISION_3           #language en-US "Rev 3"
+#string STR_TPM2_ACPI_REVISION_4           #language en-US "Rev 4"
+
+#string STR_TCG2_PPI_VERSION_1_2           #language en-US "1.2"
+#string STR_TCG2_PPI_VERSION_1_3           #language en-US "1.3"
+
+#string STR_TPM2_ACTIVE_HASH_ALGO                 #language en-US "TPM2 Active PCR Hash Algorithm"
+#string STR_TPM2_ACTIVE_HASH_ALGO_HELP            #language en-US "TPM2 Active PCR Hash Algorithm: SHA1, SHA256, SHA384, SHA512, SM3_256"
+#string STR_TPM2_ACTIVE_HASH_ALGO_CONTENT         #language en-US ""
+
+#string STR_TPM2_SUPPORTED_HASH_ALGO              #language en-US "TPM2 Hardware Supported Hash Algorithm"
+#string STR_TPM2_SUPPORTED_HASH_ALGO_HELP         #language en-US "TPM2 Hardware Supported Hash Algorithm: SHA1, SHA256, SHA384, SHA512, SM3_256"
+#string STR_TPM2_SUPPORTED_HASH_ALGO_CONTENT      #language en-US ""
+
+#string STR_BIOS_HASH_ALGO                 #language en-US "BIOS Supported Hash Algorithm"
+#string STR_BIOS_HASH_ALGO_HELP            #language en-US "BIOS Supported Hash Algorithm: SHA1, SHA256, SHA384, SHA512, SM3_256"
+#string STR_BIOS_HASH_ALGO_CONTENT         #language en-US ""
+
+#string STR_TCG2_CONFIGURATION             #language en-US "TCG2 Protocol Configuration"
+
+#string STR_TCG2_PROTOCOL_VERSION          #language en-US "TCG2 Protocol Version"
+#string STR_TCG2_PROTOCOL_VERSION_HELP     #language en-US "TCG2 Protocol Version: 1.0 or 1.1"
+#string STR_TCG2_PROTOCOL_VERSION_1_0      #language en-US "1.0"
+#string STR_TCG2_PROTOCOL_VERSION_1_1      #language en-US "1.1"
+
+#string STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT               #language en-US "Supported Event Log Format"
+#string STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT_HELP          #language en-US "TCG2 Supported Event Log Format: TCG_1_2, TCG_2"
+#string STR_TCG2_SUPPORTED_EVENT_LOG_FORMAT_CONTENT       #language en-US ""
+
+#string STR_TCG2_HASH_ALGO_BITMAP                         #language en-US "Hash Algorithm Bitmap"
+#string STR_TCG2_HASH_ALGO_BITMAP_HELP                    #language en-US "TCG2 Supported Hash Algorithm Bitmap: SHA1, SHA256, SHA384, SHA512"
+#string STR_TCG2_HASH_ALGO_BITMAP_CONTENT                 #language en-US ""
+
+#string STR_TCG2_NUMBER_OF_PCR_BANKS                      #language en-US "Number of PCR Banks"
+#string STR_TCG2_NUMBER_OF_PCR_BANKS_HELP                 #language en-US "TCG2 Number of PCR Banks"
+#string STR_TCG2_NUMBER_OF_PCR_BANKS_CONTENT              #language en-US ""
+
+#string STR_TCG2_ACTIVE_PCR_BANKS                         #language en-US "Active PCR Banks"
+#string STR_TCG2_ACTIVE_PCR_BANKS_HELP                    #language en-US "TCG2 Active PCR Banks: SHA1, SHA256, SHA384, SHA512"
+#string STR_TCG2_ACTIVE_PCR_BANKS_CONTENT                 #language en-US ""
+
+#string STR_TCG2_PCR_BANK_SHA1                            #language en-US "  PCR Bank: SHA1"
+#string STR_TCG2_PCR_BANK_SHA1_HELP                       #language en-US "TCG2 Request PCR Bank: SHA1"
+#string STR_TCG2_PCR_BANK_SHA256                          #language en-US "  PCR Bank: SHA256"
+#string STR_TCG2_PCR_BANK_SHA256_HELP                     #language en-US "TCG2 Request PCR Bank: SHA256"
+#string STR_TCG2_PCR_BANK_SHA384                          #language en-US "  PCR Bank: SHA384"
+#string STR_TCG2_PCR_BANK_SHA384_HELP                     #language en-US "TCG2 Request PCR Bank: SHA384"
+#string STR_TCG2_PCR_BANK_SHA512                          #language en-US "  PCR Bank: SHA512"
+#string STR_TCG2_PCR_BANK_SHA512_HELP                     #language en-US "TCG2 Request PCR Bank: SHA512"
+#string STR_TCG2_PCR_BANK_SM3_256                         #language en-US "  PCR Bank: SM3_256"
+#string STR_TCG2_PCR_BANK_SM3_256_HELP                    #language en-US "TCG2 Request PCR Bank: SM3_256"
+
+#string STR_NULL                           #language en-US ""

--- a/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2Internal.h
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/Tcg2Internal.h
@@ -1,0 +1,26 @@
+/** @file
+  The internal header file defines the common structures for PEI and DXE modules.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __TCG2_INTERNAL_H__
+#define __TCG2_INTERNAL_H__
+
+#define EFI_TCG2_EVENT_LOG_FORMAT_DEFAULT  EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2
+#define EFI_TCG2_EVENT_LOG_FORMAT_ALL      (EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2 | EFI_TCG2_EVENT_LOG_FORMAT_TCG_2)
+
+#define TPM_INSTANCE_ID_LIST  { \
+  {TPM_DEVICE_INTERFACE_NONE,           TPM_DEVICE_NULL},      \
+  {TPM_DEVICE_INTERFACE_TPM12,          TPM_DEVICE_1_2},       \
+  {TPM_DEVICE_INTERFACE_TPM20_DTPM,     TPM_DEVICE_2_0_DTPM},  \
+}
+
+typedef struct {
+  GUID     TpmInstanceGuid;
+  UINT8    TpmDevice;
+} TPM_INSTANCE_ID;
+
+#endif

--- a/Silicon/Sophgo/Drivers/Tcg2Config/TpmDetection.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Config/TpmDetection.c
@@ -1,0 +1,101 @@
+/** @file
+  TPM1.2/dTPM2.0 auto detection.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Ppi/ReadOnlyVariable2.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/PcdLib.h>
+#include <Library/Tpm12DeviceLib.h>
+#include <Library/Tpm12CommandLib.h>
+#include <IndustryStandard/Tpm12.h>
+
+#include "Tcg2ConfigNvData.h"
+#include "Tcg2Internal.h"
+
+/**
+  This routine check both SetupVariable and real TPM device, and return final TpmDevice configuration.
+
+  @param  SetupTpmDevice  TpmDevice configuration in setup driver
+
+  @return TpmDevice configuration
+**/
+UINT8
+DetectTpmDevice (
+  IN UINT8  SetupTpmDevice
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_BOOT_MODE                    BootMode;
+  TCG2_DEVICE_DETECTION            Tcg2DeviceDetection;
+  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *VariablePpi;
+  UINTN                            Size;
+
+  Status = PeiServicesGetBootMode (&BootMode);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // In S3, we rely on normal boot Detection, because we save to ReadOnly Variable in normal boot.
+  //
+  if (BootMode == BOOT_ON_S3_RESUME) {
+    DEBUG ((DEBUG_INFO, "DetectTpmDevice: S3 mode\n"));
+
+    Status = PeiServicesLocatePpi (&gEfiPeiReadOnlyVariable2PpiGuid, 0, NULL, (VOID **)&VariablePpi);
+    ASSERT_EFI_ERROR (Status);
+
+    Size = sizeof (TCG2_DEVICE_DETECTION);
+    ZeroMem (&Tcg2DeviceDetection, sizeof (Tcg2DeviceDetection));
+    Status = VariablePpi->GetVariable (
+                            VariablePpi,
+                            TCG2_DEVICE_DETECTION_NAME,
+                            &gTcg2ConfigFormSetGuid,
+                            NULL,
+                            &Size,
+                            &Tcg2DeviceDetection
+                            );
+    if (!EFI_ERROR (Status) &&
+        (Tcg2DeviceDetection.TpmDeviceDetected >= TPM_DEVICE_MIN) &&
+        (Tcg2DeviceDetection.TpmDeviceDetected <= TPM_DEVICE_MAX))
+    {
+      DEBUG ((DEBUG_ERROR, "TpmDevice from DeviceDetection: %x\n", Tcg2DeviceDetection.TpmDeviceDetected));
+      return Tcg2DeviceDetection.TpmDeviceDetected;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "DetectTpmDevice:\n"));
+
+  // dTPM available and not disabled by setup
+  // We need check if it is TPM1.2 or TPM2.0
+  // So try TPM1.2 command at first
+
+  Status = Tpm12RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    //
+    // dTPM not available
+    //
+    return TPM_DEVICE_NULL;
+  }
+
+  if (BootMode == BOOT_ON_S3_RESUME) {
+    Status = Tpm12Startup (TPM_ST_STATE);
+  } else {
+    Status = Tpm12Startup (TPM_ST_CLEAR);
+  }
+
+  if (EFI_ERROR (Status)) {
+    return TPM_DEVICE_2_0_DTPM;
+  }
+
+  // NO initialization needed again.
+  Status = PcdSet8S (PcdTpmInitializationPolicy, 0);
+  ASSERT_EFI_ERROR (Status);
+  return TPM_DEVICE_1_2;
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Dxe/MeasureBootPeCoff.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Dxe/MeasureBootPeCoff.c
@@ -1,0 +1,408 @@
+/** @file
+  This module implements measuring PeCoff image for Tcg2 Protocol.
+
+  Caution: This file requires additional review when modified.
+  This driver will have external input - PE/COFF image.
+  This external input must be validated carefully to avoid security issue like
+  buffer overflow, integer overflow.
+
+Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/PeCoffLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/HashLib.h>
+
+UINTN  mTcg2DxeImageSize = 0;
+
+/**
+  Reads contents of a PE/COFF image in memory buffer.
+
+  Caution: This function may receive untrusted input.
+  PE/COFF image is external input, so this function will make sure the PE/COFF image content
+  read is within the image buffer.
+
+  @param  FileHandle      Pointer to the file handle to read the PE/COFF image.
+  @param  FileOffset      Offset into the PE/COFF image to begin the read operation.
+  @param  ReadSize        On input, the size in bytes of the requested read operation.
+                          On output, the number of bytes actually read.
+  @param  Buffer          Output buffer that contains the data read from the PE/COFF image.
+
+  @retval EFI_SUCCESS     The specified portion of the PE/COFF image was read and the size
+**/
+EFI_STATUS
+EFIAPI
+Tcg2DxeImageRead (
+  IN     VOID   *FileHandle,
+  IN     UINTN  FileOffset,
+  IN OUT UINTN  *ReadSize,
+  OUT    VOID   *Buffer
+  )
+{
+  UINTN  EndPosition;
+
+  if ((FileHandle == NULL) || (ReadSize == NULL) || (Buffer == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (MAX_ADDRESS - FileOffset < *ReadSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  EndPosition = FileOffset + *ReadSize;
+  if (EndPosition > mTcg2DxeImageSize) {
+    *ReadSize = (UINT32)(mTcg2DxeImageSize - FileOffset);
+  }
+
+  if (FileOffset >= mTcg2DxeImageSize) {
+    *ReadSize = 0;
+  }
+
+  CopyMem (Buffer, (UINT8 *)((UINTN)FileHandle + FileOffset), *ReadSize);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Measure PE image into TPM log based on the authenticode image hashing in
+  PE/COFF Specification 8.0 Appendix A.
+
+  Caution: This function may receive untrusted input.
+  PE/COFF image is external input, so this function will validate its data structure
+  within this image buffer before use.
+
+  Notes: PE/COFF image is checked by BasePeCoffLib PeCoffLoaderGetImageInfo().
+
+  @param[in]  PCRIndex       TPM PCR index
+  @param[in]  ImageAddress   Start address of image buffer.
+  @param[in]  ImageSize      Image size
+  @param[out] DigestList     Digest list of this image.
+
+  @retval EFI_SUCCESS            Successfully measure image.
+  @retval EFI_OUT_OF_RESOURCES   No enough resource to measure image.
+  @retval other error value
+**/
+EFI_STATUS
+MeasurePeImageAndExtend (
+  IN  UINT32                PCRIndex,
+  IN  EFI_PHYSICAL_ADDRESS  ImageAddress,
+  IN  UINTN                 ImageSize,
+  OUT TPML_DIGEST_VALUES    *DigestList
+  )
+{
+  EFI_STATUS                           Status;
+  EFI_IMAGE_DOS_HEADER                 *DosHdr;
+  UINT32                               PeCoffHeaderOffset;
+  EFI_IMAGE_SECTION_HEADER             *Section;
+  UINT8                                *HashBase;
+  UINTN                                HashSize;
+  UINTN                                SumOfBytesHashed;
+  EFI_IMAGE_SECTION_HEADER             *SectionHeader;
+  UINTN                                Index;
+  UINTN                                Pos;
+  EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION  Hdr;
+  UINT32                               NumberOfRvaAndSizes;
+  UINT32                               CertSize;
+  HASH_HANDLE                          HashHandle;
+  PE_COFF_LOADER_IMAGE_CONTEXT         ImageContext;
+
+  HashHandle = 0xFFFFFFFF; // Know bad value
+
+  Status        = EFI_UNSUPPORTED;
+  SectionHeader = NULL;
+
+  //
+  // Check PE/COFF image
+  //
+  ZeroMem (&ImageContext, sizeof (ImageContext));
+  ImageContext.Handle    = (VOID *)(UINTN)ImageAddress;
+  mTcg2DxeImageSize      = ImageSize;
+  ImageContext.ImageRead = (PE_COFF_LOADER_READ_FILE)Tcg2DxeImageRead;
+
+  //
+  // Get information about the image being loaded
+  //
+  Status = PeCoffLoaderGetImageInfo (&ImageContext);
+  if (EFI_ERROR (Status)) {
+    //
+    // The information can't be got from the invalid PeImage
+    //
+    DEBUG ((DEBUG_INFO, "Tcg2Dxe: PeImage invalid. Cannot retrieve image information.\n"));
+    goto Finish;
+  }
+
+  DosHdr             = (EFI_IMAGE_DOS_HEADER *)(UINTN)ImageAddress;
+  PeCoffHeaderOffset = 0;
+  if (DosHdr->e_magic == EFI_IMAGE_DOS_SIGNATURE) {
+    PeCoffHeaderOffset = DosHdr->e_lfanew;
+  }
+
+  Hdr.Pe32 = (EFI_IMAGE_NT_HEADERS32 *)((UINT8 *)(UINTN)ImageAddress + PeCoffHeaderOffset);
+  if (Hdr.Pe32->Signature != EFI_IMAGE_NT_SIGNATURE) {
+    Status = EFI_UNSUPPORTED;
+    goto Finish;
+  }
+
+  //
+  // PE/COFF Image Measurement
+  //
+  //    NOTE: The following codes/steps are based upon the authenticode image hashing in
+  //      PE/COFF Specification 8.0 Appendix A.
+  //
+  //
+
+  // 1.  Load the image header into memory.
+
+  // 2.  Initialize a SHA hash context.
+
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    goto Finish;
+  }
+
+  //
+  // Measuring PE/COFF Image Header;
+  // But CheckSum field and SECURITY data directory (certificate) are excluded
+  //
+
+  //
+  // 3.  Calculate the distance from the base of the image header to the image checksum address.
+  // 4.  Hash the image header from its base to beginning of the image checksum.
+  //
+  HashBase = (UINT8 *)(UINTN)ImageAddress;
+  if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+    //
+    // Use PE32 offset
+    //
+    NumberOfRvaAndSizes = Hdr.Pe32->OptionalHeader.NumberOfRvaAndSizes;
+    HashSize            = (UINTN)(&Hdr.Pe32->OptionalHeader.CheckSum) - (UINTN)HashBase;
+  } else {
+    //
+    // Use PE32+ offset
+    //
+    NumberOfRvaAndSizes = Hdr.Pe32Plus->OptionalHeader.NumberOfRvaAndSizes;
+    HashSize            = (UINTN)(&Hdr.Pe32Plus->OptionalHeader.CheckSum) - (UINTN)HashBase;
+  }
+
+  Status = HashUpdate (HashHandle, HashBase, HashSize);
+  if (EFI_ERROR (Status)) {
+    goto Finish;
+  }
+
+  //
+  // 5.  Skip over the image checksum (it occupies a single ULONG).
+  //
+  if (NumberOfRvaAndSizes <= EFI_IMAGE_DIRECTORY_ENTRY_SECURITY) {
+    //
+    // 6.  Since there is no Cert Directory in optional header, hash everything
+    //     from the end of the checksum to the end of image header.
+    //
+    if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+      //
+      // Use PE32 offset.
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32->OptionalHeader.CheckSum + sizeof (UINT32);
+      HashSize = Hdr.Pe32->OptionalHeader.SizeOfHeaders - (UINTN)(HashBase - ImageAddress);
+    } else {
+      //
+      // Use PE32+ offset.
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32Plus->OptionalHeader.CheckSum + sizeof (UINT32);
+      HashSize = Hdr.Pe32Plus->OptionalHeader.SizeOfHeaders - (UINTN)(HashBase - ImageAddress);
+    }
+
+    if (HashSize != 0) {
+      Status = HashUpdate (HashHandle, HashBase, HashSize);
+      if (EFI_ERROR (Status)) {
+        goto Finish;
+      }
+    }
+  } else {
+    //
+    // 7.  Hash everything from the end of the checksum to the start of the Cert Directory.
+    //
+    if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+      //
+      // Use PE32 offset
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32->OptionalHeader.CheckSum + sizeof (UINT32);
+      HashSize = (UINTN)(&Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY]) - (UINTN)HashBase;
+    } else {
+      //
+      // Use PE32+ offset
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32Plus->OptionalHeader.CheckSum + sizeof (UINT32);
+      HashSize = (UINTN)(&Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY]) - (UINTN)HashBase;
+    }
+
+    if (HashSize != 0) {
+      Status = HashUpdate (HashHandle, HashBase, HashSize);
+      if (EFI_ERROR (Status)) {
+        goto Finish;
+      }
+    }
+
+    //
+    // 8.  Skip over the Cert Directory. (It is sizeof(IMAGE_DATA_DIRECTORY) bytes.)
+    // 9.  Hash everything from the end of the Cert Directory to the end of image header.
+    //
+    if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+      //
+      // Use PE32 offset
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY + 1];
+      HashSize = Hdr.Pe32->OptionalHeader.SizeOfHeaders - (UINTN)(HashBase - ImageAddress);
+    } else {
+      //
+      // Use PE32+ offset
+      //
+      HashBase = (UINT8 *)&Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY + 1];
+      HashSize = Hdr.Pe32Plus->OptionalHeader.SizeOfHeaders - (UINTN)(HashBase - ImageAddress);
+    }
+
+    if (HashSize != 0) {
+      Status = HashUpdate (HashHandle, HashBase, HashSize);
+      if (EFI_ERROR (Status)) {
+        goto Finish;
+      }
+    }
+  }
+
+  //
+  // 10. Set the SUM_OF_BYTES_HASHED to the size of the header
+  //
+  if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+    //
+    // Use PE32 offset
+    //
+    SumOfBytesHashed = Hdr.Pe32->OptionalHeader.SizeOfHeaders;
+  } else {
+    //
+    // Use PE32+ offset
+    //
+    SumOfBytesHashed = Hdr.Pe32Plus->OptionalHeader.SizeOfHeaders;
+  }
+
+  //
+  // 11. Build a temporary table of pointers to all the IMAGE_SECTION_HEADER
+  //     structures in the image. The 'NumberOfSections' field of the image
+  //     header indicates how big the table should be. Do not include any
+  //     IMAGE_SECTION_HEADERs in the table whose 'SizeOfRawData' field is zero.
+  //
+  SectionHeader = (EFI_IMAGE_SECTION_HEADER *)AllocateZeroPool (sizeof (EFI_IMAGE_SECTION_HEADER) * Hdr.Pe32->FileHeader.NumberOfSections);
+  if (SectionHeader == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Finish;
+  }
+
+  //
+  // 12.  Using the 'PointerToRawData' in the referenced section headers as
+  //      a key, arrange the elements in the table in ascending order. In other
+  //      words, sort the section headers according to the disk-file offset of
+  //      the section.
+  //
+  Section = (EFI_IMAGE_SECTION_HEADER *)(
+                                         (UINT8 *)(UINTN)ImageAddress +
+                                         PeCoffHeaderOffset +
+                                         sizeof (UINT32) +
+                                         sizeof (EFI_IMAGE_FILE_HEADER) +
+                                         Hdr.Pe32->FileHeader.SizeOfOptionalHeader
+                                         );
+  for (Index = 0; Index < Hdr.Pe32->FileHeader.NumberOfSections; Index++) {
+    Pos = Index;
+    while ((Pos > 0) && (Section->PointerToRawData < SectionHeader[Pos - 1].PointerToRawData)) {
+      CopyMem (&SectionHeader[Pos], &SectionHeader[Pos - 1], sizeof (EFI_IMAGE_SECTION_HEADER));
+      Pos--;
+    }
+
+    CopyMem (&SectionHeader[Pos], Section, sizeof (EFI_IMAGE_SECTION_HEADER));
+    Section += 1;
+  }
+
+  //
+  // 13.  Walk through the sorted table, bring the corresponding section
+  //      into memory, and hash the entire section (using the 'SizeOfRawData'
+  //      field in the section header to determine the amount of data to hash).
+  // 14.  Add the section's 'SizeOfRawData' to SUM_OF_BYTES_HASHED .
+  // 15.  Repeat steps 13 and 14 for all the sections in the sorted table.
+  //
+  for (Index = 0; Index < Hdr.Pe32->FileHeader.NumberOfSections; Index++) {
+    Section = (EFI_IMAGE_SECTION_HEADER *)&SectionHeader[Index];
+    if (Section->SizeOfRawData == 0) {
+      continue;
+    }
+
+    HashBase = (UINT8 *)(UINTN)ImageAddress + Section->PointerToRawData;
+    HashSize = (UINTN)Section->SizeOfRawData;
+
+    Status = HashUpdate (HashHandle, HashBase, HashSize);
+    if (EFI_ERROR (Status)) {
+      goto Finish;
+    }
+
+    SumOfBytesHashed += HashSize;
+  }
+
+  //
+  // 16.  If the file size is greater than SUM_OF_BYTES_HASHED, there is extra
+  //      data in the file that needs to be added to the hash. This data begins
+  //      at file offset SUM_OF_BYTES_HASHED and its length is:
+  //             FileSize  -  (CertDirectory->Size)
+  //
+  if (ImageSize > SumOfBytesHashed) {
+    HashBase = (UINT8 *)(UINTN)ImageAddress + SumOfBytesHashed;
+
+    if (NumberOfRvaAndSizes <= EFI_IMAGE_DIRECTORY_ENTRY_SECURITY) {
+      CertSize = 0;
+    } else {
+      if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+        //
+        // Use PE32 offset.
+        //
+        CertSize = Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].Size;
+      } else {
+        //
+        // Use PE32+ offset.
+        //
+        CertSize = Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].Size;
+      }
+    }
+
+    if (ImageSize > CertSize + SumOfBytesHashed) {
+      HashSize = (UINTN)(ImageSize - CertSize - SumOfBytesHashed);
+
+      Status = HashUpdate (HashHandle, HashBase, HashSize);
+      if (EFI_ERROR (Status)) {
+        goto Finish;
+      }
+    } else if (ImageSize < CertSize + SumOfBytesHashed) {
+      Status = EFI_UNSUPPORTED;
+      goto Finish;
+    }
+  }
+
+  //
+  // 17.  Finalize the SHA hash.
+  //
+  Status = HashCompleteAndExtend (HashHandle, PCRIndex, NULL, 0, DigestList);
+  if (EFI_ERROR (Status)) {
+    goto Finish;
+  }
+
+Finish:
+  if (SectionHeader != NULL) {
+    FreePool (SectionHeader);
+  }
+
+  return Status;
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.c
+++ b/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.c
@@ -1,0 +1,2919 @@
+/** @file
+  This module implements Tcg2 Protocol.
+
+Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+#include <IndustryStandard/Acpi.h>
+#include <IndustryStandard/PeImage.h>
+#include <IndustryStandard/TcpaAcpi.h>
+
+#include <Guid/GlobalVariable.h>
+#include <Guid/HobList.h>
+#include <Guid/TcgEventHob.h>
+#include <Guid/EventGroup.h>
+#include <Guid/EventExitBootServiceFailed.h>
+#include <Guid/ImageAuthentication.h>
+#include <Guid/TpmInstance.h>
+#include <Guid/DeviceAuthentication.h>
+
+#include <Protocol/DevicePath.h>
+#include <Protocol/MpService.h>
+#include <Protocol/VariableWrite.h>
+#include <Protocol/Tcg2Protocol.h>
+#include <Protocol/TrEEProtocol.h>
+#include <Protocol/ResetNotification.h>
+
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/UefiDriverEntryPoint.h>
+#include <Library/HobLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/BaseLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
+#include <Library/Tpm2CommandLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/HashLib.h>
+#include <Library/PerformanceLib.h>
+#include <Library/ReportStatusCodeLib.h>
+#include <Library/Tcg2PhysicalPresenceLib.h>
+
+#define PERF_ID_TCG2_DXE  0x3120
+
+typedef struct {
+  CHAR16      *VariableName;
+  EFI_GUID    *VendorGuid;
+} VARIABLE_TYPE;
+
+#define  TCG2_DEFAULT_MAX_COMMAND_SIZE   0x1000
+#define  TCG2_DEFAULT_MAX_RESPONSE_SIZE  0x1000
+
+typedef struct {
+  EFI_GUID                     *EventGuid;
+  EFI_TCG2_EVENT_LOG_FORMAT    LogFormat;
+} TCG2_EVENT_INFO_STRUCT;
+
+TCG2_EVENT_INFO_STRUCT  mTcg2EventInfo[] = {
+  { &gTcgEventEntryHobGuid,  EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2 },
+  { &gTcgEvent2EntryHobGuid, EFI_TCG2_EVENT_LOG_FORMAT_TCG_2   },
+};
+
+#define TCG_EVENT_LOG_AREA_COUNT_MAX  2
+
+typedef struct {
+  EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat;
+  EFI_PHYSICAL_ADDRESS         Lasa;
+  UINT64                       Laml;
+  UINTN                        EventLogSize;
+  UINT8                        *LastEvent;
+  BOOLEAN                      EventLogStarted;
+  BOOLEAN                      EventLogTruncated;
+  UINTN                        Next800155EventOffset;
+} TCG_EVENT_LOG_AREA_STRUCT;
+
+typedef struct _TCG_DXE_DATA {
+  EFI_TCG2_BOOT_SERVICE_CAPABILITY    BsCap;
+  TCG_EVENT_LOG_AREA_STRUCT           EventLogAreaStruct[TCG_EVENT_LOG_AREA_COUNT_MAX];
+  BOOLEAN                             GetEventLogCalled[TCG_EVENT_LOG_AREA_COUNT_MAX];
+  TCG_EVENT_LOG_AREA_STRUCT           FinalEventLogAreaStruct[TCG_EVENT_LOG_AREA_COUNT_MAX];
+  EFI_TCG2_FINAL_EVENTS_TABLE         *FinalEventsTable[TCG_EVENT_LOG_AREA_COUNT_MAX];
+} TCG_DXE_DATA;
+
+TCG_DXE_DATA  mTcgDxeData = {
+  {
+    sizeof (EFI_TCG2_BOOT_SERVICE_CAPABILITY), // Size
+    { 1, 1 },                                  // StructureVersion
+    { 1, 1 },                                  // ProtocolVersion
+    EFI_TCG2_BOOT_HASH_ALG_SHA1,               // HashAlgorithmBitmap
+    EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2,         // SupportedEventLogs
+    TRUE,                                      // TPMPresentFlag
+    TCG2_DEFAULT_MAX_COMMAND_SIZE,             // MaxCommandSize
+    TCG2_DEFAULT_MAX_RESPONSE_SIZE,            // MaxResponseSize
+    0,                                         // ManufacturerID
+    0,                                         // NumberOfPCRBanks
+    0,                                         // ActivePcrBanks
+  },
+};
+
+UINTN   mBootAttempts  = 0;
+CHAR16  mBootVarName[] = L"BootOrder";
+
+VARIABLE_TYPE  mVariableType[] = {
+  { EFI_SECURE_BOOT_MODE_NAME,    &gEfiGlobalVariableGuid        },
+  { EFI_PLATFORM_KEY_NAME,        &gEfiGlobalVariableGuid        },
+  { EFI_KEY_EXCHANGE_KEY_NAME,    &gEfiGlobalVariableGuid        },
+  { EFI_IMAGE_SECURITY_DATABASE,  &gEfiImageSecurityDatabaseGuid },
+  { EFI_IMAGE_SECURITY_DATABASE1, &gEfiImageSecurityDatabaseGuid },
+};
+
+EFI_HANDLE  mImageHandle;
+
+/**
+  Measure PE image into TPM log based on the authenticode image hashing in
+  PE/COFF Specification 8.0 Appendix A.
+
+  Caution: This function may receive untrusted input.
+  PE/COFF image is external input, so this function will validate its data structure
+  within this image buffer before use.
+
+  Notes: PE/COFF image is checked by BasePeCoffLib PeCoffLoaderGetImageInfo().
+
+  @param[in]  PCRIndex       TPM PCR index
+  @param[in]  ImageAddress   Start address of image buffer.
+  @param[in]  ImageSize      Image size
+  @param[out] DigestList     Digest list of this image.
+
+  @retval EFI_SUCCESS            Successfully measure image.
+  @retval EFI_OUT_OF_RESOURCES   No enough resource to measure image.
+  @retval other error value
+**/
+EFI_STATUS
+MeasurePeImageAndExtend (
+  IN  UINT32                PCRIndex,
+  IN  EFI_PHYSICAL_ADDRESS  ImageAddress,
+  IN  UINTN                 ImageSize,
+  OUT TPML_DIGEST_VALUES    *DigestList
+  );
+
+/**
+
+  This function dump raw data.
+
+  @param  Data  raw data
+  @param  Size  raw data size
+
+**/
+VOID
+InternalDumpData (
+  IN UINT8  *Data,
+  IN UINTN  Size
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < Size; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x", (UINTN)Data[Index]));
+  }
+}
+
+/**
+
+  This function initialize TCG_PCR_EVENT2_HDR for EV_NO_ACTION Event Type other than EFI Specification ID event
+  The behavior is defined by TCG PC Client PFP Spec. Section 9.3.4 EV_NO_ACTION Event Types
+
+  @param[in, out]   NoActionEvent  Event Header of EV_NO_ACTION Event
+  @param[in]        EventSize      Event Size of the EV_NO_ACTION Event
+
+**/
+VOID
+InitNoActionEvent (
+  IN OUT TCG_PCR_EVENT2_HDR  *NoActionEvent,
+  IN UINT32                  EventSize
+  )
+{
+  UINT32         DigestListCount;
+  TPMI_ALG_HASH  HashAlgId;
+  UINT8          *DigestBuffer;
+
+  DigestBuffer    = (UINT8 *)NoActionEvent->Digests.digests;
+  DigestListCount = 0;
+
+  NoActionEvent->PCRIndex  = 0;
+  NoActionEvent->EventType = EV_NO_ACTION;
+
+  //
+  // Set Hash count & hashAlg accordingly, while Digest.digests[n].digest to all 0
+  //
+  ZeroMem (&NoActionEvent->Digests, sizeof (NoActionEvent->Digests));
+
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA1) != 0) {
+    HashAlgId = TPM_ALG_SHA1;
+    CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestListCount++;
+  }
+
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA256) != 0) {
+    HashAlgId = TPM_ALG_SHA256;
+    CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestListCount++;
+  }
+
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA384) != 0) {
+    HashAlgId = TPM_ALG_SHA384;
+    CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestListCount++;
+  }
+
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA512) != 0) {
+    HashAlgId = TPM_ALG_SHA512;
+    CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestListCount++;
+  }
+
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SM3_256) != 0) {
+    HashAlgId = TPM_ALG_SM3_256;
+    CopyMem (DigestBuffer, &HashAlgId, sizeof (TPMI_ALG_HASH));
+    DigestBuffer += sizeof (TPMI_ALG_HASH) + GetHashSizeFromAlgo (HashAlgId);
+    DigestListCount++;
+  }
+
+  //
+  // Set Digests Count
+  //
+  WriteUnaligned32 ((UINT32 *)&NoActionEvent->Digests.count, DigestListCount);
+
+  //
+  // Set Event Size
+  //
+  WriteUnaligned32 ((UINT32 *)DigestBuffer, EventSize);
+}
+
+/**
+
+  This function dump raw data with colume format.
+
+  @param  Data  raw data
+  @param  Size  raw data size
+
+**/
+VOID
+InternalDumpHex (
+  IN UINT8  *Data,
+  IN UINTN  Size
+  )
+{
+  UINTN  Index;
+  UINTN  Count;
+  UINTN  Left;
+
+  #define COLUME_SIZE  (16 * 2)
+
+  Count = Size / COLUME_SIZE;
+  Left  = Size % COLUME_SIZE;
+  for (Index = 0; Index < Count; Index++) {
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+    InternalDumpData (Data + Index * COLUME_SIZE, COLUME_SIZE);
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+
+  if (Left != 0) {
+    DEBUG ((DEBUG_INFO, "%04x: ", Index * COLUME_SIZE));
+    InternalDumpData (Data + Index * COLUME_SIZE, Left);
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+}
+
+/**
+  Get All processors EFI_CPU_LOCATION in system. LocationBuf is allocated inside the function
+  Caller is responsible to free LocationBuf.
+
+  @param[out] LocationBuf          Returns Processor Location Buffer.
+  @param[out] Num                  Returns processor number.
+
+  @retval EFI_SUCCESS              Operation completed successfully.
+  @retval EFI_UNSUPPORTED       MpService protocol not found.
+
+**/
+EFI_STATUS
+GetProcessorsCpuLocation (
+  OUT  EFI_CPU_PHYSICAL_LOCATION  **LocationBuf,
+  OUT  UINTN                      *Num
+  )
+{
+  EFI_STATUS                 Status;
+  EFI_MP_SERVICES_PROTOCOL   *MpProtocol;
+  UINTN                      ProcessorNum;
+  UINTN                      EnabledProcessorNum;
+  EFI_PROCESSOR_INFORMATION  ProcessorInfo;
+  EFI_CPU_PHYSICAL_LOCATION  *ProcessorLocBuf;
+  UINTN                      Index;
+
+  Status = gBS->LocateProtocol (&gEfiMpServiceProtocolGuid, NULL, (VOID **)&MpProtocol);
+  if (EFI_ERROR (Status)) {
+    //
+    // MP protocol is not installed
+    //
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = MpProtocol->GetNumberOfProcessors (
+                         MpProtocol,
+                         &ProcessorNum,
+                         &EnabledProcessorNum
+                         );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = gBS->AllocatePool (
+                  EfiBootServicesData,
+                  sizeof (EFI_CPU_PHYSICAL_LOCATION) * ProcessorNum,
+                  (VOID **)&ProcessorLocBuf
+                  );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Get each processor Location info
+  //
+  for (Index = 0; Index < ProcessorNum; Index++) {
+    Status = MpProtocol->GetProcessorInfo (
+                           MpProtocol,
+                           Index,
+                           &ProcessorInfo
+                           );
+    if (EFI_ERROR (Status)) {
+      FreePool (ProcessorLocBuf);
+      return Status;
+    }
+
+    //
+    // Get all Processor Location info & measure
+    //
+    CopyMem (
+      &ProcessorLocBuf[Index],
+      &ProcessorInfo.Location,
+      sizeof (EFI_CPU_PHYSICAL_LOCATION)
+      );
+  }
+
+  *LocationBuf = ProcessorLocBuf;
+  *Num         = ProcessorNum;
+
+  return Status;
+}
+
+/**
+  The EFI_TCG2_PROTOCOL GetCapability function call provides protocol
+  capability information and state information.
+
+  @param[in]      This               Indicates the calling context
+  @param[in, out] ProtocolCapability The caller allocates memory for a EFI_TCG2_BOOT_SERVICE_CAPABILITY
+                                     structure and sets the size field to the size of the structure allocated.
+                                     The callee fills in the fields with the EFI protocol capability information
+                                     and the current EFI TCG2 state information up to the number of fields which
+                                     fit within the size of the structure passed in.
+
+  @retval EFI_SUCCESS            Operation completed successfully.
+  @retval EFI_DEVICE_ERROR       The command was unsuccessful.
+                                 The ProtocolCapability variable will not be populated.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect.
+                                 The ProtocolCapability variable will not be populated.
+  @retval EFI_BUFFER_TOO_SMALL   The ProtocolCapability variable is too small to hold the full response.
+                                 It will be partially populated (required Size field will be set).
+**/
+EFI_STATUS
+EFIAPI
+Tcg2GetCapability (
+  IN EFI_TCG2_PROTOCOL                     *This,
+  IN OUT EFI_TCG2_BOOT_SERVICE_CAPABILITY  *ProtocolCapability
+  )
+{
+  DEBUG ((DEBUG_VERBOSE, "Tcg2GetCapability ...\n"));
+
+  if ((This == NULL) || (ProtocolCapability == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "Size - 0x%x\n", ProtocolCapability->Size));
+  DEBUG ((DEBUG_VERBOSE, " 1.1 - 0x%x, 1.0 - 0x%x\n", sizeof (EFI_TCG2_BOOT_SERVICE_CAPABILITY), sizeof (TREE_BOOT_SERVICE_CAPABILITY_1_0)));
+
+  if (ProtocolCapability->Size < mTcgDxeData.BsCap.Size) {
+    //
+    // Handle the case that firmware support 1.1 but OS only support 1.0.
+    //
+    if ((mTcgDxeData.BsCap.ProtocolVersion.Major > 0x01) ||
+        ((mTcgDxeData.BsCap.ProtocolVersion.Major == 0x01) && ((mTcgDxeData.BsCap.ProtocolVersion.Minor > 0x00))))
+    {
+      if (ProtocolCapability->Size >= sizeof (TREE_BOOT_SERVICE_CAPABILITY_1_0)) {
+        CopyMem (ProtocolCapability, &mTcgDxeData.BsCap, sizeof (TREE_BOOT_SERVICE_CAPABILITY_1_0));
+        ProtocolCapability->Size                   = sizeof (TREE_BOOT_SERVICE_CAPABILITY_1_0);
+        ProtocolCapability->StructureVersion.Major = 1;
+        ProtocolCapability->StructureVersion.Minor = 0;
+        ProtocolCapability->ProtocolVersion.Major  = 1;
+        ProtocolCapability->ProtocolVersion.Minor  = 0;
+        DEBUG ((DEBUG_ERROR, "TreeGetCapability (Compatible) - %r\n", EFI_SUCCESS));
+        return EFI_SUCCESS;
+      }
+    }
+
+    ProtocolCapability->Size = mTcgDxeData.BsCap.Size;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  CopyMem (ProtocolCapability, &mTcgDxeData.BsCap, mTcgDxeData.BsCap.Size);
+  DEBUG ((DEBUG_VERBOSE, "Tcg2GetCapability - %r\n", EFI_SUCCESS));
+  return EFI_SUCCESS;
+}
+
+/**
+  This function dump PCR event.
+
+  @param[in]  EventHdr     TCG PCR event structure.
+**/
+VOID
+DumpEvent (
+  IN TCG_PCR_EVENT_HDR  *EventHdr
+  )
+{
+  UINTN  Index;
+
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", EventHdr->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", EventHdr->EventType));
+  DEBUG ((DEBUG_INFO, "    Digest    - "));
+  for (Index = 0; Index < sizeof (TCG_DIGEST); Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", EventHdr->Digest.digest[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventHdr->EventSize));
+  InternalDumpHex ((UINT8 *)(EventHdr + 1), EventHdr->EventSize);
+}
+
+/**
+  This function dump TCG_EfiSpecIDEventStruct.
+
+  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+**/
+VOID
+DumpTcgEfiSpecIdEventStruct (
+  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+  )
+{
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  UINTN                            Index;
+  UINT8                            *VendorInfoSize;
+  UINT8                            *VendorInfo;
+  UINT32                           NumberOfAlgorithms;
+
+  DEBUG ((DEBUG_INFO, "  TCG_EfiSpecIDEventStruct:\n"));
+  DEBUG ((DEBUG_INFO, "    signature          - '"));
+  for (Index = 0; Index < sizeof (TcgEfiSpecIdEventStruct->signature); Index++) {
+    DEBUG ((DEBUG_INFO, "%c", TcgEfiSpecIdEventStruct->signature[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "'\n"));
+  DEBUG ((DEBUG_INFO, "    platformClass      - 0x%08x\n", TcgEfiSpecIdEventStruct->platformClass));
+  DEBUG ((DEBUG_INFO, "    specVersion        - %d.%d%d\n", TcgEfiSpecIdEventStruct->specVersionMajor, TcgEfiSpecIdEventStruct->specVersionMinor, TcgEfiSpecIdEventStruct->specErrata));
+  DEBUG ((DEBUG_INFO, "    uintnSize          - 0x%02x\n", TcgEfiSpecIdEventStruct->uintnSize));
+
+  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+  DEBUG ((DEBUG_INFO, "    NumberOfAlgorithms - 0x%08x\n", NumberOfAlgorithms));
+
+  DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+  for (Index = 0; Index < NumberOfAlgorithms; Index++) {
+    DEBUG ((DEBUG_INFO, "    digest(%d)\n", Index));
+    DEBUG ((DEBUG_INFO, "      algorithmId      - 0x%04x\n", DigestSize[Index].algorithmId));
+    DEBUG ((DEBUG_INFO, "      digestSize       - 0x%04x\n", DigestSize[Index].digestSize));
+  }
+
+  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+  DEBUG ((DEBUG_INFO, "    VendorInfoSize     - 0x%02x\n", *VendorInfoSize));
+  VendorInfo = VendorInfoSize + 1;
+  DEBUG ((DEBUG_INFO, "    VendorInfo         - "));
+  for (Index = 0; Index < *VendorInfoSize; Index++) {
+    DEBUG ((DEBUG_INFO, "%02x ", VendorInfo[Index]));
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+}
+
+/**
+  This function get size of TCG_EfiSpecIDEventStruct.
+
+  @param[in]  TcgEfiSpecIdEventStruct     A pointer to TCG_EfiSpecIDEventStruct.
+**/
+UINTN
+GetTcgEfiSpecIdEventStructSize (
+  IN TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct
+  )
+{
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  UINT8                            *VendorInfoSize;
+  UINT32                           NumberOfAlgorithms;
+
+  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+
+  DigestSize     = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+  VendorInfoSize = (UINT8 *)&DigestSize[NumberOfAlgorithms];
+  return sizeof (TCG_EfiSpecIDEventStruct) + sizeof (UINT32) + (NumberOfAlgorithms * sizeof (TCG_EfiSpecIdEventAlgorithmSize)) + sizeof (UINT8) + (*VendorInfoSize);
+}
+
+/**
+  This function dump PCR event 2.
+
+  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+**/
+VOID
+DumpEvent2 (
+  IN TCG_PCR_EVENT2  *TcgPcrEvent2
+  )
+{
+  UINTN          Index;
+  UINT32         DigestIndex;
+  UINT32         DigestCount;
+  TPMI_ALG_HASH  HashAlgo;
+  UINT32         DigestSize;
+  UINT8          *DigestBuffer;
+  UINT32         EventSize;
+  UINT8          *EventBuffer;
+
+  DEBUG ((DEBUG_INFO, "  Event:\n"));
+  DEBUG ((DEBUG_INFO, "    PCRIndex  - %d\n", TcgPcrEvent2->PCRIndex));
+  DEBUG ((DEBUG_INFO, "    EventType - 0x%08x\n", TcgPcrEvent2->EventType));
+
+  DEBUG ((DEBUG_INFO, "    DigestCount: 0x%08x\n", TcgPcrEvent2->Digest.count));
+
+  DigestCount  = TcgPcrEvent2->Digest.count;
+  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+    DEBUG ((DEBUG_INFO, "      HashAlgo : 0x%04x\n", HashAlgo));
+    DEBUG ((DEBUG_INFO, "      Digest(%d): ", DigestIndex));
+    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    for (Index = 0; Index < DigestSize; Index++) {
+      DEBUG ((DEBUG_INFO, "%02x ", DigestBuffer[Index]));
+    }
+
+    DEBUG ((DEBUG_INFO, "\n"));
+    //
+    // Prepare next
+    //
+    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+  }
+
+  DEBUG ((DEBUG_INFO, "\n"));
+  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+
+  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  DEBUG ((DEBUG_INFO, "    EventSize - 0x%08x\n", EventSize));
+  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+  InternalDumpHex (EventBuffer, EventSize);
+}
+
+/**
+  This function returns size of TCG PCR event 2.
+
+  @param[in]  TcgPcrEvent2     TCG PCR event 2 structure.
+
+  @return size of TCG PCR event 2.
+**/
+UINTN
+GetPcrEvent2Size (
+  IN TCG_PCR_EVENT2  *TcgPcrEvent2
+  )
+{
+  UINT32         DigestIndex;
+  UINT32         DigestCount;
+  TPMI_ALG_HASH  HashAlgo;
+  UINT32         DigestSize;
+  UINT8          *DigestBuffer;
+  UINT32         EventSize;
+  UINT8          *EventBuffer;
+
+  DigestCount  = TcgPcrEvent2->Digest.count;
+  HashAlgo     = TcgPcrEvent2->Digest.digests[0].hashAlg;
+  DigestBuffer = (UINT8 *)&TcgPcrEvent2->Digest.digests[0].digest;
+  for (DigestIndex = 0; DigestIndex < DigestCount; DigestIndex++) {
+    DigestSize = GetHashSizeFromAlgo (HashAlgo);
+    //
+    // Prepare next
+    //
+    CopyMem (&HashAlgo, DigestBuffer + DigestSize, sizeof (TPMI_ALG_HASH));
+    DigestBuffer = DigestBuffer + DigestSize + sizeof (TPMI_ALG_HASH);
+  }
+
+  DigestBuffer = DigestBuffer - sizeof (TPMI_ALG_HASH);
+
+  CopyMem (&EventSize, DigestBuffer, sizeof (TcgPcrEvent2->EventSize));
+  EventBuffer = DigestBuffer + sizeof (TcgPcrEvent2->EventSize);
+
+  return (UINTN)EventBuffer + EventSize - (UINTN)TcgPcrEvent2;
+}
+
+/**
+  This function dump event log.
+
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[in]  EventLogLocation   A pointer to the memory address of the event log.
+  @param[in]  EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[in]  FinalEventsTable   A pointer to the memory address of the final event table.
+**/
+VOID
+DumpEventLog (
+  IN EFI_TCG2_EVENT_LOG_FORMAT    EventLogFormat,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLocation,
+  IN EFI_PHYSICAL_ADDRESS         EventLogLastEntry,
+  IN EFI_TCG2_FINAL_EVENTS_TABLE  *FinalEventsTable
+  )
+{
+  TCG_PCR_EVENT_HDR         *EventHdr;
+  TCG_PCR_EVENT2            *TcgPcrEvent2;
+  TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
+  UINTN                     NumberOfEvents;
+
+  DEBUG ((DEBUG_INFO, "EventLogFormat: (0x%x)\n", EventLogFormat));
+
+  switch (EventLogFormat) {
+    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+      while ((UINTN)EventHdr <= EventLogLastEntry) {
+        DumpEvent (EventHdr);
+        EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+      }
+
+      if (FinalEventsTable == NULL) {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+      } else {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+
+        EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)(FinalEventsTable + 1);
+        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+          DumpEvent (EventHdr);
+          EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
+        }
+      }
+
+      break;
+    case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+      //
+      // Dump first event
+      //
+      EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
+      DumpEvent (EventHdr);
+
+      TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)(EventHdr + 1);
+      DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
+
+      TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
+      while ((UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+        DumpEvent2 (TcgPcrEvent2);
+        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+      }
+
+      if (FinalEventsTable == NULL) {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable: NOT FOUND\n"));
+      } else {
+        DEBUG ((DEBUG_INFO, "FinalEventsTable:    (0x%x)\n", FinalEventsTable));
+        DEBUG ((DEBUG_INFO, "  Version:           (0x%x)\n", FinalEventsTable->Version));
+        DEBUG ((DEBUG_INFO, "  NumberOfEvents:    (0x%x)\n", FinalEventsTable->NumberOfEvents));
+
+        TcgPcrEvent2 = (TCG_PCR_EVENT2 *)(UINTN)(FinalEventsTable + 1);
+        for (NumberOfEvents = 0; NumberOfEvents < FinalEventsTable->NumberOfEvents; NumberOfEvents++) {
+          DumpEvent2 (TcgPcrEvent2);
+          TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
+        }
+      }
+
+      break;
+  }
+
+  return;
+}
+
+/**
+  The EFI_TCG2_PROTOCOL Get Event Log function call allows a caller to
+  retrieve the address of a given event log and its last entry.
+
+  @param[in]  This               Indicates the calling context
+  @param[in]  EventLogFormat     The type of the event log for which the information is requested.
+  @param[out] EventLogLocation   A pointer to the memory address of the event log.
+  @param[out] EventLogLastEntry  If the Event Log contains more than one entry, this is a pointer to the
+                                 address of the start of the last entry in the event log in memory.
+  @param[out] EventLogTruncated  If the Event Log is missing at least one entry because an event would
+                                 have exceeded the area allocated for events, this value is set to TRUE.
+                                 Otherwise, the value will be FALSE and the Event Log will be complete.
+
+  @retval EFI_SUCCESS            Operation completed successfully.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect
+                                 (e.g. asking for an event log whose format is not supported).
+**/
+EFI_STATUS
+EFIAPI
+Tcg2GetEventLog (
+  IN EFI_TCG2_PROTOCOL          *This,
+  IN EFI_TCG2_EVENT_LOG_FORMAT  EventLogFormat,
+  OUT EFI_PHYSICAL_ADDRESS      *EventLogLocation,
+  OUT EFI_PHYSICAL_ADDRESS      *EventLogLastEntry,
+  OUT BOOLEAN                   *EventLogTruncated
+  )
+{
+  UINTN  Index;
+
+  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog ... (0x%x)\n", EventLogFormat));
+
+  if (This == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if (EventLogFormat == mTcg2EventInfo[Index].LogFormat) {
+      break;
+    }
+  }
+
+  if (Index == sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0])) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((mTcg2EventInfo[Index].LogFormat & mTcgDxeData.BsCap.SupportedEventLogs) == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!mTcgDxeData.BsCap.TPMPresentFlag) {
+    if (EventLogLocation != NULL) {
+      *EventLogLocation = 0;
+    }
+
+    if (EventLogLastEntry != NULL) {
+      *EventLogLastEntry = 0;
+    }
+
+    if (EventLogTruncated != NULL) {
+      *EventLogTruncated = FALSE;
+    }
+
+    return EFI_SUCCESS;
+  }
+
+  if (EventLogLocation != NULL) {
+    *EventLogLocation = mTcgDxeData.EventLogAreaStruct[Index].Lasa;
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLocation - %x)\n", *EventLogLocation));
+  }
+
+  if (EventLogLastEntry != NULL) {
+    if (!mTcgDxeData.EventLogAreaStruct[Index].EventLogStarted) {
+      *EventLogLastEntry = (EFI_PHYSICAL_ADDRESS)(UINTN)0;
+    } else {
+      *EventLogLastEntry = (EFI_PHYSICAL_ADDRESS)(UINTN)mTcgDxeData.EventLogAreaStruct[Index].LastEvent;
+    }
+
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogLastEntry - %x)\n", *EventLogLastEntry));
+  }
+
+  if (EventLogTruncated != NULL) {
+    *EventLogTruncated = mTcgDxeData.EventLogAreaStruct[Index].EventLogTruncated;
+    DEBUG ((DEBUG_INFO, "Tcg2GetEventLog (EventLogTruncated - %x)\n", *EventLogTruncated));
+  }
+
+  DEBUG ((DEBUG_INFO, "Tcg2GetEventLog - %r\n", EFI_SUCCESS));
+
+  // Dump Event Log for debug purpose
+  if ((EventLogLocation != NULL) && (EventLogLastEntry != NULL)) {
+    DumpEventLog (EventLogFormat, *EventLogLocation, *EventLogLastEntry, mTcgDxeData.FinalEventsTable[Index]);
+  }
+
+  //
+  // All events generated after the invocation of EFI_TCG2_GET_EVENT_LOG SHALL be stored
+  // in an instance of an EFI_CONFIGURATION_TABLE named by the VendorGuid of EFI_TCG2_FINAL_EVENTS_TABLE_GUID.
+  //
+  mTcgDxeData.GetEventLogCalled[Index] = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Return if this is a Tcg800155PlatformIdEvent.
+
+  @param[in]      NewEventHdr         Pointer to a TCG_PCR_EVENT_HDR/TCG_PCR_EVENT_EX data structure.
+  @param[in]      NewEventHdrSize     New event header size.
+  @param[in]      NewEventData        Pointer to the new event data.
+  @param[in]      NewEventSize        New event data size.
+
+  @retval TRUE   This is a Tcg800155PlatformIdEvent.
+  @retval FALSE  This is NOT a Tcg800155PlatformIdEvent.
+
+**/
+BOOLEAN
+Is800155Event (
+  IN      VOID    *NewEventHdr,
+  IN      UINT32  NewEventHdrSize,
+  IN      UINT8   *NewEventData,
+  IN      UINT32  NewEventSize
+  )
+{
+  if ((((TCG_PCR_EVENT2_HDR *)NewEventHdr)->EventType == EV_NO_ACTION) &&
+      (NewEventSize >= sizeof (TCG_Sp800_155_PlatformId_Event2)) &&
+      ((CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event2_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event2_SIGNATURE) - 1
+          ) == 0) ||
+       (CompareMem (
+          NewEventData,
+          TCG_Sp800_155_PlatformId_Event3_SIGNATURE,
+          sizeof (TCG_Sp800_155_PlatformId_Event3_SIGNATURE) - 1
+          ) == 0)))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Add a new entry to the Event Log.
+
+  @param[in, out] EventLogAreaStruct  The event log area data structure
+  @param[in]      NewEventHdr         Pointer to a TCG_PCR_EVENT_HDR/TCG_PCR_EVENT_EX data structure.
+  @param[in]      NewEventHdrSize     New event header size.
+  @param[in]      NewEventData        Pointer to the new event data.
+  @param[in]      NewEventSize        New event data size.
+
+  @retval EFI_SUCCESS           The new event log entry was added.
+  @retval EFI_OUT_OF_RESOURCES  No enough memory to log the new event.
+
+**/
+EFI_STATUS
+TcgCommLogEvent (
+  IN OUT  TCG_EVENT_LOG_AREA_STRUCT  *EventLogAreaStruct,
+  IN      VOID                       *NewEventHdr,
+  IN      UINT32                     NewEventHdrSize,
+  IN      UINT8                      *NewEventData,
+  IN      UINT32                     NewEventSize
+  )
+{
+  UINTN    NewLogSize;
+  BOOLEAN  Record800155Event;
+
+  if (NewEventSize > MAX_ADDRESS -  NewEventHdrSize) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewLogSize = NewEventHdrSize + NewEventSize;
+
+  if (NewLogSize > MAX_ADDRESS -  EventLogAreaStruct->EventLogSize) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  if (NewLogSize + EventLogAreaStruct->EventLogSize > EventLogAreaStruct->Laml) {
+    DEBUG ((DEBUG_INFO, "  Laml       - 0x%x\n", EventLogAreaStruct->Laml));
+    DEBUG ((DEBUG_INFO, "  NewLogSize - 0x%x\n", NewLogSize));
+    DEBUG ((DEBUG_INFO, "  LogSize    - 0x%x\n", EventLogAreaStruct->EventLogSize));
+    DEBUG ((DEBUG_INFO, "TcgCommLogEvent - %r\n", EFI_OUT_OF_RESOURCES));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Check 800-155 event
+  // Record to 800-155 event offset only.
+  // If the offset is 0, no need to record.
+  //
+  Record800155Event = Is800155Event (NewEventHdr, NewEventHdrSize, NewEventData, NewEventSize);
+  if (Record800155Event) {
+    if (EventLogAreaStruct->Next800155EventOffset != 0) {
+      CopyMem (
+        (UINT8 *)(UINTN)EventLogAreaStruct->Lasa + EventLogAreaStruct->Next800155EventOffset + NewLogSize,
+        (UINT8 *)(UINTN)EventLogAreaStruct->Lasa + EventLogAreaStruct->Next800155EventOffset,
+        EventLogAreaStruct->EventLogSize - EventLogAreaStruct->Next800155EventOffset
+        );
+
+      CopyMem (
+        (UINT8 *)(UINTN)EventLogAreaStruct->Lasa + EventLogAreaStruct->Next800155EventOffset,
+        NewEventHdr,
+        NewEventHdrSize
+        );
+      CopyMem (
+        (UINT8 *)(UINTN)EventLogAreaStruct->Lasa + EventLogAreaStruct->Next800155EventOffset + NewEventHdrSize,
+        NewEventData,
+        NewEventSize
+        );
+
+      EventLogAreaStruct->Next800155EventOffset += NewLogSize;
+      EventLogAreaStruct->LastEvent             += NewLogSize;
+      EventLogAreaStruct->EventLogSize          += NewLogSize;
+    }
+
+    return EFI_SUCCESS;
+  }
+
+  EventLogAreaStruct->LastEvent     = (UINT8 *)(UINTN)EventLogAreaStruct->Lasa + EventLogAreaStruct->EventLogSize;
+  EventLogAreaStruct->EventLogSize += NewLogSize;
+  CopyMem (EventLogAreaStruct->LastEvent, NewEventHdr, NewEventHdrSize);
+  CopyMem (
+    EventLogAreaStruct->LastEvent + NewEventHdrSize,
+    NewEventData,
+    NewEventSize
+    );
+  return EFI_SUCCESS;
+}
+
+/**
+  Add a new entry to the Event Log.
+
+  @param[in] EventLogFormat  The type of the event log for which the information is requested.
+  @param[in] NewEventHdr     Pointer to a TCG_PCR_EVENT_HDR/TCG_PCR_EVENT_EX data structure.
+  @param[in] NewEventHdrSize New event header size.
+  @param[in] NewEventData    Pointer to the new event data.
+  @param[in] NewEventSize    New event data size.
+
+  @retval EFI_SUCCESS           The new event log entry was added.
+  @retval EFI_OUT_OF_RESOURCES  No enough memory to log the new event.
+
+**/
+EFI_STATUS
+TcgDxeLogEvent (
+  IN      EFI_TCG2_EVENT_LOG_FORMAT  EventLogFormat,
+  IN      VOID                       *NewEventHdr,
+  IN      UINT32                     NewEventHdrSize,
+  IN      UINT8                      *NewEventData,
+  IN      UINT32                     NewEventSize
+  )
+{
+  EFI_STATUS                 Status;
+  UINTN                      Index;
+  TCG_EVENT_LOG_AREA_STRUCT  *EventLogAreaStruct;
+
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if (EventLogFormat == mTcg2EventInfo[Index].LogFormat) {
+      break;
+    }
+  }
+
+  if (Index == sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0])) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Record to normal event log
+  //
+  EventLogAreaStruct = &mTcgDxeData.EventLogAreaStruct[Index];
+
+  if (EventLogAreaStruct->EventLogTruncated) {
+    return EFI_VOLUME_FULL;
+  }
+
+  Status = TcgCommLogEvent (
+             EventLogAreaStruct,
+             NewEventHdr,
+             NewEventHdrSize,
+             NewEventData,
+             NewEventSize
+             );
+
+  if (Status == EFI_OUT_OF_RESOURCES) {
+    EventLogAreaStruct->EventLogTruncated = TRUE;
+    return EFI_VOLUME_FULL;
+  } else if (Status == EFI_SUCCESS) {
+    EventLogAreaStruct->EventLogStarted = TRUE;
+  }
+
+  //
+  // If GetEventLog is called, record to FinalEventsTable, too.
+  //
+  if (mTcgDxeData.GetEventLogCalled[Index]) {
+    if (mTcgDxeData.FinalEventsTable[Index] == NULL) {
+      //
+      // no need for FinalEventsTable
+      //
+      return EFI_SUCCESS;
+    }
+
+    EventLogAreaStruct = &mTcgDxeData.FinalEventLogAreaStruct[Index];
+
+    if (EventLogAreaStruct->EventLogTruncated) {
+      return EFI_VOLUME_FULL;
+    }
+
+    Status = TcgCommLogEvent (
+               EventLogAreaStruct,
+               NewEventHdr,
+               NewEventHdrSize,
+               NewEventData,
+               NewEventSize
+               );
+    if (Status == EFI_OUT_OF_RESOURCES) {
+      EventLogAreaStruct->EventLogTruncated = TRUE;
+      return EFI_VOLUME_FULL;
+    } else if (Status == EFI_SUCCESS) {
+      EventLogAreaStruct->EventLogStarted = TRUE;
+      //
+      // Increase the NumberOfEvents in FinalEventsTable
+      //
+      (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents++;
+      DEBUG ((DEBUG_INFO, "FinalEventsTable->NumberOfEvents - 0x%x\n", (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents));
+      DEBUG ((DEBUG_INFO, "  Size - 0x%x\n", (UINTN)EventLogAreaStruct->EventLogSize));
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Get TPML_DIGEST_VALUES compact binary buffer size.
+
+  @param[in]     DigestListBin    TPML_DIGEST_VALUES compact binary buffer.
+
+  @return TPML_DIGEST_VALUES compact binary buffer size.
+**/
+UINT32
+GetDigestListBinSize (
+  IN VOID  *DigestListBin
+  )
+{
+  UINTN          Index;
+  UINT16         DigestSize;
+  UINT32         TotalSize;
+  UINT32         Count;
+  TPMI_ALG_HASH  HashAlg;
+
+  Count         = ReadUnaligned32 (DigestListBin);
+  TotalSize     = sizeof (Count);
+  DigestListBin = (UINT8 *)DigestListBin + sizeof (Count);
+  for (Index = 0; Index < Count; Index++) {
+    HashAlg       = ReadUnaligned16 (DigestListBin);
+    TotalSize    += sizeof (HashAlg);
+    DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
+
+    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+    TotalSize    += DigestSize;
+    DigestListBin = (UINT8 *)DigestListBin + DigestSize;
+  }
+
+  return TotalSize;
+}
+
+/**
+  Copy TPML_DIGEST_VALUES compact binary into a buffer
+
+  @param[in,out]    Buffer                  Buffer to hold copied TPML_DIGEST_VALUES compact binary.
+  @param[in]        DigestListBin           TPML_DIGEST_VALUES compact binary buffer.
+  @param[in]        HashAlgorithmMask       HASH bits corresponding to the desired digests to copy.
+  @param[out]       HashAlgorithmMaskCopied Pointer to HASH bits corresponding to the digests copied.
+
+  @return The end of buffer to hold TPML_DIGEST_VALUES compact binary.
+**/
+VOID *
+CopyDigestListBinToBuffer (
+  IN OUT VOID  *Buffer,
+  IN VOID      *DigestListBin,
+  IN UINT32    HashAlgorithmMask,
+  OUT UINT32   *HashAlgorithmMaskCopied
+  )
+{
+  UINTN          Index;
+  UINT16         DigestSize;
+  UINT32         Count;
+  TPMI_ALG_HASH  HashAlg;
+  UINT32         DigestListCount;
+  UINT32         *DigestListCountPtr;
+
+  DigestListCountPtr         = (UINT32 *)Buffer;
+  DigestListCount            = 0;
+  (*HashAlgorithmMaskCopied) = 0;
+
+  Count         = ReadUnaligned32 (DigestListBin);
+  Buffer        = (UINT8 *)Buffer + sizeof (Count);
+  DigestListBin = (UINT8 *)DigestListBin + sizeof (Count);
+  for (Index = 0; Index < Count; Index++) {
+    HashAlg       = ReadUnaligned16 (DigestListBin);
+    DigestListBin = (UINT8 *)DigestListBin + sizeof (HashAlg);
+    DigestSize    = GetHashSizeFromAlgo (HashAlg);
+
+    if (IsHashAlgSupportedInHashAlgorithmMask (HashAlg, HashAlgorithmMask)) {
+      CopyMem (Buffer, &HashAlg, sizeof (HashAlg));
+      Buffer = (UINT8 *)Buffer + sizeof (HashAlg);
+      CopyMem (Buffer, DigestListBin, DigestSize);
+      Buffer = (UINT8 *)Buffer + DigestSize;
+      DigestListCount++;
+      (*HashAlgorithmMaskCopied) |= GetHashMaskFromAlgo (HashAlg);
+    } else {
+      DEBUG ((DEBUG_ERROR, "WARNING: CopyDigestListBinToBuffer Event log has HashAlg unsupported by PCR bank (0x%x)\n", HashAlg));
+    }
+
+    DigestListBin = (UINT8 *)DigestListBin + DigestSize;
+  }
+
+  WriteUnaligned32 (DigestListCountPtr, DigestListCount);
+
+  return Buffer;
+}
+
+/**
+  Add a new entry to the Event Log.
+
+  @param[in]     DigestList    A list of digest.
+  @param[in,out] NewEventHdr   Pointer to a TCG_PCR_EVENT_HDR data structure.
+  @param[in]     NewEventData  Pointer to the new event data.
+
+  @retval EFI_SUCCESS           The new event log entry was added.
+  @retval EFI_OUT_OF_RESOURCES  No enough memory to log the new event.
+**/
+EFI_STATUS
+TcgDxeLogHashEvent (
+  IN TPML_DIGEST_VALUES      *DigestList,
+  IN OUT  TCG_PCR_EVENT_HDR  *NewEventHdr,
+  IN      UINT8              *NewEventData
+  )
+{
+  EFI_STATUS      Status;
+  EFI_TPL         OldTpl;
+  UINTN           Index;
+  EFI_STATUS      RetStatus;
+  TCG_PCR_EVENT2  TcgPcrEvent2;
+  UINT8           *DigestBuffer;
+  UINT32          *EventSizePtr;
+
+  DEBUG ((DEBUG_INFO, "SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
+
+  RetStatus = EFI_SUCCESS;
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
+      DEBUG ((DEBUG_INFO, "  LogFormat - 0x%08x\n", mTcg2EventInfo[Index].LogFormat));
+      switch (mTcg2EventInfo[Index].LogFormat) {
+        case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+          Status = GetDigestFromDigestList (TPM_ALG_SHA1, DigestList, &NewEventHdr->Digest);
+          if (!EFI_ERROR (Status)) {
+            //
+            // Enter critical region
+            //
+            OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+            Status = TcgDxeLogEvent (
+                       mTcg2EventInfo[Index].LogFormat,
+                       NewEventHdr,
+                       sizeof (TCG_PCR_EVENT_HDR),
+                       NewEventData,
+                       NewEventHdr->EventSize
+                       );
+            if (Status != EFI_SUCCESS) {
+              RetStatus = Status;
+            }
+
+            gBS->RestoreTPL (OldTpl);
+            //
+            // Exit critical region
+            //
+          }
+
+          break;
+        case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+          ZeroMem (&TcgPcrEvent2, sizeof (TcgPcrEvent2));
+          TcgPcrEvent2.PCRIndex  = NewEventHdr->PCRIndex;
+          TcgPcrEvent2.EventType = NewEventHdr->EventType;
+          DigestBuffer           = (UINT8 *)&TcgPcrEvent2.Digest;
+          EventSizePtr           = CopyDigestListToBuffer (DigestBuffer, DigestList, mTcgDxeData.BsCap.ActivePcrBanks);
+          CopyMem (EventSizePtr, &NewEventHdr->EventSize, sizeof (NewEventHdr->EventSize));
+
+          //
+          // Enter critical region
+          //
+          OldTpl = gBS->RaiseTPL (TPL_HIGH_LEVEL);
+          Status = TcgDxeLogEvent (
+                     mTcg2EventInfo[Index].LogFormat,
+                     &TcgPcrEvent2,
+                     sizeof (TcgPcrEvent2.PCRIndex) + sizeof (TcgPcrEvent2.EventType) + GetDigestListBinSize (DigestBuffer) + sizeof (TcgPcrEvent2.EventSize),
+                     NewEventData,
+                     NewEventHdr->EventSize
+                     );
+          if (Status != EFI_SUCCESS) {
+            RetStatus = Status;
+          }
+
+          gBS->RestoreTPL (OldTpl);
+          //
+          // Exit critical region
+          //
+          break;
+      }
+    }
+  }
+
+  return RetStatus;
+}
+
+/**
+  Do a hash operation on a data buffer, extend a specific TPM PCR with the hash result,
+  and add an entry to the Event Log.
+
+  @param[in]      Flags         Bitmap providing additional information.
+  @param[in]      HashData      Physical address of the start of the data buffer
+                                to be hashed, extended, and logged.
+  @param[in]      HashDataLen   The length, in bytes, of the buffer referenced by HashData
+  @param[in, out] NewEventHdr   Pointer to a TCG_PCR_EVENT_HDR data structure.
+  @param[in]      NewEventData  Pointer to the new event data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  No enough memory to log the new event.
+  @retval EFI_DEVICE_ERROR      The command was unsuccessful.
+
+**/
+EFI_STATUS
+TcgDxeHashLogExtendEvent (
+  IN      UINT64             Flags,
+  IN      UINT8              *HashData,
+  IN      UINT64             HashDataLen,
+  IN OUT  TCG_PCR_EVENT_HDR  *NewEventHdr,
+  IN      UINT8              *NewEventData
+  )
+{
+  EFI_STATUS          Status;
+  TPML_DIGEST_VALUES  DigestList;
+  TCG_PCR_EVENT2_HDR  NoActionEvent;
+
+  if (!mTcgDxeData.BsCap.TPMPresentFlag) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (NewEventHdr->EventType == EV_NO_ACTION) {
+    //
+    // Do not do TPM extend for EV_NO_ACTION
+    //
+    if (NewEventHdr->PCRIndex <= MAX_PCR_INDEX) {
+      Status = EFI_SUCCESS;
+      InitNoActionEvent (&NoActionEvent, NewEventHdr->EventSize);
+      if ((Flags & EFI_TCG2_EXTEND_ONLY) == 0) {
+        Status = TcgDxeLogHashEvent (&(NoActionEvent.Digests), NewEventHdr, NewEventData);
+      }
+    } else {
+      //
+      // Extend to NvIndex
+      //
+      Status = HashAndExtend (
+                 NewEventHdr->PCRIndex,
+                 HashData,
+                 (UINTN)HashDataLen,
+                 &DigestList
+                 );
+      if (!EFI_ERROR (Status)) {
+        Status = TcgDxeLogHashEvent (&DigestList, NewEventHdr, NewEventData);
+      }
+    }
+
+    return Status;
+  }
+
+  Status = HashAndExtend (
+             NewEventHdr->PCRIndex,
+             HashData,
+             (UINTN)HashDataLen,
+             &DigestList
+             );
+  if (!EFI_ERROR (Status)) {
+    if ((Flags & EFI_TCG2_EXTEND_ONLY) == 0) {
+      Status = TcgDxeLogHashEvent (&DigestList, NewEventHdr, NewEventData);
+    }
+  }
+
+  if (Status == EFI_DEVICE_ERROR) {
+    DEBUG ((DEBUG_ERROR, "TcgDxeHashLogExtendEvent - %r. Disable TPM.\n", Status));
+    mTcgDxeData.BsCap.TPMPresentFlag = FALSE;
+    REPORT_STATUS_CODE (
+      EFI_ERROR_CODE | EFI_ERROR_MINOR,
+      (PcdGet32 (PcdStatusCodeSubClassTpmDevice) | EFI_P_EC_INTERFACE_ERROR)
+      );
+  }
+
+  return Status;
+}
+
+/**
+  The EFI_TCG2_PROTOCOL HashLogExtendEvent function call provides callers with
+  an opportunity to extend and optionally log events without requiring
+  knowledge of actual TPM commands.
+  The extend operation will occur even if this function cannot create an event
+  log entry (e.g. due to the event log being full).
+
+  @param[in]  This               Indicates the calling context
+  @param[in]  Flags              Bitmap providing additional information.
+  @param[in]  DataToHash         Physical address of the start of the data buffer to be hashed.
+  @param[in]  DataToHashLen      The length in bytes of the buffer referenced by DataToHash.
+  @param[in]  Event              Pointer to data buffer containing information about the event.
+
+  @retval EFI_SUCCESS            Operation completed successfully.
+  @retval EFI_DEVICE_ERROR       The command was unsuccessful.
+  @retval EFI_VOLUME_FULL        The extend operation occurred, but the event could not be written to one or more event logs.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect.
+  @retval EFI_UNSUPPORTED        The PE/COFF image type is not supported.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2HashLogExtendEvent (
+  IN EFI_TCG2_PROTOCOL     *This,
+  IN UINT64                Flags,
+  IN EFI_PHYSICAL_ADDRESS  DataToHash,
+  IN UINT64                DataToHashLen,
+  IN EFI_TCG2_EVENT        *Event
+  )
+{
+  EFI_STATUS          Status;
+  TCG_PCR_EVENT_HDR   NewEventHdr;
+  TPML_DIGEST_VALUES  DigestList;
+
+  DEBUG ((DEBUG_VERBOSE, "Tcg2HashLogExtendEvent ...\n"));
+
+  if ((This == NULL) || (Event == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Do not check hash data size for EV_NO_ACTION event.
+  //
+  if ((Event->Header.EventType != EV_NO_ACTION) && (DataToHash == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!mTcgDxeData.BsCap.TPMPresentFlag) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (Event->Size < Event->Header.HeaderSize + sizeof (UINT32)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Event->Header.EventType != EV_NO_ACTION) && (Event->Header.PCRIndex > MAX_PCR_INDEX)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NewEventHdr.PCRIndex  = Event->Header.PCRIndex;
+  NewEventHdr.EventType = Event->Header.EventType;
+  NewEventHdr.EventSize = Event->Size - sizeof (UINT32) - Event->Header.HeaderSize;
+  if ((Flags & PE_COFF_IMAGE) != 0) {
+    Status = MeasurePeImageAndExtend (
+               NewEventHdr.PCRIndex,
+               DataToHash,
+               (UINTN)DataToHashLen,
+               &DigestList
+               );
+    if (!EFI_ERROR (Status)) {
+      if ((Flags & EFI_TCG2_EXTEND_ONLY) == 0) {
+        Status = TcgDxeLogHashEvent (&DigestList, &NewEventHdr, Event->Event);
+      }
+    }
+
+    if (Status == EFI_DEVICE_ERROR) {
+      DEBUG ((DEBUG_ERROR, "MeasurePeImageAndExtend - %r. Disable TPM.\n", Status));
+      mTcgDxeData.BsCap.TPMPresentFlag = FALSE;
+      REPORT_STATUS_CODE (
+        EFI_ERROR_CODE | EFI_ERROR_MINOR,
+        (PcdGet32 (PcdStatusCodeSubClassTpmDevice) | EFI_P_EC_INTERFACE_ERROR)
+        );
+    }
+  } else {
+    Status = TcgDxeHashLogExtendEvent (
+               Flags,
+               (UINT8 *)(UINTN)DataToHash,
+               DataToHashLen,
+               &NewEventHdr,
+               Event->Event
+               );
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "Tcg2HashLogExtendEvent - %r\n", Status));
+  return Status;
+}
+
+/**
+  This service enables the sending of commands to the TPM.
+
+  @param[in]  This                     Indicates the calling context
+  @param[in]  InputParameterBlockSize  Size of the TPM input parameter block.
+  @param[in]  InputParameterBlock      Pointer to the TPM input parameter block.
+  @param[in]  OutputParameterBlockSize Size of the TPM output parameter block.
+  @param[in]  OutputParameterBlock     Pointer to the TPM output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_INVALID_PARAMETER  One or more of the parameters are incorrect.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2SubmitCommand (
+  IN EFI_TCG2_PROTOCOL  *This,
+  IN UINT32             InputParameterBlockSize,
+  IN UINT8              *InputParameterBlock,
+  IN UINT32             OutputParameterBlockSize,
+  IN UINT8              *OutputParameterBlock
+  )
+{
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand ...\n"));
+
+  if ((This == NULL) ||
+      (InputParameterBlockSize == 0) || (InputParameterBlock == NULL) ||
+      (OutputParameterBlockSize == 0) || (OutputParameterBlock == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!mTcgDxeData.BsCap.TPMPresentFlag) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (InputParameterBlockSize > mTcgDxeData.BsCap.MaxCommandSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (OutputParameterBlockSize > mTcgDxeData.BsCap.MaxResponseSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = Tpm2SubmitCommand (
+             InputParameterBlockSize,
+             InputParameterBlock,
+             &OutputParameterBlockSize,
+             OutputParameterBlock
+             );
+  DEBUG ((DEBUG_INFO, "Tcg2SubmitCommand - %r\n", Status));
+  return Status;
+}
+
+/**
+  This service returns the currently active PCR banks.
+
+  @param[in]  This            Indicates the calling context
+  @param[out] ActivePcrBanks  Pointer to the variable receiving the bitmap of currently active PCR banks.
+
+  @retval EFI_SUCCESS           The bitmap of active PCR banks was stored in the ActivePcrBanks parameter.
+  @retval EFI_INVALID_PARAMETER One or more of the parameters are incorrect.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2GetActivePCRBanks (
+  IN  EFI_TCG2_PROTOCOL  *This,
+  OUT UINT32             *ActivePcrBanks
+  )
+{
+  if (ActivePcrBanks == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *ActivePcrBanks = mTcgDxeData.BsCap.ActivePcrBanks;
+  return EFI_SUCCESS;
+}
+
+/**
+  This service sets the currently active PCR banks.
+
+  @param[in]  This            Indicates the calling context
+  @param[in]  ActivePcrBanks  Bitmap of the requested active PCR banks. At least one bit SHALL be set.
+
+  @retval EFI_SUCCESS           The bitmap in ActivePcrBank parameter is already active.
+  @retval EFI_INVALID_PARAMETER One or more of the parameters are incorrect.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2SetActivePCRBanks (
+  IN EFI_TCG2_PROTOCOL  *This,
+  IN UINT32             ActivePcrBanks
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ReturnCode;
+
+  DEBUG ((DEBUG_INFO, "Tcg2SetActivePCRBanks ... (0x%x)\n", ActivePcrBanks));
+
+  if (ActivePcrBanks == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((ActivePcrBanks & (~mTcgDxeData.BsCap.HashAlgorithmBitmap)) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ActivePcrBanks == mTcgDxeData.BsCap.ActivePcrBanks) {
+    //
+    // Need clear previous SET_PCR_BANKS setting
+    //
+    ReturnCode = Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (TCG2_PHYSICAL_PRESENCE_NO_ACTION, 0);
+  } else {
+    ReturnCode = Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction (TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS, ActivePcrBanks);
+  }
+
+  if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_SUCCESS) {
+    Status = EFI_SUCCESS;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_GENERAL_FAILURE) {
+    Status = EFI_OUT_OF_RESOURCES;
+  } else if (ReturnCode == TCG_PP_SUBMIT_REQUEST_TO_PREOS_NOT_IMPLEMENTED) {
+    Status = EFI_UNSUPPORTED;
+  } else {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  DEBUG ((DEBUG_INFO, "Tcg2SetActivePCRBanks - %r\n", Status));
+
+  return Status;
+}
+
+/**
+  This service retrieves the result of a previous invocation of SetActivePcrBanks.
+
+  @param[in]  This              Indicates the calling context
+  @param[out] OperationPresent  Non-zero value to indicate a SetActivePcrBank operation was invoked during the last boot.
+  @param[out] Response          The response from the SetActivePcrBank request.
+
+  @retval EFI_SUCCESS           The result value could be returned.
+  @retval EFI_INVALID_PARAMETER One or more of the parameters are incorrect.
+**/
+EFI_STATUS
+EFIAPI
+Tcg2GetResultOfSetActivePcrBanks (
+  IN  EFI_TCG2_PROTOCOL  *This,
+  OUT UINT32             *OperationPresent,
+  OUT UINT32             *Response
+  )
+{
+  UINT32  ReturnCode;
+
+  if ((OperationPresent == NULL) || (Response == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ReturnCode = Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (OperationPresent, Response);
+  if (ReturnCode == TCG_PP_RETURN_TPM_OPERATION_RESPONSE_SUCCESS) {
+    return EFI_SUCCESS;
+  } else {
+    return EFI_UNSUPPORTED;
+  }
+}
+
+EFI_TCG2_PROTOCOL  mTcg2Protocol = {
+  Tcg2GetCapability,
+  Tcg2GetEventLog,
+  Tcg2HashLogExtendEvent,
+  Tcg2SubmitCommand,
+  Tcg2GetActivePCRBanks,
+  Tcg2SetActivePCRBanks,
+  Tcg2GetResultOfSetActivePcrBanks,
+};
+
+/**
+  Initialize the Event Log and log events passed from the PEI phase.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+
+**/
+EFI_STATUS
+SetupEventLog (
+  VOID
+  )
+{
+  EFI_STATUS                       Status;
+  VOID                             *TcgEvent;
+  EFI_PEI_HOB_POINTERS             GuidHob;
+  EFI_PHYSICAL_ADDRESS             Lasa;
+  UINTN                            Index;
+  VOID                             *DigestListBin;
+  TPML_DIGEST_VALUES               TempDigestListBin;
+  UINT32                           DigestListBinSize;
+  UINT8                            *Event;
+  UINT32                           EventSize;
+  UINT32                           *EventSizePtr;
+  UINT32                           HashAlgorithmMaskCopied;
+  TCG_EfiSpecIDEventStruct         *TcgEfiSpecIdEventStruct;
+  UINT8                            TempBuf[sizeof (TCG_EfiSpecIDEventStruct) + sizeof (UINT32) + (HASH_COUNT * sizeof (TCG_EfiSpecIdEventAlgorithmSize)) + sizeof (UINT8)];
+  TCG_PCR_EVENT_HDR                SpecIdEvent;
+  TCG_PCR_EVENT2_HDR               NoActionEvent;
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  TCG_EfiSpecIdEventAlgorithmSize  *TempDigestSize;
+  UINT8                            *VendorInfoSize;
+  UINT32                           NumberOfAlgorithms;
+  TCG_EfiStartupLocalityEvent      StartupLocalityEvent;
+
+  DEBUG ((DEBUG_INFO, "SetupEventLog\n"));
+
+  //
+  // 1. Create Log Area
+  //
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
+      mTcgDxeData.EventLogAreaStruct[Index].EventLogFormat = mTcg2EventInfo[Index].LogFormat;
+      if (PcdGet8 (PcdTpm2AcpiTableRev) >= 4) {
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiACPIMemoryNVS,
+                        EFI_SIZE_TO_PAGES (PcdGet32 (PcdTcgLogAreaMinLen)),
+                        &Lasa
+                        );
+      } else {
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiBootServicesData,
+                        EFI_SIZE_TO_PAGES (PcdGet32 (PcdTcgLogAreaMinLen)),
+                        &Lasa
+                        );
+      }
+
+      if (EFI_ERROR (Status)) {
+        return Status;
+      }
+
+      mTcgDxeData.EventLogAreaStruct[Index].Lasa                  = Lasa;
+      mTcgDxeData.EventLogAreaStruct[Index].Laml                  = PcdGet32 (PcdTcgLogAreaMinLen);
+      mTcgDxeData.EventLogAreaStruct[Index].Next800155EventOffset = 0;
+
+      if ((PcdGet8 (PcdTpm2AcpiTableRev) >= 4) ||
+          (mTcg2EventInfo[Index].LogFormat == EFI_TCG2_EVENT_LOG_FORMAT_TCG_2))
+      {
+        //
+        // Report TCG2 event log address and length, so that they can be reported in TPM2 ACPI table.
+        // Ignore the return status, because those fields are optional.
+        //
+        PcdSet32S (PcdTpm2AcpiTableLaml, (UINT32)mTcgDxeData.EventLogAreaStruct[Index].Laml);
+        PcdSet64S (PcdTpm2AcpiTableLasa, mTcgDxeData.EventLogAreaStruct[Index].Lasa);
+      }
+
+      //
+      // To initialize them as 0xFF is recommended
+      // because the OS can know the last entry for that.
+      //
+      SetMem ((VOID *)(UINTN)Lasa, PcdGet32 (PcdTcgLogAreaMinLen), 0xFF);
+      //
+      // Create first entry for Log Header Entry Data
+      //
+      if (mTcg2EventInfo[Index].LogFormat != EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2) {
+        //
+        // TcgEfiSpecIdEventStruct
+        //
+        TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)TempBuf;
+        CopyMem (TcgEfiSpecIdEventStruct->signature, TCG_EfiSpecIDEventStruct_SIGNATURE_03, sizeof (TcgEfiSpecIdEventStruct->signature));
+        TcgEfiSpecIdEventStruct->platformClass    = PcdGet8 (PcdTpmPlatformClass);
+        TcgEfiSpecIdEventStruct->specVersionMajor = TCG_EfiSpecIDEventStruct_SPEC_VERSION_MAJOR_TPM2;
+        TcgEfiSpecIdEventStruct->specVersionMinor = TCG_EfiSpecIDEventStruct_SPEC_VERSION_MINOR_TPM2;
+        TcgEfiSpecIdEventStruct->specErrata       = (UINT8)PcdGet32 (PcdTcgPfpMeasurementRevision);
+        TcgEfiSpecIdEventStruct->uintnSize        = sizeof (UINTN)/sizeof (UINT32);
+        NumberOfAlgorithms                        = 0;
+        DigestSize                                = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+        if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA1) != 0) {
+          TempDigestSize              = DigestSize;
+          TempDigestSize             += NumberOfAlgorithms;
+          TempDigestSize->algorithmId = TPM_ALG_SHA1;
+          TempDigestSize->digestSize  = SHA1_DIGEST_SIZE;
+          NumberOfAlgorithms++;
+        }
+
+        if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA256) != 0) {
+          TempDigestSize              = DigestSize;
+          TempDigestSize             += NumberOfAlgorithms;
+          TempDigestSize->algorithmId = TPM_ALG_SHA256;
+          TempDigestSize->digestSize  = SHA256_DIGEST_SIZE;
+          NumberOfAlgorithms++;
+        }
+
+        if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA384) != 0) {
+          TempDigestSize              = DigestSize;
+          TempDigestSize             += NumberOfAlgorithms;
+          TempDigestSize->algorithmId = TPM_ALG_SHA384;
+          TempDigestSize->digestSize  = SHA384_DIGEST_SIZE;
+          NumberOfAlgorithms++;
+        }
+
+        if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA512) != 0) {
+          TempDigestSize              = DigestSize;
+          TempDigestSize             += NumberOfAlgorithms;
+          TempDigestSize->algorithmId = TPM_ALG_SHA512;
+          TempDigestSize->digestSize  = SHA512_DIGEST_SIZE;
+          NumberOfAlgorithms++;
+        }
+
+        if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SM3_256) != 0) {
+          TempDigestSize              = DigestSize;
+          TempDigestSize             += NumberOfAlgorithms;
+          TempDigestSize->algorithmId = TPM_ALG_SM3_256;
+          TempDigestSize->digestSize  = SM3_256_DIGEST_SIZE;
+          NumberOfAlgorithms++;
+        }
+
+        CopyMem (TcgEfiSpecIdEventStruct + 1, &NumberOfAlgorithms, sizeof (NumberOfAlgorithms));
+        TempDigestSize  = DigestSize;
+        TempDigestSize += NumberOfAlgorithms;
+        VendorInfoSize  = (UINT8 *)TempDigestSize;
+        *VendorInfoSize = 0;
+
+        SpecIdEvent.PCRIndex  = 0;
+        SpecIdEvent.EventType = EV_NO_ACTION;
+        ZeroMem (&SpecIdEvent.Digest, sizeof (SpecIdEvent.Digest));
+        SpecIdEvent.EventSize = (UINT32)GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct);
+
+        //
+        // Log TcgEfiSpecIdEventStruct as the first Event. Event format is TCG_PCR_EVENT.
+        //   TCG EFI Protocol Spec. Section 5.3 Event Log Header
+        //   TCG PC Client PFP spec. Section 9.2 Measurement Event Entries and Log
+        //
+        Status = TcgDxeLogEvent (
+                   mTcg2EventInfo[Index].LogFormat,
+                   &SpecIdEvent,
+                   sizeof (SpecIdEvent),
+                   (UINT8 *)TcgEfiSpecIdEventStruct,
+                   SpecIdEvent.EventSize
+                   );
+        //
+        // record the offset at the end of 800-155 event.
+        // the future 800-155 event can be inserted here.
+        //
+        mTcgDxeData.EventLogAreaStruct[Index].Next800155EventOffset = \
+          mTcgDxeData.EventLogAreaStruct[Index].EventLogSize;
+
+        //
+        // Tcg800155PlatformIdEvent. Event format is TCG_PCR_EVENT2
+        //
+        GuidHob.Guid = GetFirstGuidHob (&gTcg800155PlatformIdEventHobGuid);
+        while (GuidHob.Guid != NULL) {
+          InitNoActionEvent (&NoActionEvent, GET_GUID_HOB_DATA_SIZE (GuidHob.Guid));
+
+          Status = TcgDxeLogEvent (
+                     mTcg2EventInfo[Index].LogFormat,
+                     &NoActionEvent,
+                     sizeof (NoActionEvent.PCRIndex) + sizeof (NoActionEvent.EventType) + GetDigestListBinSize (&NoActionEvent.Digests) + sizeof (NoActionEvent.EventSize),
+                     GET_GUID_HOB_DATA (GuidHob.Guid),
+                     GET_GUID_HOB_DATA_SIZE (GuidHob.Guid)
+                     );
+
+          GuidHob.Guid = GET_NEXT_HOB (GuidHob);
+          GuidHob.Guid = GetNextGuidHob (&gTcg800155PlatformIdEventHobGuid, GuidHob.Guid);
+        }
+
+        //
+        // EfiStartupLocalityEvent. Event format is TCG_PCR_EVENT2
+        //
+        GuidHob.Guid = GetFirstGuidHob (&gTpm2StartupLocalityHobGuid);
+        if (GuidHob.Guid != NULL) {
+          //
+          // Get Locality Indicator from StartupLocality HOB
+          //
+          StartupLocalityEvent.StartupLocality = *(UINT8 *)(GET_GUID_HOB_DATA (GuidHob.Guid));
+          CopyMem (StartupLocalityEvent.Signature, TCG_EfiStartupLocalityEvent_SIGNATURE, sizeof (StartupLocalityEvent.Signature));
+          DEBUG ((DEBUG_INFO, "SetupEventLog: Set Locality from HOB into StartupLocalityEvent 0x%02x\n", StartupLocalityEvent.StartupLocality));
+
+          //
+          // Initialize StartupLocalityEvent
+          //
+          InitNoActionEvent (&NoActionEvent, sizeof (StartupLocalityEvent));
+
+          //
+          // Log EfiStartupLocalityEvent as the second Event
+          //   TCG PC Client PFP spec. Section 9.3.4.3 Startup Locality Event
+          //
+          Status = TcgDxeLogEvent (
+                     mTcg2EventInfo[Index].LogFormat,
+                     &NoActionEvent,
+                     sizeof (NoActionEvent.PCRIndex) + sizeof (NoActionEvent.EventType) + GetDigestListBinSize (&NoActionEvent.Digests) + sizeof (NoActionEvent.EventSize),
+                     (UINT8 *)&StartupLocalityEvent,
+                     sizeof (StartupLocalityEvent)
+                     );
+        }
+      }
+    }
+  }
+
+  //
+  // 2. Create Final Log Area
+  //
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
+      if (mTcg2EventInfo[Index].LogFormat == EFI_TCG2_EVENT_LOG_FORMAT_TCG_2) {
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiACPIMemoryNVS,
+                        EFI_SIZE_TO_PAGES (PcdGet32 (PcdTcg2FinalLogAreaLen)),
+                        &Lasa
+                        );
+        if (EFI_ERROR (Status)) {
+          return Status;
+        }
+
+        SetMem ((VOID *)(UINTN)Lasa, PcdGet32 (PcdTcg2FinalLogAreaLen), 0xFF);
+
+        //
+        // Initialize
+        //
+        mTcgDxeData.FinalEventsTable[Index]                   = (VOID *)(UINTN)Lasa;
+        (mTcgDxeData.FinalEventsTable[Index])->Version        = EFI_TCG2_FINAL_EVENTS_TABLE_VERSION;
+        (mTcgDxeData.FinalEventsTable[Index])->NumberOfEvents = 0;
+
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogFormat        = mTcg2EventInfo[Index].LogFormat;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Lasa                  = Lasa + sizeof (EFI_TCG2_FINAL_EVENTS_TABLE);
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Laml                  = PcdGet32 (PcdTcg2FinalLogAreaLen) - sizeof (EFI_TCG2_FINAL_EVENTS_TABLE);
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogSize          = 0;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].LastEvent             = (VOID *)(UINTN)mTcgDxeData.FinalEventLogAreaStruct[Index].Lasa;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogStarted       = FALSE;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogTruncated     = FALSE;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Next800155EventOffset = 0;
+
+        //
+        // Install to configuration table for EFI_TCG2_EVENT_LOG_FORMAT_TCG_2
+        //
+        Status = gBS->InstallConfigurationTable (&gEfiTcg2FinalEventsTableGuid, (VOID *)mTcgDxeData.FinalEventsTable[Index]);
+        if (EFI_ERROR (Status)) {
+          return Status;
+        }
+      } else {
+        //
+        // No need to handle EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2
+        //
+        mTcgDxeData.FinalEventsTable[Index]                              = NULL;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogFormat        = mTcg2EventInfo[Index].LogFormat;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Lasa                  = 0;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Laml                  = 0;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogSize          = 0;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].LastEvent             = 0;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogStarted       = FALSE;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].EventLogTruncated     = FALSE;
+        mTcgDxeData.FinalEventLogAreaStruct[Index].Next800155EventOffset = 0;
+      }
+    }
+  }
+
+  //
+  // 3. Sync data from PEI to DXE
+  //
+  Status = EFI_SUCCESS;
+  for (Index = 0; Index < sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]); Index++) {
+    if ((mTcgDxeData.BsCap.SupportedEventLogs & mTcg2EventInfo[Index].LogFormat) != 0) {
+      GuidHob.Raw = GetHobList ();
+      Status      = EFI_SUCCESS;
+      while (!EFI_ERROR (Status) &&
+             (GuidHob.Raw = GetNextGuidHob (mTcg2EventInfo[Index].EventGuid, GuidHob.Raw)) != NULL)
+      {
+        TcgEvent = AllocateCopyPool (GET_GUID_HOB_DATA_SIZE (GuidHob.Guid), GET_GUID_HOB_DATA (GuidHob.Guid));
+        ASSERT (TcgEvent != NULL);
+        GuidHob.Raw = GET_NEXT_HOB (GuidHob);
+        switch (mTcg2EventInfo[Index].LogFormat) {
+          case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
+            Status = TcgDxeLogEvent (
+                       mTcg2EventInfo[Index].LogFormat,
+                       TcgEvent,
+                       sizeof (TCG_PCR_EVENT_HDR),
+                       ((TCG_PCR_EVENT *)TcgEvent)->Event,
+                       ((TCG_PCR_EVENT_HDR *)TcgEvent)->EventSize
+                       );
+            break;
+          case EFI_TCG2_EVENT_LOG_FORMAT_TCG_2:
+            DigestListBin     = (UINT8 *)TcgEvent + sizeof (TCG_PCRINDEX) + sizeof (TCG_EVENTTYPE);
+            DigestListBinSize = GetDigestListBinSize (DigestListBin);
+            //
+            // Save event size.
+            //
+            CopyMem (&EventSize, (UINT8 *)DigestListBin + DigestListBinSize, sizeof (UINT32));
+            Event = (UINT8 *)DigestListBin + DigestListBinSize + sizeof (UINT32);
+            //
+            // Filter inactive digest in the event2 log from PEI HOB.
+            //
+            CopyMem (&TempDigestListBin, DigestListBin, GetDigestListBinSize (DigestListBin));
+            EventSizePtr = CopyDigestListBinToBuffer (
+                             DigestListBin,
+                             &TempDigestListBin,
+                             mTcgDxeData.BsCap.ActivePcrBanks,
+                             &HashAlgorithmMaskCopied
+                             );
+            if (HashAlgorithmMaskCopied != mTcgDxeData.BsCap.ActivePcrBanks) {
+              DEBUG ((
+                DEBUG_ERROR,
+                "ERROR: The event2 log includes digest hash mask 0x%x, but required digest hash mask is 0x%x\n",
+                HashAlgorithmMaskCopied,
+                mTcgDxeData.BsCap.ActivePcrBanks
+                ));
+            }
+
+            //
+            // Restore event size.
+            //
+            CopyMem (EventSizePtr, &EventSize, sizeof (UINT32));
+            DigestListBinSize = GetDigestListBinSize (DigestListBin);
+
+            Status = TcgDxeLogEvent (
+                       mTcg2EventInfo[Index].LogFormat,
+                       TcgEvent,
+                       sizeof (TCG_PCRINDEX) + sizeof (TCG_EVENTTYPE) + DigestListBinSize + sizeof (UINT32),
+                       Event,
+                       EventSize
+                       );
+            break;
+        }
+
+        FreePool (TcgEvent);
+      }
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Measure and log an action string, and extend the measurement result into PCR[PCRIndex].
+
+  @param[in] PCRIndex         PCRIndex to extend
+  @param[in] String           A specific string that indicates an Action event.
+
+  @retval EFI_SUCCESS         Operation completed successfully.
+  @retval EFI_DEVICE_ERROR    The operation was unsuccessful.
+
+**/
+EFI_STATUS
+TcgMeasureAction (
+  IN      TPM_PCRINDEX  PCRIndex,
+  IN      CHAR8         *String
+  )
+{
+  TCG_PCR_EVENT_HDR  TcgEvent;
+
+  TcgEvent.PCRIndex  = PCRIndex;
+  TcgEvent.EventType = EV_EFI_ACTION;
+  TcgEvent.EventSize = (UINT32)AsciiStrLen (String);
+  return TcgDxeHashLogExtendEvent (
+           0,
+           (UINT8 *)String,
+           TcgEvent.EventSize,
+           &TcgEvent,
+           (UINT8 *)String
+           );
+}
+
+/**
+  Measure and log EFI handoff tables, and extend the measurement result into PCR[1].
+
+  @retval EFI_SUCCESS         Operation completed successfully.
+  @retval EFI_DEVICE_ERROR    The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureHandoffTables (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  TCG_PCR_EVENT_HDR           TcgEvent;
+  EFI_HANDOFF_TABLE_POINTERS  HandoffTables;
+  UINTN                       ProcessorNum;
+  EFI_CPU_PHYSICAL_LOCATION   *ProcessorLocBuf;
+
+  ProcessorLocBuf = NULL;
+  Status          = EFI_SUCCESS;
+
+  if (PcdGet8 (PcdTpmPlatformClass) == TCG_PLATFORM_TYPE_SERVER) {
+    //
+    // Tcg Server spec.
+    // Measure each processor EFI_CPU_PHYSICAL_LOCATION with EV_TABLE_OF_DEVICES to PCR[1]
+    //
+    Status = GetProcessorsCpuLocation (&ProcessorLocBuf, &ProcessorNum);
+
+    if (!EFI_ERROR (Status)) {
+      TcgEvent.PCRIndex  = 1;
+      TcgEvent.EventType = EV_TABLE_OF_DEVICES;
+      TcgEvent.EventSize = sizeof (HandoffTables);
+
+      HandoffTables.NumberOfTables            = 1;
+      HandoffTables.TableEntry[0].VendorGuid  = gEfiMpServiceProtocolGuid;
+      HandoffTables.TableEntry[0].VendorTable = ProcessorLocBuf;
+
+      Status = TcgDxeHashLogExtendEvent (
+                 0,
+                 (UINT8 *)(UINTN)ProcessorLocBuf,
+                 sizeof (EFI_CPU_PHYSICAL_LOCATION) * ProcessorNum,
+                 &TcgEvent,
+                 (UINT8 *)&HandoffTables
+                 );
+
+      FreePool (ProcessorLocBuf);
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Measure and log Separator event, and extend the measurement result into a specific PCR.
+
+  @param[in] PCRIndex         PCR index.
+
+  @retval EFI_SUCCESS         Operation completed successfully.
+  @retval EFI_DEVICE_ERROR    The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureSeparatorEvent (
+  IN      TPM_PCRINDEX  PCRIndex
+  )
+{
+  TCG_PCR_EVENT_HDR  TcgEvent;
+  UINT32             EventData;
+
+  DEBUG ((DEBUG_INFO, "MeasureSeparatorEvent Pcr - %x\n", PCRIndex));
+
+  EventData          = 0;
+  TcgEvent.PCRIndex  = PCRIndex;
+  TcgEvent.EventType = EV_SEPARATOR;
+  TcgEvent.EventSize = (UINT32)sizeof (EventData);
+  return TcgDxeHashLogExtendEvent (
+           0,
+           (UINT8 *)&EventData,
+           sizeof (EventData),
+           &TcgEvent,
+           (UINT8 *)&EventData
+           );
+}
+
+/**
+  Measure and log an EFI variable, and extend the measurement result into a specific PCR.
+
+  @param[in]  PCRIndex          PCR Index.
+  @param[in]  EventType         Event type.
+  @param[in]  VarName           A Null-terminated string that is the name of the vendor's variable.
+  @param[in]  VendorGuid        A unique identifier for the vendor.
+  @param[in]  VarData           The content of the variable data.
+  @param[in]  VarSize           The size of the variable data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureVariable (
+  IN      TPM_PCRINDEX   PCRIndex,
+  IN      TCG_EVENTTYPE  EventType,
+  IN      CHAR16         *VarName,
+  IN      EFI_GUID       *VendorGuid,
+  IN      VOID           *VarData,
+  IN      UINTN          VarSize
+  )
+{
+  EFI_STATUS          Status;
+  TCG_PCR_EVENT_HDR   TcgEvent;
+  UINTN               VarNameLength;
+  UEFI_VARIABLE_DATA  *VarLog;
+
+  DEBUG ((DEBUG_INFO, "Tcg2Dxe: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)PCRIndex, (UINTN)EventType));
+  DEBUG ((DEBUG_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
+
+  VarNameLength      = StrLen (VarName);
+  TcgEvent.PCRIndex  = PCRIndex;
+  TcgEvent.EventType = EventType;
+
+  TcgEvent.EventSize = (UINT32)(sizeof (*VarLog) + VarNameLength * sizeof (*VarName) + VarSize
+                                - sizeof (VarLog->UnicodeName) - sizeof (VarLog->VariableData));
+
+  VarLog = (UEFI_VARIABLE_DATA *)AllocatePool (TcgEvent.EventSize);
+  if (VarLog == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //VarLog->VariableName       = *VendorGuid;
+  CopyMem (
+      &VarLog->VariableName,
+      VendorGuid,
+      sizeof (EFI_GUID)
+    );
+  VarLog->UnicodeNameLength  = VarNameLength;
+  VarLog->VariableDataLength = VarSize;
+  CopyMem (
+    VarLog->UnicodeName,
+    VarName,
+    VarNameLength * sizeof (*VarName)
+    );
+  if ((VarSize != 0) && (VarData != NULL)) {
+    CopyMem (
+      (CHAR16 *)VarLog->UnicodeName + VarNameLength,
+      VarData,
+      VarSize
+      );
+  }
+
+  if ((EventType == EV_EFI_VARIABLE_DRIVER_CONFIG) || (EventType == EV_EFI_SPDM_DEVICE_POLICY)) {
+    //
+    // Digest is the event data (UEFI_VARIABLE_DATA)
+    //
+    Status = TcgDxeHashLogExtendEvent (
+               0,
+               (UINT8 *)VarLog,
+               TcgEvent.EventSize,
+               &TcgEvent,
+               (UINT8 *)VarLog
+               );
+  } else {
+    ASSERT (VarData != NULL);
+    Status = TcgDxeHashLogExtendEvent (
+               0,
+               (UINT8 *)VarData,
+               VarSize,
+               &TcgEvent,
+               (UINT8 *)VarLog
+               );
+  }
+
+  FreePool (VarLog);
+  return Status;
+}
+
+/**
+  Read then Measure and log an EFI variable, and extend the measurement result into a specific PCR.
+
+  @param[in]  PCRIndex          PCR Index.
+  @param[in]  EventType         Event type.
+  @param[in]   VarName          A Null-terminated string that is the name of the vendor's variable.
+  @param[in]   VendorGuid       A unique identifier for the vendor.
+  @param[out]  VarSize          The size of the variable data.
+  @param[out]  VarData          Pointer to the content of the variable.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+ReadAndMeasureVariable (
+  IN      TPM_PCRINDEX   PCRIndex,
+  IN      TCG_EVENTTYPE  EventType,
+  IN      CHAR16         *VarName,
+  IN      EFI_GUID       *VendorGuid,
+  OUT     UINTN          *VarSize,
+  OUT     VOID           **VarData
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = GetVariable2 (VarName, VendorGuid, VarData, VarSize);
+  if (EventType == EV_EFI_VARIABLE_DRIVER_CONFIG) {
+    if (EFI_ERROR (Status)) {
+      //
+      // It is valid case, so we need handle it.
+      //
+      *VarData = NULL;
+      *VarSize = 0;
+    }
+  } else {
+    //
+    // if status error, VarData is freed and set NULL by GetVariable2
+    //
+    if (EFI_ERROR (Status)) {
+      return EFI_NOT_FOUND;
+    }
+  }
+
+  Status = MeasureVariable (
+             PCRIndex,
+             EventType,
+             VarName,
+             VendorGuid,
+             *VarData,
+             *VarSize
+             );
+  return Status;
+}
+
+/**
+  Read then Measure and log an EFI boot variable, and extend the measurement result into PCR[1].
+according to TCG PC Client PFP spec 0021 Section 2.4.4.2
+
+  @param[in]   VarName          A Null-terminated string that is the name of the vendor's variable.
+  @param[in]   VendorGuid       A unique identifier for the vendor.
+  @param[out]  VarSize          The size of the variable data.
+  @param[out]  VarData          Pointer to the content of the variable.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+ReadAndMeasureBootVariable (
+  IN      CHAR16    *VarName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINTN     *VarSize,
+  OUT     VOID      **VarData
+  )
+{
+  return ReadAndMeasureVariable (
+           1,
+           EV_EFI_VARIABLE_BOOT,
+           VarName,
+           VendorGuid,
+           VarSize,
+           VarData
+           );
+}
+
+/**
+  Read then Measure and log an EFI Secure variable, and extend the measurement result into PCR[7].
+
+  @param[in]   VarName          A Null-terminated string that is the name of the vendor's variable.
+  @param[in]   VendorGuid       A unique identifier for the vendor.
+  @param[out]  VarSize          The size of the variable data.
+  @param[out]  VarData          Pointer to the content of the variable.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+ReadAndMeasureSecureVariable (
+  IN      CHAR16    *VarName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINTN     *VarSize,
+  OUT     VOID      **VarData
+  )
+{
+  return ReadAndMeasureVariable (
+           7,
+           EV_EFI_VARIABLE_DRIVER_CONFIG,
+           VarName,
+           VendorGuid,
+           VarSize,
+           VarData
+           );
+}
+
+/**
+  Measure and log all EFI boot variables, and extend the measurement result into a specific PCR.
+
+  The EFI boot variables are BootOrder and Boot#### variables.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureAllBootVariables (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      *BootOrder;
+  UINTN       BootCount;
+  UINTN       Index;
+  VOID        *BootVarData;
+  UINTN       Size;
+
+  Status = ReadAndMeasureBootVariable (
+             mBootVarName,
+             &gEfiGlobalVariableGuid,
+             &BootCount,
+             (VOID **)&BootOrder
+             );
+  if ((Status == EFI_NOT_FOUND) || (BootOrder == NULL)) {
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    //
+    // BootOrder can't be NULL if status is not EFI_NOT_FOUND
+    //
+    FreePool (BootOrder);
+    return Status;
+  }
+
+  BootCount /= sizeof (*BootOrder);
+  for (Index = 0; Index < BootCount; Index++) {
+    UnicodeSPrint (mBootVarName, sizeof (mBootVarName), L"Boot%04x", BootOrder[Index]);
+    Status = ReadAndMeasureBootVariable (
+               mBootVarName,
+               &gEfiGlobalVariableGuid,
+               &Size,
+               &BootVarData
+               );
+    if (!EFI_ERROR (Status)) {
+      FreePool (BootVarData);
+    }
+  }
+
+  FreePool (BootOrder);
+  return EFI_SUCCESS;
+}
+
+/**
+  Measure and log all EFI Secure variables, and extend the measurement result into a specific PCR.
+
+  The EFI boot variables are BootOrder and Boot#### variables.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureAllSecureVariables (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Data;
+  UINTN       DataSize;
+  UINTN       Index;
+
+  Status = EFI_NOT_FOUND;
+  for (Index = 0; Index < sizeof (mVariableType)/sizeof (mVariableType[0]); Index++) {
+    Status = ReadAndMeasureSecureVariable (
+               mVariableType[Index].VariableName,
+               mVariableType[Index].VendorGuid,
+               &DataSize,
+               &Data
+               );
+    if (!EFI_ERROR (Status)) {
+      if (Data != NULL) {
+        FreePool (Data);
+      }
+    }
+  }
+
+  //
+  // Measure DBT if present and not empty
+  //
+  Status = GetVariable2 (EFI_IMAGE_SECURITY_DATABASE2, &gEfiImageSecurityDatabaseGuid, &Data, &DataSize);
+  if (!EFI_ERROR (Status)) {
+    Status = MeasureVariable (
+               7,
+               EV_EFI_VARIABLE_DRIVER_CONFIG,
+               EFI_IMAGE_SECURITY_DATABASE2,
+               &gEfiImageSecurityDatabaseGuid,
+               Data,
+               DataSize
+               );
+    FreePool (Data);
+  } else {
+    DEBUG ((DEBUG_INFO, "Skip measuring variable %s since it's deleted\n", EFI_IMAGE_SECURITY_DATABASE2));
+  }
+
+  //
+  // Meaurement UEFI device signature database
+  //
+  if ((PcdGet32 (PcdTcgPfpMeasurementRevision) >= TCG_EfiSpecIDEventStruct_SPEC_ERRATA_TPM2_REV_106) &&
+      (PcdGet8 (PcdEnableSpdmDeviceAuthentication) != 0))
+  {
+    Status = GetVariable2 (EFI_DEVICE_SECURITY_DATABASE, &gEfiDeviceSignatureDatabaseGuid, &Data, &DataSize);
+    if (Status == EFI_SUCCESS) {
+      Status = MeasureVariable (
+                 PCR_INDEX_FOR_SIGNATURE_DB,
+                 EV_EFI_SPDM_DEVICE_POLICY,
+                 EFI_DEVICE_SECURITY_DATABASE,
+                 &gEfiDeviceSignatureDatabaseGuid,
+                 Data,
+                 DataSize
+                 );
+      FreePool (Data);
+    } else if (Status == EFI_NOT_FOUND) {
+      Data     = NULL;
+      DataSize = 0;
+      Status   = MeasureVariable (
+                   PCR_INDEX_FOR_SIGNATURE_DB,
+                   EV_EFI_SPDM_DEVICE_POLICY,
+                   EFI_DEVICE_SECURITY_DATABASE,
+                   &gEfiDeviceSignatureDatabaseGuid,
+                   Data,
+                   DataSize
+                   );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Measure and log launch of FirmwareDebugger, and extend the measurement result into a specific PCR.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_OUT_OF_RESOURCES  Out of memory.
+  @retval EFI_DEVICE_ERROR      The operation was unsuccessful.
+
+**/
+EFI_STATUS
+MeasureLaunchOfFirmwareDebugger (
+  VOID
+  )
+{
+  TCG_PCR_EVENT_HDR  TcgEvent;
+
+  TcgEvent.PCRIndex  = 7;
+  TcgEvent.EventType = EV_EFI_ACTION;
+  TcgEvent.EventSize = sizeof (FIRMWARE_DEBUGGER_EVENT_STRING) - 1;
+  return TcgDxeHashLogExtendEvent (
+           0,
+           (UINT8 *)FIRMWARE_DEBUGGER_EVENT_STRING,
+           sizeof (FIRMWARE_DEBUGGER_EVENT_STRING) - 1,
+           &TcgEvent,
+           (UINT8 *)FIRMWARE_DEBUGGER_EVENT_STRING
+           );
+}
+
+/**
+  Measure and log all Secure Boot Policy, and extend the measurement result into a specific PCR.
+
+  Platform firmware adhering to the policy must therefore measure the following values into PCR[7]: (in order listed)
+   - The contents of the SecureBoot variable
+   - The contents of the PK variable
+   - The contents of the KEK variable
+   - The contents of the EFI_IMAGE_SECURITY_DATABASE variable
+   - The contents of the EFI_IMAGE_SECURITY_DATABASE1 variable
+   - Separator
+   - Entries in the EFI_IMAGE_SECURITY_DATABASE that are used to validate EFI Drivers or EFI Boot Applications in the boot path
+
+  NOTE: Because of the above, UEFI variables PK, KEK, EFI_IMAGE_SECURITY_DATABASE,
+  EFI_IMAGE_SECURITY_DATABASE1 and SecureBoot SHALL NOT be measured into PCR[3].
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+**/
+VOID
+EFIAPI
+MeasureSecureBootPolicy (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Protocol;
+
+  Status = gBS->LocateProtocol (&gEfiVariableWriteArchProtocolGuid, NULL, (VOID **)&Protocol);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  if (PcdGetBool (PcdFirmwareDebuggerInitialized)) {
+    Status = MeasureLaunchOfFirmwareDebugger ();
+    DEBUG ((DEBUG_INFO, "MeasureLaunchOfFirmwareDebugger - %r\n", Status));
+  }
+
+  Status = MeasureAllSecureVariables ();
+  DEBUG ((DEBUG_INFO, "MeasureAllSecureVariables - %r\n", Status));
+
+  //
+  // We need measure Separator(7) here, because this event must be between SecureBootPolicy (Configure)
+  // and ImageVerification (Authority)
+  // There might be a case that we need measure UEFI image from DriverOrder, besides BootOrder. So
+  // the Authority measurement happen before ReadToBoot event.
+  //
+  Status = MeasureSeparatorEvent (7);
+  DEBUG ((DEBUG_INFO, "MeasureSeparatorEvent - %r\n", Status));
+  return;
+}
+
+/**
+  Ready to Boot Event notification handler.
+
+  Sequence of OS boot events is measured in this event notification handler.
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+
+**/
+VOID
+EFIAPI
+OnReadyToBoot (
+  IN      EFI_EVENT  Event,
+  IN      VOID       *Context
+  )
+{
+  EFI_STATUS    Status;
+  TPM_PCRINDEX  PcrIndex;
+
+  PERF_START_EX (mImageHandle, "EventRec", "Tcg2Dxe", 0, PERF_ID_TCG2_DXE);
+  if (mBootAttempts == 0) {
+    //
+    // Measure handoff tables.
+    //
+    Status = MeasureHandoffTables ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "HOBs not Measured. Error!\n"));
+    }
+
+    //
+    // Measure BootOrder & Boot#### variables.
+    //
+    Status = MeasureAllBootVariables ();
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Boot Variables not Measured. Error!\n"));
+    }
+
+    //
+    // 1. This is the first boot attempt.
+    //
+    Status = TcgMeasureAction (
+               4,
+               EFI_CALLING_EFI_APPLICATION
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
+    }
+
+    //
+    // 2. Draw a line between pre-boot env and entering post-boot env.
+    // PCR[7] is already done.
+    //
+    for (PcrIndex = 0; PcrIndex < 7; PcrIndex++) {
+      Status = MeasureSeparatorEvent (PcrIndex);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Separator Event not Measured. Error!\n"));
+      }
+    }
+
+    //
+    // 3. Measure GPT. It would be done in SAP driver.
+    //
+
+    //
+    // 4. Measure PE/COFF OS loader. It would be done in SAP driver.
+    //
+
+    //
+    // 5. Read & Measure variable. BootOrder already measured.
+    //
+  } else {
+    //
+    // 6. Not first attempt, meaning a return from last attempt
+    //
+    Status = TcgMeasureAction (
+               4,
+               EFI_RETURNING_FROM_EFI_APPLICATION
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_RETURNING_FROM_EFI_APPLICATION));
+    }
+
+    //
+    // 7. Next boot attempt, measure "Calling EFI Application from Boot Option" again
+    // TCG PC Client PFP spec Section 2.4.4.5 Step 4
+    //
+    Status = TcgMeasureAction (
+               4,
+               EFI_CALLING_EFI_APPLICATION
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_CALLING_EFI_APPLICATION));
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "TPM2 Tcg2Dxe Measure Data when ReadyToBoot\n"));
+  //
+  // Increase boot attempt counter.
+  //
+  mBootAttempts++;
+  PERF_END_EX (mImageHandle, "EventRec", "Tcg2Dxe", 0, PERF_ID_TCG2_DXE + 1);
+}
+
+/**
+  Exit Boot Services Event notification handler.
+
+  Measure invocation and success of ExitBootServices.
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+
+**/
+VOID
+EFIAPI
+OnExitBootServices (
+  IN      EFI_EVENT  Event,
+  IN      VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Measure invocation of ExitBootServices,
+  //
+  Status = TcgMeasureAction (
+             5,
+             EFI_EXIT_BOOT_SERVICES_INVOCATION
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
+  }
+
+  //
+  // Measure success of ExitBootServices
+  //
+  Status = TcgMeasureAction (
+             5,
+             EFI_EXIT_BOOT_SERVICES_SUCCEEDED
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_SUCCEEDED));
+  }
+}
+
+/**
+  Exit Boot Services Failed Event notification handler.
+
+  Measure Failure of ExitBootServices.
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+
+**/
+VOID
+EFIAPI
+OnExitBootServicesFailed (
+  IN      EFI_EVENT  Event,
+  IN      VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Measure invocation of ExitBootServices,
+  //
+  Status = TcgMeasureAction (
+             5,
+             EFI_EXIT_BOOT_SERVICES_INVOCATION
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_INVOCATION));
+  }
+
+  //
+  // Measure Failure of ExitBootServices,
+  //
+  Status = TcgMeasureAction (
+             5,
+             EFI_EXIT_BOOT_SERVICES_FAILED
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a not Measured. Error!\n", EFI_EXIT_BOOT_SERVICES_FAILED));
+  }
+}
+
+/**
+  This routine is called to properly shutdown the TPM before system reset.
+  It follow chapter "12.2.3 Startup State" in Trusted Platform Module Library
+  Part 1: Architecture, Revision 01.16.
+
+  @param[in]  ResetType         The type of reset to perform.
+  @param[in]  ResetStatus       The status code for the reset.
+  @param[in]  DataSize          The size, in bytes, of ResetData.
+  @param[in]  ResetData         For a ResetType of EfiResetCold, EfiResetWarm, or
+                                EfiResetShutdown the data buffer starts with a Null-terminated
+                                string, optionally followed by additional binary data.
+                                The string is a description that the caller may use to further
+                                indicate the reason for the system reset.
+                                For a ResetType of EfiResetPlatformSpecific the data buffer
+                                also starts with a Null-terminated string that is followed
+                                by an EFI_GUID that describes the specific type of reset to perform.
+**/
+VOID
+EFIAPI
+ShutdownTpmOnReset (
+  IN EFI_RESET_TYPE  ResetType,
+  IN EFI_STATUS      ResetStatus,
+  IN UINTN           DataSize,
+  IN VOID            *ResetData OPTIONAL
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = Tpm2Shutdown (TPM_SU_CLEAR);
+  DEBUG ((DEBUG_VERBOSE, "Tpm2Shutdown (SU_CLEAR) - %r\n", Status));
+}
+
+/**
+  Hook the system reset to properly shutdown TPM.
+  It follow chapter "12.2.3 Startup State" in Trusted Platform Module Library
+  Part 1: Architecture, Revision 01.16.
+
+  @param[in]  Event     Event whose notification function is being invoked
+  @param[in]  Context   Pointer to the notification function's context
+**/
+VOID
+EFIAPI
+OnResetNotificationInstall (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_RESET_NOTIFICATION_PROTOCOL  *ResetNotify;
+
+  Status = gBS->LocateProtocol (&gEfiResetNotificationProtocolGuid, NULL, (VOID **)&ResetNotify);
+  if (!EFI_ERROR (Status)) {
+    Status = ResetNotify->RegisterResetNotify (ResetNotify, ShutdownTpmOnReset);
+    ASSERT_EFI_ERROR (Status);
+    DEBUG ((DEBUG_VERBOSE, "TCG2: Hook system reset to properly shutdown TPM.\n"));
+
+    gBS->CloseEvent (Event);
+  }
+}
+
+/**
+  The function install Tcg2 protocol.
+
+  @retval EFI_SUCCESS     Tcg2 protocol is installed.
+  @retval other           Some error occurs.
+**/
+EFI_STATUS
+InstallTcg2 (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  Handle;
+
+  Handle = NULL;
+  Status = gBS->InstallMultipleProtocolInterfaces (
+                  &Handle,
+                  &gEfiTcg2ProtocolGuid,
+                  &mTcg2Protocol,
+                  NULL
+                  );
+  return Status;
+}
+
+/**
+  The driver's entry point. It publishes EFI Tcg2 Protocol.
+
+  @param[in] ImageHandle  The firmware allocated handle for the EFI image.
+  @param[in] SystemTable  A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS     The entry point is executed successfully.
+  @retval other           Some error occurs when executing this entry point.
+**/
+EFI_STATUS
+EFIAPI
+DriverEntry (
+  IN    EFI_HANDLE        ImageHandle,
+  IN    EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_EVENT                        Event;
+  VOID                             *Registration;
+  UINT32                           MaxCommandSize;
+  UINT32                           MaxResponseSize;
+  UINTN                            Index;
+  EFI_TCG2_EVENT_ALGORITHM_BITMAP  TpmHashAlgorithmBitmap;
+  UINT32                           ActivePCRBanks;
+  UINT32                           NumberOfPCRBanks;
+
+  mImageHandle = ImageHandle;
+
+  if (CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceNoneGuid) ||
+      CompareGuid (PcdGetPtr (PcdTpmInstanceGuid), &gEfiTpmDeviceInstanceTpm12Guid))
+  {
+    DEBUG ((DEBUG_INFO, "No TPM2 instance required!\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (GetFirstGuidHob (&gTpmErrorHobGuid) != NULL) {
+    DEBUG ((DEBUG_ERROR, "TPM2 error!\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  Status = Tpm2RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "TPM2 not detected!\n"));
+    return Status;
+  }
+
+  //
+  // Fill information
+  //
+  ASSERT (TCG_EVENT_LOG_AREA_COUNT_MAX == sizeof (mTcg2EventInfo)/sizeof (mTcg2EventInfo[0]));
+
+  mTcgDxeData.BsCap.Size                   = sizeof (EFI_TCG2_BOOT_SERVICE_CAPABILITY);
+  mTcgDxeData.BsCap.ProtocolVersion.Major  = 1;
+  mTcgDxeData.BsCap.ProtocolVersion.Minor  = 1;
+  mTcgDxeData.BsCap.StructureVersion.Major = 1;
+  mTcgDxeData.BsCap.StructureVersion.Minor = 1;
+
+  DEBUG ((DEBUG_INFO, "Tcg2.ProtocolVersion  - %02x.%02x\n", mTcgDxeData.BsCap.ProtocolVersion.Major, mTcgDxeData.BsCap.ProtocolVersion.Minor));
+  DEBUG ((DEBUG_INFO, "Tcg2.StructureVersion - %02x.%02x\n", mTcgDxeData.BsCap.StructureVersion.Major, mTcgDxeData.BsCap.StructureVersion.Minor));
+
+  Status = Tpm2GetCapabilityManufactureID (&mTcgDxeData.BsCap.ManufacturerID);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityManufactureID fail!\n"));
+  } else {
+    DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityManufactureID - %08x\n", mTcgDxeData.BsCap.ManufacturerID));
+  }
+
+  DEBUG_CODE_BEGIN ();
+  UINT32  FirmwareVersion1;
+  UINT32  FirmwareVersion2;
+
+  Status = Tpm2GetCapabilityFirmwareVersion (&FirmwareVersion1, &FirmwareVersion2);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityFirmwareVersion fail!\n"));
+  } else {
+    DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityFirmwareVersion - %08x %08x\n", FirmwareVersion1, FirmwareVersion2));
+  }
+
+  DEBUG_CODE_END ();
+
+  Status = Tpm2GetCapabilityMaxCommandResponseSize (&MaxCommandSize, &MaxResponseSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2GetCapabilityMaxCommandResponseSize fail!\n"));
+  } else {
+    mTcgDxeData.BsCap.MaxCommandSize  = (UINT16)MaxCommandSize;
+    mTcgDxeData.BsCap.MaxResponseSize = (UINT16)MaxResponseSize;
+    DEBUG ((DEBUG_INFO, "Tpm2GetCapabilityMaxCommandResponseSize - %08x, %08x\n", MaxCommandSize, MaxResponseSize));
+  }
+
+  //
+  // Get supported PCR and current Active PCRs
+  //
+  Status = Tpm2GetCapabilitySupportedAndActivePcrs (&TpmHashAlgorithmBitmap, &ActivePCRBanks);
+  ASSERT_EFI_ERROR (Status);
+
+  mTcgDxeData.BsCap.HashAlgorithmBitmap = TpmHashAlgorithmBitmap & PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+  mTcgDxeData.BsCap.ActivePcrBanks      = ActivePCRBanks & PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+
+  //
+  // Need calculate NumberOfPCRBanks here, because HashAlgorithmBitmap might be removed by PCD.
+  //
+  NumberOfPCRBanks = 0;
+  for (Index = 0; Index < 32; Index++) {
+    if ((mTcgDxeData.BsCap.HashAlgorithmBitmap & (1u << Index)) != 0) {
+      NumberOfPCRBanks++;
+    }
+  }
+
+  if (PcdGet32 (PcdTcg2NumberOfPCRBanks) == 0) {
+    mTcgDxeData.BsCap.NumberOfPCRBanks = NumberOfPCRBanks;
+  } else {
+    mTcgDxeData.BsCap.NumberOfPCRBanks = PcdGet32 (PcdTcg2NumberOfPCRBanks);
+    if (PcdGet32 (PcdTcg2NumberOfPCRBanks) > NumberOfPCRBanks) {
+      DEBUG ((DEBUG_ERROR, "ERROR: PcdTcg2NumberOfPCRBanks(0x%x) > NumberOfPCRBanks(0x%x)\n", PcdGet32 (PcdTcg2NumberOfPCRBanks), NumberOfPCRBanks));
+      mTcgDxeData.BsCap.NumberOfPCRBanks = NumberOfPCRBanks;
+    }
+  }
+
+  mTcgDxeData.BsCap.SupportedEventLogs = EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2 | EFI_TCG2_EVENT_LOG_FORMAT_TCG_2;
+  if ((mTcgDxeData.BsCap.ActivePcrBanks & EFI_TCG2_BOOT_HASH_ALG_SHA1) == 0) {
+    //
+    // No need to expose TCG1.2 event log if SHA1 bank does not exist.
+    //
+    mTcgDxeData.BsCap.SupportedEventLogs &= ~EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2;
+  }
+
+  DEBUG ((DEBUG_INFO, "Tcg2.SupportedEventLogs - 0x%08x\n", mTcgDxeData.BsCap.SupportedEventLogs));
+  DEBUG ((DEBUG_INFO, "Tcg2.HashAlgorithmBitmap - 0x%08x\n", mTcgDxeData.BsCap.HashAlgorithmBitmap));
+  DEBUG ((DEBUG_INFO, "Tcg2.NumberOfPCRBanks      - 0x%08x\n", mTcgDxeData.BsCap.NumberOfPCRBanks));
+  DEBUG ((DEBUG_INFO, "Tcg2.ActivePcrBanks        - 0x%08x\n", mTcgDxeData.BsCap.ActivePcrBanks));
+
+  if (mTcgDxeData.BsCap.TPMPresentFlag) {
+    //
+    // Setup the log area and copy event log from hob list to it
+    //
+    Status = SetupEventLog ();
+    ASSERT_EFI_ERROR (Status);
+
+    //
+    // Measure handoff tables, Boot#### variables etc.
+    //
+    Status = EfiCreateEventReadyToBootEx (
+               TPL_CALLBACK,
+               OnReadyToBoot,
+               NULL,
+               &Event
+               );
+
+    Status = gBS->CreateEventEx (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_NOTIFY,
+                    OnExitBootServices,
+                    NULL,
+                    &gEfiEventExitBootServicesGuid,
+                    &Event
+                    );
+
+    //
+    // Measure Exit Boot Service failed
+    //
+    Status = gBS->CreateEventEx (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_NOTIFY,
+                    OnExitBootServicesFailed,
+                    NULL,
+                    &gEventExitBootServicesFailedGuid,
+                    &Event
+                    );
+
+    //
+    // Create event callback, because we need access variable on SecureBootPolicyVariable
+    // We should use VariableWriteArch instead of VariableArch, because Variable driver
+    // may update SecureBoot value based on last setting.
+    //
+    EfiCreateProtocolNotifyEvent (&gEfiVariableWriteArchProtocolGuid, TPL_CALLBACK, MeasureSecureBootPolicy, NULL, &Registration);
+
+    //
+    // Hook the system reset to properly shutdown TPM.
+    //
+    EfiCreateProtocolNotifyEvent (&gEfiResetNotificationProtocolGuid, TPL_CALLBACK, OnResetNotificationInstall, NULL, &Registration);
+  }
+
+  //
+  // Install Tcg2Protocol
+  //
+  Status = InstallTcg2 ();
+  DEBUG ((DEBUG_INFO, "InstallTcg2 - %r\n", Status));
+
+  return Status;
+}

--- a/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.inf
+++ b/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.inf
@@ -1,0 +1,121 @@
+## @file
+#  Produces Tcg2 protocol and measure boot environment
+#
+#  Spec Compliance Info:
+#    "TCG PC Client Platform Firmware Profile Specification for TPM Family 2.0 Level 00 Revision 1.03 v51"
+#      along with
+#    "Errata for PC Client Specific Platform Firmware Profile Specification Version 1.0 Revision 1.03"
+#    "TCG EFI Protocol Specification" "Family 2.0" "Level 00 Revision 00.13"
+#      along with
+#    "Errata Version 0.5 for TCG EFI Protocol Specification"
+#
+#  This module will produce Tcg2 protocol and measure boot environment.
+#
+#  Caution: This module requires additional review when modified.
+#  This driver will have external input - PE/COFF image.
+#  This external input must be validated carefully to avoid security issue like
+#  buffer overflow, integer overflow.
+#
+# Copyright (c) 2015 - 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tcg2Dxe
+  MODULE_UNI_FILE                = Tcg2Dxe.uni
+  FILE_GUID                      = FDFF263D-5F68-4591-87BA-B768F445A9AF
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = DriverEntry
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  Tcg2Dxe.c
+  MeasureBootPeCoff.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  MemoryAllocationLib
+  BaseLib
+  UefiBootServicesTableLib
+  HobLib
+  UefiDriverEntryPoint
+  UefiRuntimeServicesTableLib
+  BaseMemoryLib
+  DebugLib
+  Tpm2CommandLib
+  PrintLib
+  UefiLib
+  Tpm2DeviceLib
+  HashLib
+  PerformanceLib
+  ReportStatusCodeLib
+  Tcg2PhysicalPresenceLib
+  PeCoffLib
+
+[Guids]
+  ## SOMETIMES_CONSUMES     ## Variable:L"SecureBoot"
+  ## SOMETIMES_CONSUMES     ## Variable:L"PK"
+  ## SOMETIMES_CONSUMES     ## Variable:L"KEK"
+  ## SOMETIMES_CONSUMES     ## Variable:L"BootXXXX"
+  gEfiGlobalVariableGuid
+
+  ## SOMETIMES_CONSUMES      ## Variable:L"db"
+  ## SOMETIMES_CONSUMES      ## Variable:L"dbx"
+  gEfiImageSecurityDatabaseGuid
+
+  gTcgEventEntryHobGuid                              ## SOMETIMES_CONSUMES  ## HOB
+  gTpmErrorHobGuid                                   ## SOMETIMES_CONSUMES  ## HOB
+  gEfiEventExitBootServicesGuid                      ## CONSUMES            ## Event
+  gEventExitBootServicesFailedGuid                   ## SOMETIMES_CONSUMES  ## Event
+  gEfiTpmDeviceInstanceNoneGuid                      ## SOMETIMES_CONSUMES  ## GUID       # TPM device identifier
+  gEfiTpmDeviceInstanceTpm12Guid                     ## SOMETIMES_CONSUMES  ## GUID       # TPM device identifier
+
+  gTcgEvent2EntryHobGuid                             ## SOMETIMES_CONSUMES  ## HOB
+  gTpm2StartupLocalityHobGuid                        ## SOMETIMES_CONSUMES  ## HOB
+  gTcg800155PlatformIdEventHobGuid                   ## SOMETIMES_CONSUMES  ## HOB
+  gEfiDeviceSignatureDatabaseGuid
+
+[Protocols]
+  gEfiTcg2ProtocolGuid                               ## PRODUCES
+  gEfiTcg2FinalEventsTableGuid                       ## PRODUCES
+  gEfiMpServiceProtocolGuid                          ## SOMETIMES_CONSUMES
+  gEfiVariableWriteArchProtocolGuid                  ## NOTIFY
+  gEfiResetNotificationProtocolGuid                  ## CONSUMES
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmPlatformClass                         ## SOMETIMES_CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdFirmwareDebuggerInitialized              ## SOMETIMES_CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmInstanceGuid                          ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdStatusCodeSubClassTpmDevice              ## SOMETIMES_CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap                  ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2NumberOfPCRBanks                     ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcgLogAreaMinLen                         ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTcg2FinalLogAreaLen                      ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev                         ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLaml                        ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableLasa                        ## PRODUCES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision               ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableSpdmDeviceAuthentication           ## CONSUMES
+
+[Depex]
+  # According to PcdTpm2AcpiTableRev definition in SecurityPkg.dec
+  # This PCD should be configured at DynamicHii or DynamicHiiEx.
+  # So, this PCD read operation depends on GetVariable service.
+  # Add VariableArch protocol dependency to make sure PCD read works.
+  gEfiVariableArchProtocolGuid
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  Tcg2DxeExtra.uni

--- a/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2Dxe.uni
@@ -1,0 +1,21 @@
+// /** @file
+// Produces TCG2 protocol and measure boot environment
+//
+// This module will produce TCG2 protocol and measure boot environment.
+//
+// Caution: This module requires additional review when modified.
+// This driver will have external input - PE/COFF image.
+// This external input must be validated carefully to avoid security issue like
+// buffer overflow, integer overflow.
+//
+// Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Produces TCG2 protocol and measure boot environment"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module will produce TCG2 protocol and measure boot environment."
+

--- a/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2DxeExtra.uni
+++ b/Silicon/Sophgo/Drivers/Tcg2Dxe/Tcg2DxeExtra.uni
@@ -1,0 +1,12 @@
+// /** @file
+// Tcg2Dxe Localized Strings and Content
+//
+// Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"TCG2 (Trusted Computing Group) DXE"

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.h
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.h
@@ -1,0 +1,67 @@
+/** @file
+  This header file includes common internal fuction prototypes.
+
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _TPM2_DEVICE_LIB_DTPM_H_
+#define _TPM2_DEVICE_LIB_DTPM_H_
+
+/**
+  Return PTP interface type.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @return PTP interface type.
+**/
+TPM2_PTP_INTERFACE_TYPE
+Tpm2GetPtpInterface (
+  IN VOID  *Register
+  );
+
+/**
+  Return PTP CRB interface IdleByPass state.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @return PTP CRB interface IdleByPass state.
+**/
+UINT8
+Tpm2GetIdleByPass (
+  IN VOID  *Register
+  );
+
+/**
+  Return cached PTP interface type.
+
+  @return Cached PTP interface type.
+**/
+TPM2_PTP_INTERFACE_TYPE
+GetCachedPtpInterface (
+  VOID
+  );
+
+/**
+  Return cached PTP CRB interface IdleByPass state.
+
+  @return Cached PTP CRB interface IdleByPass state.
+**/
+UINT8
+GetCachedIdleByPass (
+  VOID
+  );
+
+/**
+  The common function cache current active TpmInterfaceType when needed.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+**/
+EFI_STATUS
+InternalTpm2DeviceLibDTpmCommonConstructor (
+  VOID
+  );
+
+#endif // _TPM2_DEVICE_LIB_DTPM_H_

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmBase.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpmBase.c
@@ -1,0 +1,68 @@
+/** @file
+  This file abstract internal interfaces of which implementation differs per library instance.
+
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+
+/**
+  Return cached PTP CRB interface IdleByPass state.
+
+  @return Cached PTP CRB interface IdleByPass state.
+**/
+UINT8
+GetCachedIdleByPass (
+  VOID
+  )
+{
+  return PcdGet8 (PcdCRBIdleByPass);
+}
+
+/**
+  Return cached PTP interface type.
+
+  @return Cached PTP interface type.
+**/
+TPM2_PTP_INTERFACE_TYPE
+GetCachedPtpInterface (
+  VOID
+  )
+{
+  return PcdGet8 (PcdActiveTpmInterfaceType);
+}
+
+/**
+  The common function cache current active TpmInterfaceType when needed.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+**/
+EFI_STATUS
+InternalTpm2DeviceLibDTpmCommonConstructor (
+  VOID
+  )
+{
+  TPM2_PTP_INTERFACE_TYPE  PtpInterface;
+  UINT8                    IdleByPass;
+
+  //
+  // Cache current active TpmInterfaceType only when needed
+  //
+  if (PcdGet8 (PcdActiveTpmInterfaceType) == 0xFF) {
+    PtpInterface = Tpm2GetPtpInterface ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    PcdSet8S (PcdActiveTpmInterfaceType, PtpInterface);
+  }
+
+  if ((PcdGet8 (PcdActiveTpmInterfaceType) == Tpm2PtpInterfaceCrb) && (PcdGet8 (PcdCRBIdleByPass) == 0xFF)) {
+    IdleByPass = Tpm2GetIdleByPass ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    PcdSet8S (PcdCRBIdleByPass, IdleByPass);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpm.c
@@ -1,0 +1,101 @@
+/** @file
+  This library is TPM2 DTPM instance.
+  It can be registered to Tpm2 Device router, to be active TPM2 engine,
+  based on platform setting.
+
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved. <BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+
+#include <Guid/TpmInstance.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2Transfer.h"
+
+/**
+  Dump PTP register information.
+
+  @param[in] Register                Pointer to PTP register.
+**/
+VOID
+DumpPtpInfo (
+  IN VOID  *Register
+  );
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  );
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2RequestUseTpm (
+  VOID
+  );
+
+TPM2_DEVICE_INTERFACE  mDTpm2InternalTpm2Device = {
+  TPM_DEVICE_INTERFACE_TPM20_DTPM,
+  DTpm2SubmitCommand,
+  DTpm2RequestUseTpm,
+};
+
+/**
+  The function register DTPM2.0 instance and caches current active TPM interface type.
+
+  @retval EFI_SUCCESS   DTPM2.0 instance is registered, or system does not support register DTPM2.0 instance
+**/
+EFI_STATUS
+EFIAPI
+Tpm2InstanceLibDTpmConstructor (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Tpm2SpiInitialize ();
+
+  Status = Tpm2RegisterTpm2DeviceLib (&mDTpm2InternalTpm2Device);
+  if ((Status == EFI_SUCCESS) || (Status == EFI_UNSUPPORTED)) {
+    //
+    // Unsupported means platform policy does not need this instance enabled.
+    //
+    if (Status == EFI_SUCCESS) {
+      Status = InternalTpm2DeviceLibDTpmCommonConstructor ();
+      DumpPtpInfo ((VOID *)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    }
+
+    return EFI_SUCCESS;
+  }
+
+  return Status;
+}

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.inf
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.inf
@@ -1,0 +1,65 @@
+## @file
+#  Provides a DTPM instance for TPM 2.0 TIS/PTP.
+#
+#  This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+#  engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+#  and PTP (Platform TPM Profile) functions.
+#
+# Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2InstanceLibDTpm
+  MODULE_UNI_FILE                = Tpm2InstanceLibDTpm.uni
+  FILE_GUID                      = 286BF25A-C2C3-408c-B3B4-25E6758B7317
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = Tpm2InstanceLibDTpmConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Ptp.c
+  Tpm2InstanceLibDTpm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+  Tpm2TransferDxe.c
+  Tpm2Transfer.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  SecurityPkg/SecurityPkg.dec
+  Silicon/Sophgo/Sophgo.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  DxeServicesTableLib
+  MemoryAllocationLib
+  UefiBootServicesTableLib
+
+[Protocols]
+  gFdtClientProtocolGuid          ## CONSUMES
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType  ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass             ## PRODUCES
+  gSophgoTokenSpaceGuid.PcdTpm2GpioBaseAddress                 ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdTpm2SpiBaseAddress                  ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdTopBaseAddress                  ## CONSUMES

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.uni
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmDxe.uni
@@ -1,0 +1,18 @@
+// /** @file
+// Provides a DTPM instance for TPM 2.0 TIS/PTP
+//
+// This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+// engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+// and PTP (Platform TPM Profile) functions.
+//
+// Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Provides a DTPM instance for TPM 2.0 TIS/PTP"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This library can be registered to Tpm 2.0 device router, to be active TPM 2.0 engine, based on platform setting. It supports both TIS (TPM Interface Specification) and PTP (Platform TPM Profile) functions."
+

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmPei.inf
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmPei.inf
@@ -1,0 +1,61 @@
+## @file
+#  Provides a DTPM instance for TPM 2.0 TIS/PTP.
+#
+#  This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+#  engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+#  and PTP (Platform TPM Profile) functions.
+#
+# Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = Tpm2InstanceLibDTpm
+  MODULE_UNI_FILE                = Tpm2InstanceLibDTpm.uni
+  FILE_GUID                      = 286BF25A-C2C3-408c-B3B4-25E6758B7317
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = Tpm2InstanceLibDTpmConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  Tpm2Tis.c
+  Tpm2Ptp.c
+  Tpm2InstanceLibDTpm.c
+  Tpm2DeviceLibDTpmBase.c
+  Tpm2DeviceLibDTpm.h
+  Tpm2TransferPei.c
+  Tpm2Transfer.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  SecurityPkg/SecurityPkg.dec
+  Silicon/Sophgo/Sophgo.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  IoLib
+  TimerLib
+  DebugLib
+  PcdLib
+  MemoryAllocationLib
+  HobLib
+
+[Pcd]
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpmBaseAddress          ## CONSUMES
+  gEfiSecurityPkgTokenSpaceGuid.PcdActiveTpmInterfaceType  ## PRODUCES
+  gEfiSecurityPkgTokenSpaceGuid.PcdCRBIdleByPass             ## PRODUCES
+  gSophgoTokenSpaceGuid.PcdTpm2GpioBaseAddress                 ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdTpm2SpiBaseAddress                  ## CONSUMES
+  gSophgoTokenSpaceGuid.PcdTopBaseAddress                  ## CONSUMES

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmPei.uni
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2InstanceLibDTpmPei.uni
@@ -1,0 +1,18 @@
+// /** @file
+// Provides a DTPM instance for TPM 2.0 TIS/PTP
+//
+// This library can be registered to Tpm 2.0 device router, to be active TPM 2.0
+// engine, based on platform setting. It supports both TIS (TPM Interface Specification)
+// and PTP (Platform TPM Profile) functions.
+//
+// Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Provides a DTPM instance for TPM 2.0 TIS/PTP"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This library can be registered to Tpm 2.0 device router, to be active TPM 2.0 engine, based on platform setting. It supports both TIS (TPM Interface Specification) and PTP (Platform TPM Profile) functions."
+

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Ptp.c
@@ -1,0 +1,651 @@
+/** @file
+  PTP (Platform TPM Profile) CRB (Command Response Buffer) interface used by dTPM2.0 library.
+
+Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c), Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/Tpm20.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/IoLib.h>
+#include <Library/TimerLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+
+#include <IndustryStandard/TpmPtp.h>
+#include <IndustryStandard/TpmTis.h>
+
+#include "Tpm2DeviceLibDTpm.h"
+#include "Tpm2Transfer.h"
+
+//
+// Execution of the command may take from several seconds to minutes for certain
+// commands, such as key generation.
+//
+#define PTP_TIMEOUT_MAX  (90000 * 1000)             // 90s
+
+//
+// Max TPM command/response length
+//
+#define TPMCMDBUFLENGTH  0x500
+
+//
+// Max retry count according to Spec TCG PC Client Device Driver Design Principles
+// for TPM2.0, Version 1.1, Revision 0.04, Section 7.2.1
+//
+#define RETRY_CNT_MAX  3
+
+/**
+  Check whether TPM PTP register exist.
+
+  @param[in] Reg  Pointer to PTP register.
+
+  @retval    TRUE    TPM PTP exists.
+  @retval    FALSE   TPM PTP is not found.
+**/
+BOOLEAN
+Tpm2IsPtpPresence (
+  IN VOID  *Reg
+  )
+{
+  UINT8  RegRead;
+
+  RegRead = Tpm2Read8 ((UINTN)Reg);
+  if (RegRead == 0xFF) {
+    DEBUG ((DEBUG_INFO, "PTpm2IsPtpPresence failed is %x\n", RegRead));
+    //
+    // No TPM chip
+    //
+    return FALSE;
+  }
+  DEBUG ((DEBUG_INFO, "PTpm2IsPtpPresence success is %x\n", RegRead));   
+  return TRUE;
+}
+
+/**
+  Check whether the value of a TPM chip register satisfies the input BIT setting.
+
+  @param[in]  Register     Address port of register to be checked.
+  @param[in]  BitSet       Check these data bits are set.
+  @param[in]  BitClear     Check these data bits are clear.
+  @param[in]  TimeOut      The max wait time (unit MicroSecond) when checking register.
+
+  @retval     EFI_SUCCESS  The register satisfies the check bit.
+  @retval     EFI_TIMEOUT  The register can't run into the expected status in time.
+**/
+EFI_STATUS
+PtpCrbWaitRegisterBits (
+  IN      UINT32  *Register,
+  IN      UINT32  BitSet,
+  IN      UINT32  BitClear,
+  IN      UINT32  TimeOut
+  )
+{
+  UINT32  RegRead;
+  UINT32  WaitTime;
+
+  for (WaitTime = 0; WaitTime < TimeOut; WaitTime += 30) {
+    RegRead = Tpm2Read32 ((UINTN)Register);
+    if (((RegRead & BitSet) == BitSet) && ((RegRead & BitClear) == 0)) {
+      return EFI_SUCCESS;
+    }
+
+    MicroSecondDelay (30);
+  }
+
+  return EFI_TIMEOUT;
+}
+
+/**
+  Get the control of TPM chip.
+
+  @param[in] CrbReg                Pointer to CRB register.
+
+  @retval    EFI_SUCCESS           Get the control of TPM chip.
+  @retval    EFI_INVALID_PARAMETER CrbReg is NULL.
+  @retval    EFI_NOT_FOUND         TPM chip doesn't exit.
+  @retval    EFI_TIMEOUT           Can't get the TPM control in time.
+**/
+EFI_STATUS
+PtpCrbRequestUseTpm (
+  IN      PTP_CRB_REGISTERS_PTR  CrbReg
+  )
+{
+  EFI_STATUS  Status;
+
+  if (!Tpm2IsPtpPresence (CrbReg)) {
+    return EFI_NOT_FOUND;
+  }
+
+  Tpm2Write32 ((UINTN)&CrbReg->LocalityControl, PTP_CRB_LOCALITY_CONTROL_REQUEST_ACCESS);
+  Status = PtpCrbWaitRegisterBits (
+             &CrbReg->LocalityStatus,
+             PTP_CRB_LOCALITY_STATUS_GRANTED,
+             0,
+             PTP_TIMEOUT_A
+             );
+  return Status;
+}
+
+/**
+  Send a command to TPM for execution and return response data.
+
+  @param[in]      CrbReg        TPM register space base address.
+  @param[in]      BufferIn      Buffer for command data.
+  @param[in]      SizeIn        Size of command data.
+  @param[in, out] BufferOut     Buffer for response data.
+  @param[in, out] SizeOut       Size of response data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+PtpCrbTpmCommand (
+  IN     PTP_CRB_REGISTERS_PTR  CrbReg,
+  IN     UINT8                  *BufferIn,
+  IN     UINT32                 SizeIn,
+  IN OUT UINT8                  *BufferOut,
+  IN OUT UINT32                 *SizeOut
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      Index;
+  UINT32      TpmOutSize;
+  UINT16      Data16;
+  UINT32      Data32;
+  UINT8       RetryCnt;
+
+  DEBUG_CODE_BEGIN ();
+  UINTN  DebugSize;
+
+  DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand Send - "));
+  if (SizeIn > 0x100) {
+    DebugSize = 0x40;
+  } else {
+    DebugSize = SizeIn;
+  }
+
+  for (Index = 0; Index < DebugSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+  }
+
+  if (DebugSize != SizeIn) {
+    DEBUG ((DEBUG_VERBOSE, "...... "));
+    for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+    }
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  TpmOutSize = 0;
+
+  RetryCnt = 0;
+  while (TRUE) {
+    //
+    // STEP 0:
+    // if CapCRbIdelByPass == 0, enforce Idle state before sending command
+    //
+    if ((GetCachedIdleByPass () == 0) && ((Tpm2Read32 ((UINTN)&CrbReg->CrbControlStatus) & PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE) == 0)) {
+      Status = PtpCrbWaitRegisterBits (
+                 &CrbReg->CrbControlStatus,
+                 PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE,
+                 0,
+                 PTP_TIMEOUT_C
+                 );
+      if (EFI_ERROR (Status)) {
+        RetryCnt++;
+        if (RetryCnt < RETRY_CNT_MAX) {
+          Tpm2Write32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
+          continue;
+        } else {
+          //
+          // Try to goIdle to recover TPM
+          //
+          Status = EFI_DEVICE_ERROR;
+          goto GoIdle_Exit;
+        }
+      }
+    }
+
+    //
+    // STEP 1:
+    // Ready is any time the TPM is ready to receive a command, following a write
+    // of 1 by software to Request.cmdReady, as indicated by the Status field
+    // being cleared to 0.
+    //
+    Tpm2Write32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_COMMAND_READY);
+    Status = PtpCrbWaitRegisterBits (
+               &CrbReg->CrbControlRequest,
+               0,
+               PTP_CRB_CONTROL_AREA_REQUEST_COMMAND_READY,
+               PTP_TIMEOUT_C
+               );
+    if (EFI_ERROR (Status)) {
+      RetryCnt++;
+      if (RetryCnt < RETRY_CNT_MAX) {
+        Tpm2Write32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
+        continue;
+      } else {
+        Status = EFI_DEVICE_ERROR;
+        goto GoIdle_Exit;
+      }
+    }
+
+    Status = PtpCrbWaitRegisterBits (
+               &CrbReg->CrbControlStatus,
+               0,
+               PTP_CRB_CONTROL_AREA_STATUS_TPM_IDLE,
+               PTP_TIMEOUT_C
+               );
+    if (EFI_ERROR (Status)) {
+      RetryCnt++;
+      if (RetryCnt < RETRY_CNT_MAX) {
+        Tpm2Write32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
+        continue;
+      } else {
+        Status = EFI_DEVICE_ERROR;
+        goto GoIdle_Exit;
+      }
+    }
+
+    break;
+  }
+
+  //
+  // STEP 2:
+  // Command Reception occurs following a Ready state between the write of the
+  // first byte of a command to the Command Buffer and the receipt of a write
+  // of 1 to Start.
+  //
+  for (Index = 0; Index < SizeIn; Index++) {
+    Tpm2Write8 ((UINTN)&CrbReg->CrbDataBuffer[Index], BufferIn[Index]);
+  }
+
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlCommandAddressHigh, (UINT32)RShiftU64 ((UINTN)CrbReg->CrbDataBuffer, 32));
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlCommandAddressLow, (UINT32)(UINTN)CrbReg->CrbDataBuffer);
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlCommandSize, sizeof (CrbReg->CrbDataBuffer));
+
+  MmioWrite64 ((UINTN)&CrbReg->CrbControlResponseAddrss, (UINT32)(UINTN)CrbReg->CrbDataBuffer);
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlResponseSize, sizeof (CrbReg->CrbDataBuffer));
+
+  //
+  // STEP 3:
+  // Command Execution occurs after receipt of a 1 to Start and the TPM
+  // clearing Start to 0.
+  //
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlStart, PTP_CRB_CONTROL_START);
+  Status = PtpCrbWaitRegisterBits (
+             &CrbReg->CrbControlStart,
+             0,
+             PTP_CRB_CONTROL_START,
+             PTP_TIMEOUT_MAX
+             );
+  if (EFI_ERROR (Status)) {
+    //
+    // Command Completion check timeout. Cancel the currently executing command by writing TPM_CRB_CTRL_CANCEL,
+    // Expect TPM_RC_CANCELLED or successfully completed response.
+    //
+    Tpm2Write32 ((UINTN)&CrbReg->CrbControlCancel, PTP_CRB_CONTROL_CANCEL);
+    Status = PtpCrbWaitRegisterBits (
+               &CrbReg->CrbControlStart,
+               0,
+               PTP_CRB_CONTROL_START,
+               PTP_TIMEOUT_B
+               );
+    Tpm2Write32 ((UINTN)&CrbReg->CrbControlCancel, 0);
+
+    if (EFI_ERROR (Status)) {
+      //
+      // Still in Command Execution state. Try to goIdle, the behavior is agnostic.
+      //
+      Status = EFI_DEVICE_ERROR;
+      goto GoIdle_Exit;
+    }
+  }
+
+  //
+  // STEP 4:
+  // Command Completion occurs after completion of a command (indicated by the
+  // TPM clearing TPM_CRB_CTRL_Start_x to 0) and before a write of a 1 by the
+  // software to Request.goIdle.
+  //
+
+  //
+  // Get response data header
+  //
+  for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
+    BufferOut[Index] = Tpm2Read8 ((UINTN)&CrbReg->CrbDataBuffer[Index]);
+  }
+
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand ReceiveHeader - "));
+  for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  //
+  // Check the response data header (tag, parasize and returncode)
+  //
+  CopyMem (&Data16, BufferOut, sizeof (UINT16));
+  // TPM2 should not use this RSP_COMMAND
+  if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
+    DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
+    Status = EFI_UNSUPPORTED;
+    goto GoIdle_Exit;
+  }
+
+  CopyMem (&Data32, (BufferOut + 2), sizeof (UINT32));
+  TpmOutSize = SwapBytes32 (Data32);
+  if (*SizeOut < TpmOutSize) {
+    //
+    // Command completed, but buffer is not enough
+    //
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto GoIdle_Exit;
+  }
+
+  *SizeOut = TpmOutSize;
+  //
+  // Continue reading the remaining data
+  //
+  for (Index = sizeof (TPM2_RESPONSE_HEADER); Index < TpmOutSize; Index++) {
+    BufferOut[Index] = Tpm2Read8 ((UINTN)&CrbReg->CrbDataBuffer[Index]);
+  }
+
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "PtpCrbTpmCommand Receive - "));
+  for (Index = 0; Index < TpmOutSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+
+  //
+  // Do not wait for state transition for TIMEOUT_C
+  // This function will try to wait 2 TIMEOUT_C at the beginning in next call.
+  //
+GoIdle_Exit:
+
+  //
+  //  Return to Idle state by setting TPM_CRB_CTRL_STS_x.Status.goIdle to 1.
+  //
+  Tpm2Write32 ((UINTN)&CrbReg->CrbControlRequest, PTP_CRB_CONTROL_AREA_REQUEST_GO_IDLE);
+
+  return Status;
+}
+
+/**
+  Send a command to TPM for execution and return response data.
+
+  @param[in]      TisReg        TPM register space base address.
+  @param[in]      BufferIn      Buffer for command data.
+  @param[in]      SizeIn        Size of command data.
+  @param[in, out] BufferOut     Buffer for response data.
+  @param[in, out] SizeOut       Size of response data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2TisTpmCommand (
+  IN     TIS_PC_REGISTERS_PTR  TisReg,
+  IN     UINT8                 *BufferIn,
+  IN     UINT32                SizeIn,
+  IN OUT UINT8                 *BufferOut,
+  IN OUT UINT32                *SizeOut
+  );
+
+/**
+  Get the control of TPM chip by sending requestUse command TIS_PC_ACC_RQUUSE
+  to ACCESS Register in the time of default TIS_TIMEOUT_A.
+
+  @param[in] TisReg                Pointer to TIS register.
+
+  @retval    EFI_SUCCESS           Get the control of TPM chip.
+  @retval    EFI_INVALID_PARAMETER TisReg is NULL.
+  @retval    EFI_NOT_FOUND         TPM chip doesn't exit.
+  @retval    EFI_TIMEOUT           Can't get the TPM control in time.
+**/
+EFI_STATUS
+TisPcRequestUseTpm (
+  IN     TIS_PC_REGISTERS_PTR  TisReg
+  );
+
+/**
+  Return PTP interface type.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @return PTP interface type.
+**/
+TPM2_PTP_INTERFACE_TYPE
+Tpm2GetPtpInterface (
+  IN VOID  *Register
+  )
+{
+  PTP_CRB_INTERFACE_IDENTIFIER   InterfaceId;
+  PTP_FIFO_INTERFACE_CAPABILITY  InterfaceCapability;
+
+  if (!Tpm2IsPtpPresence (Register)) {
+    return Tpm2PtpInterfaceMax;
+  }
+
+  //
+  // Check interface id
+  //
+  InterfaceId.Uint32         = Tpm2Read32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+  InterfaceCapability.Uint32 = Tpm2Read32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
+
+  if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_CRB) &&
+      (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB) &&
+      (InterfaceId.Bits.CapCRB != 0))
+  {
+    return Tpm2PtpInterfaceCrb;
+  }
+
+  if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO) &&
+      (InterfaceId.Bits.InterfaceVersion == PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_FIFO) &&
+      (InterfaceId.Bits.CapFIFO != 0) &&
+      (InterfaceCapability.Bits.InterfaceVersion == INTERFACE_CAPABILITY_INTERFACE_VERSION_PTP))
+  {
+    return Tpm2PtpInterfaceFifo;
+  }
+
+  if (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) {
+    return Tpm2PtpInterfaceTis;
+  }
+
+  return Tpm2PtpInterfaceMax;
+}
+
+/**
+  Return PTP CRB interface IdleByPass state.
+
+  @param[in] Register                Pointer to PTP register.
+
+  @return PTP CRB interface IdleByPass state.
+**/
+UINT8
+Tpm2GetIdleByPass (
+  IN VOID  *Register
+  )
+{
+  PTP_CRB_INTERFACE_IDENTIFIER  InterfaceId;
+
+  //
+  // Check interface id
+  //
+  InterfaceId.Uint32 = Tpm2Read32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+
+  return (UINT8)(InterfaceId.Bits.CapCRBIdleBypass);
+}
+
+/**
+  Dump PTP register information.
+
+  @param[in] Register                Pointer to PTP register.
+**/
+VOID
+DumpPtpInfo (
+  IN VOID  *Register
+  )
+{
+  PTP_CRB_INTERFACE_IDENTIFIER   InterfaceId;
+  PTP_FIFO_INTERFACE_CAPABILITY  InterfaceCapability;
+  UINT8                          StatusEx;
+  UINT16                         Vid;
+  UINT16                         Did;
+  UINT8                          Rid;
+  TPM2_PTP_INTERFACE_TYPE        PtpInterface;
+
+  if (!Tpm2IsPtpPresence (Register)) {
+    return;
+  }
+
+  InterfaceId.Uint32         = Tpm2Read32 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->InterfaceId);
+  InterfaceCapability.Uint32 = Tpm2Read32 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->InterfaceCapability);
+  StatusEx                   = Tpm2Read8 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->StatusEx);
+
+  //
+  // Dump InterfaceId Register for PTP
+  //
+  DEBUG ((DEBUG_INFO, "InterfaceId - 0x%08x\n", InterfaceId.Uint32));
+  DEBUG ((DEBUG_INFO, "  InterfaceType    - 0x%02x\n", InterfaceId.Bits.InterfaceType));
+  if (InterfaceId.Bits.InterfaceType != PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) {
+    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%02x\n", InterfaceId.Bits.InterfaceVersion));
+    DEBUG ((DEBUG_INFO, "  CapFIFO          - 0x%x\n", InterfaceId.Bits.CapFIFO));
+    DEBUG ((DEBUG_INFO, "  CapCRB           - 0x%x\n", InterfaceId.Bits.CapCRB));
+  }
+
+  //
+  // Dump Capability Register for TIS and FIFO
+  //
+  DEBUG ((DEBUG_INFO, "InterfaceCapability - 0x%08x\n", InterfaceCapability.Uint32));
+  if ((InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_TIS) ||
+      (InterfaceId.Bits.InterfaceType == PTP_INTERFACE_IDENTIFIER_INTERFACE_TYPE_FIFO))
+  {
+    DEBUG ((DEBUG_INFO, "  InterfaceVersion - 0x%x\n", InterfaceCapability.Bits.InterfaceVersion));
+  }
+
+  //
+  // Dump StatusEx Register for PTP FIFO
+  //
+  DEBUG ((DEBUG_INFO, "StatusEx - 0x%02x\n", StatusEx));
+  if (InterfaceCapability.Bits.InterfaceVersion == INTERFACE_CAPABILITY_INTERFACE_VERSION_PTP) {
+    DEBUG ((DEBUG_INFO, "  TpmFamily - 0x%x\n", (StatusEx & PTP_FIFO_STS_EX_TPM_FAMILY) >> PTP_FIFO_STS_EX_TPM_FAMILY_OFFSET));
+  }
+
+  Vid          = 0xFFFF;
+  Did          = 0xFFFF;
+  Rid          = 0xFF;
+  PtpInterface = GetCachedPtpInterface ();
+  DEBUG ((DEBUG_INFO, "PtpInterface - %x\n", PtpInterface));
+  switch (PtpInterface) {
+    case Tpm2PtpInterfaceCrb:
+      Vid = Tpm2Read16 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->Vid);
+      Did = Tpm2Read16 ((UINTN)&((PTP_CRB_REGISTERS *)Register)->Did);
+      Rid = (UINT8)InterfaceId.Bits.Rid;
+      break;
+    case Tpm2PtpInterfaceFifo:
+    case Tpm2PtpInterfaceTis:
+      Vid = Tpm2Read16 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->Vid);
+      Did = Tpm2Read16 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->Did);
+      Rid = Tpm2Read8 ((UINTN)&((PTP_FIFO_REGISTERS *)Register)->Rid);
+      break;
+    default:
+      break;
+  }
+
+  DEBUG ((DEBUG_INFO, "VID - 0x%04x\n", Vid));
+  DEBUG ((DEBUG_INFO, "DID - 0x%04x\n", Did));
+  DEBUG ((DEBUG_INFO, "RID - 0x%02x\n", Rid));
+}
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2SubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  TPM2_PTP_INTERFACE_TYPE  PtpInterface;
+
+  PtpInterface = GetCachedPtpInterface ();
+  switch (PtpInterface) {
+    case Tpm2PtpInterfaceCrb:
+      return PtpCrbTpmCommand (
+               (PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress),
+               InputParameterBlock,
+               InputParameterBlockSize,
+               OutputParameterBlock,
+               OutputParameterBlockSize
+               );
+    case Tpm2PtpInterfaceFifo:
+    case Tpm2PtpInterfaceTis:
+      return Tpm2TisTpmCommand (
+               (TIS_PC_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress),
+               InputParameterBlock,
+               InputParameterBlockSize,
+               OutputParameterBlock,
+               OutputParameterBlockSize
+               );
+    default:
+      return EFI_NOT_FOUND;
+  }
+}
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2RequestUseTpm (
+  VOID
+  )
+{
+  TPM2_PTP_INTERFACE_TYPE  PtpInterface;
+
+  PtpInterface = GetCachedPtpInterface ();
+  switch (PtpInterface) {
+    case Tpm2PtpInterfaceCrb:
+      return PtpCrbRequestUseTpm ((PTP_CRB_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    case Tpm2PtpInterfaceFifo:
+    case Tpm2PtpInterfaceTis:
+      return TisPcRequestUseTpm ((TIS_PC_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+    default:
+      return EFI_NOT_FOUND;
+  }
+}

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Tis.c
@@ -1,0 +1,454 @@
+/** @file
+  TIS (TPM Interface Specification) functions used by dTPM2.0 library.
+
+Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <IndustryStandard/Tpm20.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/IoLib.h>
+#include <Library/TimerLib.h>
+#include <Library/DebugLib.h>
+#include <Library/Tpm2DeviceLib.h>
+#include <Library/PcdLib.h>
+
+#include <IndustryStandard/TpmTis.h>
+#include "Tpm2Transfer.h"
+
+#define TIS_TIMEOUT_MAX  (90000 * 1000)             // 90s
+
+//
+// Max TPM command/response length
+//
+#define TPMCMDBUFLENGTH  0x500
+
+/**
+  Check whether TPM chip exist.
+
+  @param[in] TisReg  Pointer to TIS register.
+
+  @retval    TRUE    TPM chip exists.
+  @retval    FALSE   TPM chip is not found.
+**/
+BOOLEAN
+TisPcPresenceCheck (
+  IN      TIS_PC_REGISTERS_PTR  TisReg
+  )
+{
+  UINT8  RegRead;
+
+  RegRead = Tpm2Read8 ((UINTN)&TisReg->Access);
+  return (BOOLEAN)(RegRead != (UINT8)-1);
+}
+
+/**
+  Check whether the value of a TPM chip register satisfies the input BIT setting.
+
+  @param[in]  Register     Address port of register to be checked.
+  @param[in]  BitSet       Check these data bits are set.
+  @param[in]  BitClear     Check these data bits are clear.
+  @param[in]  TimeOut      The max wait time (unit MicroSecond) when checking register.
+
+  @retval     EFI_SUCCESS  The register satisfies the check bit.
+  @retval     EFI_TIMEOUT  The register can't run into the expected status in time.
+**/
+EFI_STATUS
+TisPcWaitRegisterBits (
+  IN      UINT8   *Register,
+  IN      UINT8   BitSet,
+  IN      UINT8   BitClear,
+  IN      UINT32  TimeOut
+  )
+{
+  UINT8   RegRead;
+  UINT32  WaitTime;
+
+  for (WaitTime = 0; WaitTime < TimeOut; WaitTime += 30) {
+    RegRead = Tpm2Read8 ((UINTN)Register);
+    if (((RegRead & BitSet) == BitSet) && ((RegRead & BitClear) == 0)) {
+      //DEBUG ((DEBUG_INFO, "Success: Read Byte is 0x%x!\n", RegRead));
+      return EFI_SUCCESS;
+    }
+
+    MicroSecondDelay (30);
+  }
+  DEBUG ((DEBUG_INFO, "Fail: Read Byte is 0x%x!\n", RegRead));
+  return EFI_TIMEOUT;
+}
+
+/**
+  Get BurstCount by reading the burstCount field of a TIS register
+  in the time of default TIS_TIMEOUT_D.
+
+  @param[in]  TisReg                Pointer to TIS register.
+  @param[out] BurstCount            Pointer to a buffer to store the got BurstCount.
+
+  @retval     EFI_SUCCESS           Get BurstCount.
+  @retval     EFI_INVALID_PARAMETER TisReg is NULL or BurstCount is NULL.
+  @retval     EFI_TIMEOUT           BurstCount can't be got in time.
+**/
+EFI_STATUS
+TisPcReadBurstCount (
+  IN      TIS_PC_REGISTERS_PTR  TisReg,
+  OUT  UINT16                   *BurstCount
+  )
+{
+  UINT32  WaitTime;
+  UINT8   DataByte0;
+  UINT8   DataByte1;
+
+  if ((BurstCount == NULL) || (TisReg == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  WaitTime = 0;
+  do {
+    //
+    // TIS_PC_REGISTERS_PTR->burstCount is UINT16, but it is not 2bytes aligned,
+    // so it needs to use Tpm2Read8 to read two times
+    //
+    DataByte0   = Tpm2Read8 ((UINTN)&TisReg->BurstCount);
+    DataByte1   = Tpm2Read8 ((UINTN)&TisReg->BurstCount + 1);
+    *BurstCount = (UINT16)((DataByte1 << 8) + DataByte0);
+    if (*BurstCount != 0) {
+      return EFI_SUCCESS;
+    }
+
+    MicroSecondDelay (30);
+    WaitTime += 30;
+  } while (WaitTime < TIS_TIMEOUT_D);
+
+  return EFI_TIMEOUT;
+}
+
+/**
+  Set TPM chip to ready state by sending ready command TIS_PC_STS_READY
+  to Status Register in time.
+
+  @param[in] TisReg                Pointer to TIS register.
+
+  @retval    EFI_SUCCESS           TPM chip enters into ready state.
+  @retval    EFI_INVALID_PARAMETER TisReg is NULL.
+  @retval    EFI_TIMEOUT           TPM chip can't be set to ready state in time.
+**/
+EFI_STATUS
+TisPcPrepareCommand (
+  IN      TIS_PC_REGISTERS_PTR  TisReg
+  )
+{
+  EFI_STATUS  Status;
+
+  if (TisReg == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Tpm2Write8 ((UINTN)&TisReg->Status, TIS_PC_STS_READY);
+  Status = TisPcWaitRegisterBits (
+             &TisReg->Status,
+             TIS_PC_STS_READY,
+             0,
+             TIS_TIMEOUT_B
+             );
+  return Status;
+}
+
+/**
+  Get the control of TPM chip by sending requestUse command TIS_PC_ACC_RQUUSE
+  to ACCESS Register in the time of default TIS_TIMEOUT_A.
+
+  @param[in] TisReg                Pointer to TIS register.
+
+  @retval    EFI_SUCCESS           Get the control of TPM chip.
+  @retval    EFI_INVALID_PARAMETER TisReg is NULL.
+  @retval    EFI_NOT_FOUND         TPM chip doesn't exit.
+  @retval    EFI_TIMEOUT           Can't get the TPM control in time.
+**/
+EFI_STATUS
+TisPcRequestUseTpm (
+  IN      TIS_PC_REGISTERS_PTR  TisReg
+  )
+{
+  EFI_STATUS  Status;
+
+  if (TisReg == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!TisPcPresenceCheck (TisReg)) {
+    return EFI_NOT_FOUND;
+  }
+
+  Tpm2Write8 ((UINTN)&TisReg->Access, TIS_PC_ACC_RQUUSE);
+  Status = TisPcWaitRegisterBits (
+             &TisReg->Access,
+             (UINT8)(TIS_PC_ACC_ACTIVE |TIS_PC_VALID),
+             0,
+             TIS_TIMEOUT_A
+             );
+  return Status;
+}
+
+/**
+  Send a command to TPM for execution and return response data.
+
+  @param[in]      TisReg        TPM register space base address.
+  @param[in]      BufferIn      Buffer for command data.
+  @param[in]      SizeIn        Size of command data.
+  @param[in, out] BufferOut     Buffer for response data.
+  @param[in, out] SizeOut       Size of response data.
+
+  @retval EFI_SUCCESS           Operation completed successfully.
+  @retval EFI_BUFFER_TOO_SMALL  Response data buffer is too small.
+  @retval EFI_DEVICE_ERROR      Unexpected device behavior.
+  @retval EFI_UNSUPPORTED       Unsupported TPM version
+
+**/
+EFI_STATUS
+Tpm2TisTpmCommand (
+  IN     TIS_PC_REGISTERS_PTR  TisReg,
+  IN     UINT8                 *BufferIn,
+  IN     UINT32                SizeIn,
+  IN OUT UINT8                 *BufferOut,
+  IN OUT UINT32                *SizeOut
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      BurstCount;
+  UINT32      Index;
+  UINT32      TpmOutSize;
+  UINT16      Data16;
+  UINT32      Data32;
+  UINT16      TrSize;
+  UINT8*      TpmTmpOut;
+
+  DEBUG_CODE_BEGIN ();
+  UINTN  DebugSize;
+
+  DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand Send - "));
+  if (SizeIn > 0x100) {
+    DebugSize = 0x40;
+  } else {
+    DebugSize = SizeIn;
+  }
+
+  for (Index = 0; Index < DebugSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+  }
+
+  if (DebugSize != SizeIn) {
+    DEBUG ((DEBUG_VERBOSE, "...... "));
+    for (Index = SizeIn - 0x20; Index < SizeIn; Index++) {
+      DEBUG ((DEBUG_VERBOSE, "%02x ", BufferIn[Index]));
+    }
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  TpmOutSize = 0;
+
+  Status = TisPcPrepareCommand (TisReg);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2 is not ready for command!\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Send the command data to Tpm
+  //
+  Index = 0;
+  while (Index < SizeIn) {
+    Status = TisPcReadBurstCount (TisReg, &BurstCount);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "burst count get failed!\n"));
+      Status = EFI_DEVICE_ERROR;
+      goto Exit;
+    }
+
+    TrSize = MIN_T (UINT16, BurstCount, SizeIn);
+    Tpm2WriteNBytes ((UINTN)&TisReg->DataFifo, BufferIn, TrSize);
+    BufferIn += TrSize;
+    Index += TrSize;
+  }
+
+  //
+  // Check the Tpm status STS_EXPECT change from 1 to 0
+  //
+  Status = TisPcWaitRegisterBits (
+             &TisReg->Status,
+             (UINT8)TIS_PC_VALID,
+             TIS_PC_STS_EXPECT,
+             TIS_TIMEOUT_B
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Tpm2 The send buffer too small!\n"));
+    Status = EFI_BUFFER_TOO_SMALL;
+    goto Exit;
+  }
+
+  //
+  // Executed the TPM command and waiting for the response data ready
+  //
+  Tpm2Write8 ((UINTN)&TisReg->Status, TIS_PC_STS_GO);
+
+  //
+  // NOTE: That may take many seconds to minutes for certain commands, such as key generation.
+  //
+  Status = TisPcWaitRegisterBits (
+             &TisReg->Status,
+             (UINT8)(TIS_PC_VALID | TIS_PC_STS_DATA),
+             0,
+             TIS_TIMEOUT_MAX
+             );
+  if (EFI_ERROR (Status)) {
+    //
+    // dataAvail check timeout. Cancel the currently executing command by writing commandCancel,
+    // Expect TPM_RC_CANCELLED or successfully completed response.
+    //
+    DEBUG ((DEBUG_ERROR, "Wait for Tpm2 response data time out. Trying to cancel the command!!\n"));
+
+    Tpm2Write32 ((UINTN)&TisReg->Status, TIS_PC_STS_CANCEL);
+    Status = TisPcWaitRegisterBits (
+               &TisReg->Status,
+               (UINT8)(TIS_PC_VALID | TIS_PC_STS_DATA),
+               0,
+               TIS_TIMEOUT_B
+               );
+    //
+    // Do not clear CANCEL bit here because Writes of 0 to this bit are ignored
+    //
+    if (EFI_ERROR (Status)) {
+      //
+      // Cancel executing command fail to get any response
+      // Try to abort the command with write of a 1 to commandReady in Command Execution state
+      //
+      Status = EFI_DEVICE_ERROR;
+      goto Exit;
+    }
+  }
+
+  //
+  // Get response data header
+  //
+  Index      = 0;
+  BurstCount = 0;
+  TpmTmpOut = BufferOut;
+  while (Index < sizeof (TPM2_RESPONSE_HEADER)) {
+    Status = TisPcReadBurstCount (TisReg, &BurstCount);
+    if (EFI_ERROR (Status)) {
+      Status = EFI_DEVICE_ERROR;
+      DEBUG ((DEBUG_ERROR, "TisPcReadBurstCount error - %x\n", EFI_DEVICE_ERROR));
+      goto Exit;
+    }
+
+    TrSize = MIN_T (UINT16, BurstCount, sizeof (TPM2_RESPONSE_HEADER));
+    Tpm2readNBytes ((UINTN)&TisReg->DataFifo, TrSize, TpmTmpOut);
+    Index += TrSize;
+    TpmTmpOut += TrSize;
+  }
+
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand ReceiveHeader - "));
+  for (Index = 0; Index < sizeof (TPM2_RESPONSE_HEADER); Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  //
+  // Check the response data header (tag,parasize and returncode )
+  //
+  CopyMem (&Data16, BufferOut, sizeof (UINT16));
+  // TPM2 should not use this RSP_COMMAND
+  if (SwapBytes16 (Data16) == TPM_ST_RSP_COMMAND) {
+    DEBUG ((DEBUG_ERROR, "TPM2: TPM_ST_RSP error - %x\n", TPM_ST_RSP_COMMAND));
+    Status = EFI_UNSUPPORTED;
+    goto Exit;
+  }
+
+  CopyMem (&Data32, (BufferOut + 2), sizeof (UINT32));
+  TpmOutSize = SwapBytes32 (Data32);
+  if (*SizeOut < TpmOutSize) {
+    Status = EFI_BUFFER_TOO_SMALL;
+    DEBUG ((DEBUG_ERROR, "TPM2: Out buffer too small - %x\n", EFI_BUFFER_TOO_SMALL));
+    goto Exit;
+  }
+
+  *SizeOut = TpmOutSize;
+  //
+  // Continue reading the remaining data
+  //
+  while ( Index < TpmOutSize ) {
+    Status = TisPcReadBurstCount (TisReg, &BurstCount);
+    if (EFI_ERROR (Status)) {
+      Status = EFI_DEVICE_ERROR;
+      goto Exit;
+    }
+    TrSize = MIN_T (UINT16, BurstCount, TpmOutSize - Index);
+    Tpm2readNBytes ((UINTN)&TisReg->DataFifo, TrSize, TpmTmpOut);
+    Index += TrSize;
+    TpmTmpOut += TrSize;
+  }
+
+Exit:
+  DEBUG_CODE_BEGIN ();
+  DEBUG ((DEBUG_VERBOSE, "Tpm2TisTpmCommand Receive - "));
+  for (Index = 0; Index < TpmOutSize; Index++) {
+    DEBUG ((DEBUG_VERBOSE, "%02x ", BufferOut[Index]));
+  }
+
+  DEBUG ((DEBUG_VERBOSE, "\n"));
+  DEBUG_CODE_END ();
+  Tpm2Write8 ((UINTN)&TisReg->Status, TIS_PC_STS_READY);
+  return Status;
+}
+
+/**
+  This service enables the sending of commands to the TPM2.
+
+  @param[in]      InputParameterBlockSize  Size of the TPM2 input parameter block.
+  @param[in]      InputParameterBlock      Pointer to the TPM2 input parameter block.
+  @param[in,out]  OutputParameterBlockSize Size of the TPM2 output parameter block.
+  @param[in]      OutputParameterBlock     Pointer to the TPM2 output parameter block.
+
+  @retval EFI_SUCCESS            The command byte stream was successfully sent to the device and a response was successfully received.
+  @retval EFI_DEVICE_ERROR       The command was not successfully sent to the device or a response was not successfully received from the device.
+  @retval EFI_BUFFER_TOO_SMALL   The output parameter block is too small.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2TisSubmitCommand (
+  IN UINT32      InputParameterBlockSize,
+  IN UINT8       *InputParameterBlock,
+  IN OUT UINT32  *OutputParameterBlockSize,
+  IN UINT8       *OutputParameterBlock
+  )
+{
+  return Tpm2TisTpmCommand (
+           (TIS_PC_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress),
+           InputParameterBlock,
+           InputParameterBlockSize,
+           OutputParameterBlock,
+           OutputParameterBlockSize
+           );
+}
+
+/**
+  This service requests use TPM2.
+
+  @retval EFI_SUCCESS      Get the control of TPM2 chip.
+  @retval EFI_NOT_FOUND    TPM2 not found.
+  @retval EFI_DEVICE_ERROR Unexpected device behavior.
+**/
+EFI_STATUS
+EFIAPI
+DTpm2TisRequestUseTpm (
+  VOID
+  )
+{
+  return TisPcRequestUseTpm ((TIS_PC_REGISTERS_PTR)(UINTN)PcdGet64 (PcdTpmBaseAddress));
+}

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Transfer.h
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2Transfer.h
@@ -1,0 +1,236 @@
+#ifndef _TPM2_TRANSFER_H_
+#define _TPM2_TRANSFER_H_
+
+#include <Include/DwSpi.h>
+#include <Library/DebugLib.h>
+
+#define MIN3(Nx, Ny, Nz)    MIN((typeof(Nx))MIN(Nx, Ny), Nz)
+#define UINT64_C(Val)       (Val ## UL)
+#define GENMASK_64(Nh, Nl)  (((~UINT64_C(0)) << (Nl)) & (~UINT64_C(0) >> (64 - 1 - (Nh))))
+#define GENMASK(Nh, Nl)     GENMASK_64(Nh, Nl)
+#define BIT(Nr)             (1 << (Nr))
+
+
+#define BUFFER_SIZE_8 5
+#define BUFFER_SIZE_16 6
+#define BUFFER_SIZE_32 8
+
+//
+// Divide positive or negative dividend by positive or negative divisor
+// and round to closest integer. Result is undefined for negative
+// divisors if the dividend variable type is unsigned and for negative
+// dividends if the divisor variable type is unsigned.
+//
+#define DIV_ROUND_CLOSEST(x, Divisor)(  \
+{                                       \
+  typeof(x) __x = x;                    \
+  typeof(Divisor) __d = Divisor;        \
+  (((typeof(x))-1) > 0 ||               \
+    ((typeof(Divisor))-1) > 0 ||        \
+    (((__x) > 0) == ((__d) > 0))) ?     \
+    (((__x) + ((__d) / 2)) / (__d)) :   \
+    (((__x) - ((__d) / 2)) / (__d));    \
+  }                                     \
+)
+
+#define DIV_ROUND_UP(Nn, Nd) (((Nn) + (Nd) - 1) / (Nd))
+
+#define MIN_T(Type, Nx, Ny) ({          \
+  Type __Min1 = (Nx);                   \
+  Type __Min2 = (Ny);                   \
+  __Min1 < __Min2 ? __Min1: __Min2; })
+
+#define BITS_TO_BYTES(Nr)       DIV_ROUND_UP(Nr, 8)
+
+#define NSEC_PER_SEC           (1000000000L)
+#define NSEC_PER_USEC          (1000L)
+#define BITS_PER_BYTE          8
+
+#define DW_SPI_GET_BYTE(_Val, _Idx)     \
+  ((_Val) >> (BITS_PER_BYTE * (_Idx)) & 0xff)
+
+#define DW_SPI_WAIT_RETRIES    5
+#define DW_SPI_SR_BUSY         BIT(0)
+
+//
+// Register offsets
+//
+#define DW_SPI_CTRLR0          0x00
+#define DW_SPI_CTRLR1          0x04
+#define DW_SPI_SSIENR          0x08
+#define DW_SPI_MWCR            0x0c
+#define DW_SPI_SER             0x10
+#define DW_SPI_BAUDR           0x14
+#define DW_SPI_TXFTLR          0x18
+#define DW_SPI_RXFTLR          0x1c
+#define DW_SPI_TXFLR           0x20
+#define DW_SPI_RXFLR           0x24
+#define DW_SPI_SR              0x28
+#define DW_SPI_IMR             0x2c
+#define DW_SPI_ISR             0x30
+#define DW_SPI_RISR            0x34
+#define DW_SPI_TXOICR          0x38
+#define DW_SPI_RXOICR          0x3c
+#define DW_SPI_RXUICR          0x40
+#define DW_SPI_MSTICR          0x44
+#define DW_SPI_ICR             0x48
+#define DW_SPI_DMACR           0x4c
+#define DW_SPI_DMATDLR         0x50
+#define DW_SPI_DMARDLR         0x54
+#define DW_SPI_IDR             0x58
+#define DW_SPI_VERSION         0x5c
+#define DW_SPI_DR              0x60
+#define DW_SPI_RX_SAMPLE_DLY   0xf0
+
+//
+// Bit fields in CTRLR0
+//
+#define CTRLR0_DFS_MASK        GENMASK(3, 0)
+
+#define CTRLR0_FRF_MASK        GENMASK(5, 4)
+#define CTRLR0_FRF_SPI         0x0
+#define CTRLR0_FRF_SSP         0x1
+#define CTRLR0_FRF_MICROWIRE   0x2
+#define CTRLR0_FRF_RESV        0x3
+
+#define CTRLR0_DFS_OFFSET      0
+#define CTRLR0_DFS_32_OFFSET   16
+
+#define CTRLR0_MODE_MASK       GENMASK(7, 6)
+#define DW_CTRLR0_SCPHA        BIT(6)
+#define DW_CTRLR0_SCPOL        BIT(7)
+#define DW_CTRLR0_SRL          BIT(11)
+#define DW_CTRLR0_SSTE	       BIT(24)
+
+#define CTRLR0_SPI_CPHA        BIT(0)
+#define CTRLR0_SPI_CPOL        BIT(1)
+#define CTRLR0_SPI_LOOP        BIT(5)
+
+//
+// check chipselect if active high or not
+//
+#define SPI_CS_HIGH            BIT(2)
+
+#define CTRLR0_TMOD_MASK       GENMASK(9, 8)
+#define CTRLR0_TMOD_TR         0x0
+#define CTRLR0_TMOD_TO         0x1
+#define CTRLR0_TMOD_RO         0x2
+#define CTRLR0_TMOD_EPROMREAD  0x3
+
+//
+// Bit fields in ISR, IMR, RISR, 7 bits
+//
+#define DW_SPI_INT_MASK        GENMASK(5, 0)
+#define DW_SPI_INT_TXEI        BIT(0)
+#define DW_SPI_INT_TXOI        BIT(1)
+#define DW_SPI_INT_RXUI        BIT(2)
+#define DW_SPI_INT_RXOI        BIT(3)
+#define DW_SPI_INT_RXFI        BIT(4)
+#define DW_SPI_INT_MSTI        BIT(5)
+
+#define TRY_TIMES                 50
+#define TOP_SPI0_CS_OFFSET        0xe4
+#define TOP_PIN_MUX_OFFSET        0x1000
+
+#define GPIO_SWPORTA_DR           0x00000000
+#define GPIO_SWPORTA_DDR          0x00000004
+#define GPIO_EXT_PORTA            0x00000050
+#define GPIO_PINS_PER_CONTROLLER  32
+
+#define CLOCK_FREQURNCY           250000000
+#define SPI_SPEED_HZ              10 * 1000 * 1000
+#define SPI_BUS_NUM               0
+#define SPI_SLAVE_NUM             0
+#define SPI_POLARITY              0
+
+//
+// Slave spi_device related
+//
+typedef struct {
+  UINT32   Cr0;
+  UINT32   RxSampleDly;
+} DW_SPI_CHIP_DATA;
+
+//
+// Slave spi_transfer/spi_mem_op related
+//
+typedef struct {
+  UINT8    Tmode;
+  UINT8    Dfs;
+  UINT32   Ndf;
+  UINT32   Freq;
+} DW_SPI_CFG;
+
+typedef struct {
+  UINT32   Version;           // Synopsys component version
+  UINTN    Regs;
+  UINT32   FifoLen;           // Depth of the FIFO buffer
+  UINT32   DfsOffset;         // CTRLR0 DFS field offset
+  UINT32   MaxFreq;           // max bus freq supported, get from "clock-frequency" in DTB
+  UINT32   MaxMemFreq;
+  UINT32   NumCs;
+  UINT16   BusNum;
+  VOID     *Tx;
+  UINT32   TxLen;
+  VOID     *Rx;
+  UINT32   RxLen;
+  UINT8    NBytes;           // current is a 1/2 bytes op
+  UINT32   CurrentFreq;      // current tranfer frequency
+  UINT32   CurRxSampleDly;
+  UINT32   DefRxSampleDlyNs;
+  VOID     (*SetCs) (SPI_DEVICE *Spi, BOOLEAN Level);
+} DW_SPI;
+
+typedef struct {
+  UINTN    Regs;
+  UINT32   NrGpios;
+} DW_GPIO;
+
+typedef struct {
+  UINTN    Regs;
+  UINT32   Offset;
+} SUB_CTRL;
+
+UINT8 Tpm2Read8 (
+  IN UINTN regs
+  );
+
+UINT16 Tpm2Read16 (
+  IN UINTN regs
+  );
+
+UINT32 Tpm2Read32 (
+  IN UINTN regs
+  );
+
+VOID Tpm2Write8 (
+  IN UINTN regs,
+  IN UINT8 Data
+  );
+
+VOID Tpm2Write32 (
+  IN UINTN  regs,
+  IN UINT32 Data
+  );
+
+EFI_STATUS
+EFIAPI
+Tpm2SpiInitialize (
+  VOID
+  );
+
+EFI_STATUS
+Tpm2WriteNBytes (
+  IN UINTN     regs,
+  IN UINT8     *Data,
+  IN UINT16    Size
+  );
+
+EFI_STATUS
+Tpm2readNBytes (
+  IN  UINTN    regs,
+  IN  UINT16   Size,
+  OUT UINT8    *OutBuffer
+  );
+
+#endif

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2TransferDxe.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2TransferDxe.c
@@ -1,0 +1,1083 @@
+/** @file
+  This file is used to implement DesignWare SPI communication.
+
+  Copyright (c) 2009, Intel Corporation.
+  Copyright (C) 2014 Stefan Roese <sr@denx.de>
+  Copyright (C) 2020 Sean Anderson <seanga2@gmail.com>
+  Copyright (c) 2024, SOPHGO Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Pi/PiDxeCis.h>
+#include <Library/TimerLib.h>
+#include <Protocol/FdtClient.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+
+#include "Tpm2Transfer.h"
+
+extern EFI_DXE_SERVICES     *gDS;
+
+STATIC DW_GPIO              *mDwGpioInsatce;
+STATIC DW_SPI               *mDwSpiInsatce;
+STATIC SUB_CTRL             *mSubCtrl;
+STATIC SPI_DEVICE           *Tpm2SpiSlave;
+STATIC DW_SPI_CHIP_DATA     mChip;
+
+STATIC
+VOID
+DwWriteL (
+  IN  DW_SPI  *Dws,
+  IN  UINT32  OffSet,
+  IN  UINT32  Value
+  )
+{
+  volatile UINTN Regs = Dws->Regs + OffSet;
+  MmioWrite32 (Regs, Value);
+}
+
+STATIC
+UINT32
+DwReadL (
+  IN  DW_SPI  *Dws,
+  IN  UINT32  OffSet
+  )
+{
+  volatile UINTN Regs = Dws->Regs + OffSet;
+  return MmioRead32 (Regs);
+}
+
+/**
+  Set chip select line electric level.
+
+  @param[in]  Spi    The pointer to SPI_DEVICE.
+  @param[in]  Level  TRUE for high electric level, FALSE for low electric level.
+
+**/
+VOID
+DwSpiSetCs (
+  IN  SPI_DEVICE  *Spi,
+  IN  BOOLEAN     Level
+  )
+{
+  DW_SPI   *Dws;
+  BOOLEAN  IsCsActiveHigh;
+
+  Dws = mDwSpiInsatce;
+  IsCsActiveHigh = !!(Spi->Mode & SPI_CS_HIGH);
+
+  //
+  // DW SPI controller demands any native CS being set in order to
+  // proceed with data transfer. So in order to activate the SPI
+  // communications we must set a corresponding bit in the Slave
+  // Enable register no matter whether the SPI core is configured to
+  // support active-high or active-low CS level.
+  //
+  if (IsCsActiveHigh == Level)
+    DwWriteL (Dws, DW_SPI_SER, BIT(Spi->Cs));
+  else
+    DwWriteL (Dws, DW_SPI_SER, 0);
+}
+
+EFI_STATUS
+GetGpioInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mGpioBase;
+
+  mGpioBase = (UINTN)PcdGet64 (PcdTpm2GpioBaseAddress);
+  mDwGpioInsatce = AllocateZeroPool (sizeof (DW_GPIO));
+  if (!mDwGpioInsatce) {
+    DEBUG ((DEBUG_ERROR, "allocate gpio memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mDwGpioInsatce->Regs            = mGpioBase;
+  mDwGpioInsatce->NrGpios         = GPIO_PINS_PER_CONTROLLER;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+GetSpiInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mSpiBase;
+
+  mSpiBase = (UINTN)PcdGet64 (PcdTpm2SpiBaseAddress);
+  mDwSpiInsatce = AllocateZeroPool (sizeof (DW_SPI));
+  if (!mDwSpiInsatce) {
+    DEBUG ((DEBUG_ERROR, "allocate spi memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mDwSpiInsatce->Regs             = mSpiBase;
+  mDwSpiInsatce->MaxFreq          = CLOCK_FREQURNCY;
+  mDwSpiInsatce->MaxMemFreq       = mDwSpiInsatce->MaxFreq;
+  mDwSpiInsatce->SetCs            = DwSpiSetCs;
+  mDwSpiInsatce->BusNum           = 0;
+  mDwSpiInsatce->DefRxSampleDlyNs = 0;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+GetTopInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mTopBase;
+
+  mTopBase = (UINTN)PcdGet64 (PcdTopBaseAddress);
+  mSubCtrl = AllocateZeroPool (sizeof (SUB_CTRL));
+  if (!mSubCtrl) {
+    DEBUG ((DEBUG_ERROR, "allocate gpio memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+  mSubCtrl->Regs    = mTopBase;
+  mSubCtrl->Offset  = TOP_PIN_MUX_OFFSET;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+SetMemory (
+  IN UINTN  Reg
+  )
+{
+  EFI_STATUS                      Status;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR Desc;
+
+  Status = gDS->GetMemorySpaceDescriptor (Reg, &Desc);
+  if (EFI_ERROR (Status) || Desc.GcdMemoryType == EfiGcdMemoryTypeNonExistent) {
+    Status = gDS->AddMemorySpace(
+                    EfiGcdMemoryTypeMemoryMappedIo,
+                    Reg,
+                    SIZE_4KB,
+                    EFI_MEMORY_UC | EFI_MEMORY_XP
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "[%a:%d] Add memory space failed: %r\n",
+            __func__, __LINE__, Status));
+      return Status;
+    }
+  }
+
+  Status = gDS->SetMemorySpaceAttributes (
+                  Reg,
+                  SIZE_4KB,
+                  EFI_MEMORY_UC | EFI_MEMORY_XP
+                  );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a:%d] Set memory attributes failed: %r\n",
+            __func__, __LINE__, Status));
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Find last (most-significant) bit set (1-based index).
+  Note GenericFls (0) = 0, GenericFls (1) = 1, GenericFls (0x80000000) = 32.
+
+  @param[in]   Num         The word to search.
+
+**/
+STATIC
+INT32
+GenericFls (
+  IN UINT32 Number
+  )
+{
+  int Result = 32;
+
+  if (!Number)
+    return 0;
+  if (!(Number & 0xffff0000u)) {
+    Number <<= 16;
+    Result -=  16;
+  }
+  if (!(Number & 0xff000000u)) {
+    Number <<= 8;
+    Result -=  8;
+  }
+  if (!(Number & 0xf0000000u)) {
+    Number <<= 4;
+    Result -=  4;
+  }
+  if (!(Number & 0xc0000000u)) {
+    Number <<= 2;
+    Result -=  2;
+  }
+  if (!(Number & 0x80000000u)) {
+    Number <<= 1;
+    Result -=  1;
+  }
+
+  return Result;
+}
+
+STATIC
+UINT32
+RoundupPowOfTwo (
+  IN  UINT32  Num
+  )
+{
+  if (Num == 0) {
+      return 1;
+  }
+
+  return 1U << GenericFls (Num - 1);;
+}
+
+STATIC
+UINT32
+Hweight16 (
+  UINT32 Val
+  )
+{
+  UINT32 Res;
+
+  Res = Val - ((Val >> 1) & 0x5555);
+  Res = (Res & 0x3333) + ((Res >> 2) & 0x3333);
+  Res = (Res + (Res >> 4)) & 0x0F0F;
+
+  return (Res + (Res >> 8)) & 0x00FF;
+}
+
+STATIC
+UINT32
+FieldPrep (
+  IN UINT32 Mask,
+  IN UINT32 Val
+  )
+{
+  INT32  Shift, Tmp;
+
+  Shift = 0;
+  Tmp   = Mask;
+  while ((Tmp & 1) == 0) {
+    Tmp >>= 1;
+    Shift++;
+  }
+
+  return (Val << Shift) & Mask;
+}
+
+STATIC
+VOID *
+SpiGetCtldata (
+  IN CONST SPI_DEVICE *Spi
+  )
+{
+  //
+  // Ctldata is for the bus_controller driver's runtime state
+  //
+  return Spi->ControllerState;
+}
+
+STATIC
+VOID
+SpiSetCtldata (
+  IN OUT SPI_DEVICE *Spi,
+  IN     VOID       *State
+  )
+{
+  Spi->ControllerState = State;
+}
+
+STATIC
+VOID
+DwSpiSetClk (
+  IN  DW_SPI *Dws,
+  IN  UINT16 Div
+  )
+{
+  DwWriteL (Dws, DW_SPI_BAUDR, Div);
+}
+
+STATIC
+VOID
+DwSpiEnableChip (
+  IN DW_SPI *Dws,
+  IN INT32  Enable
+  )
+{
+  DwWriteL (Dws, DW_SPI_SSIENR, (Enable ? 1 : 0));
+}
+
+STATIC
+VOID
+DwSpiMaskIntr (
+  IN DW_SPI *Dws,
+  IN UINT32 Mask
+  )
+{
+  UINT32 NewMask;
+
+  NewMask = DwReadL (Dws, DW_SPI_IMR) & ~Mask;
+  DwWriteL (Dws, DW_SPI_IMR, NewMask);
+}
+
+STATIC
+VOID
+DwSpiResetChip (
+  IN DW_SPI *Dws
+  )
+{
+  DwSpiEnableChip (Dws, 0);
+  DwSpiMaskIntr (Dws, 0xff);
+  DwReadL (Dws, DW_SPI_ICR);
+  DwWriteL (Dws, DW_SPI_SER, 0);
+  DwSpiEnableChip (Dws, 1);
+}
+
+STATIC
+UINT32
+DwSpiPrepareCr0 (
+  IN SPI_DEVICE *Spi
+  )
+{
+  UINT32 Cr0 = 0;
+
+  //
+  // CTRLR0[ 5: 4] Frame Format
+  //
+  Cr0 |= FieldPrep (CTRLR0_FRF_MASK, CTRLR0_FRF_SPI);
+
+  //
+  // SPI mode (SCPOL|SCPH)
+  // CTRLR0[ 6] Serial Clock Phase
+  // CTRLR0[ 7] Serial Clock Polarity
+  //
+  if (Spi->Mode & CTRLR0_SPI_CPOL)
+    Cr0 |= DW_CTRLR0_SCPOL;
+  if (Spi->Mode & CTRLR0_SPI_CPHA)
+    Cr0 |= DW_CTRLR0_SCPHA;
+
+  //
+  // CTRLR0[11] Shift Register Loop
+  //
+  if (Spi->Mode & CTRLR0_SPI_LOOP)
+    Cr0 |= DW_CTRLR0_SRL;
+
+  return Cr0;
+}
+
+STATIC
+VOID
+AssertCs (
+  VOID
+  )
+{
+  volatile UINTN     TopRegs;
+  UINT32             Val;
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val & 0xfd;
+  MmioWrite32 (TopRegs, Val);
+}
+
+STATIC
+VOID
+DeAssertCs (
+  VOID
+  )
+{
+  volatile UINTN     TopRegs;
+  UINT32             Val;
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+}
+
+/**
+  Setup a spi slave using the given parameters.
+
+  @param[in]       This           The pointer to SOPHGO_SPI_PROTOCOL.
+  @param[in, out]  Spi            The pointer to SPI_DEVICE.
+  @param[in]       SpiBus         The spi bus number used by this spi slave.
+  @param[in]       Cs             The chip select lines used by this spi slave.
+  @param[in]       Mode           Defines how data is clocked out and in.
+
+  @retval  EFI_SUCCESS            The operation completed successfully.
+  @retval  EFI_INVALID_PARAMETER  The SpiBus exceeds the number of spi controllers
+  @retval  EFI_OUT_OF_RESOURCES   Cat not allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DwSpiSetup (
+  IN OUT SPI_DEVICE          *Spi,
+  IN     UINT32              SpiBus,
+  IN     UINT8               Cs,
+  IN     UINT8               Mode
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+  UINT32           RxSampleDlyNs;
+  DW_SPI           *Dws;
+
+  Dws          = mDwSpiInsatce;
+  Spi->SpiBus = SpiBus;
+  Spi->Cs     = Cs;
+  Spi->Mode   = Mode;
+  Chip        = SpiGetCtldata (Spi);
+
+  //
+  // Only alloc on first setup
+  //
+  if (!Chip) {
+    Chip =  &mChip;
+    SpiSetCtldata (Spi, Chip);
+
+    RxSampleDlyNs = Dws->DefRxSampleDlyNs;
+
+    Chip->RxSampleDly = DIV_ROUND_CLOSEST (RxSampleDlyNs, NSEC_PER_SEC / Dws->MaxFreq);
+  }
+
+  //
+  // Update CR0 data each time the setup callback is invoked since
+  // the device parameters could have been changed, for instance, by
+  // the MMC SPI driver or something else.
+  //
+  Chip->Cr0 = DwSpiPrepareCr0 (Spi);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Clean a spi slave.
+
+  @param[in]       This  The pointer to SOPHGO_SPI_PROTOCOL.
+  @param[in, out]  Spi   The pointer to SPI_DEVICE.
+
+  @retval  EFI_SUCCESS   The operation completed successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+DwSpiCleanup (
+  IN OUT SPI_DEVICE          *Spi
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+
+  Chip = SpiGetCtldata (Spi);
+
+  SpiSetCtldata (Spi, NULL);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+SpiHwInit (
+  IN OUT  DW_SPI  *Dws
+  )
+{
+  UINT32  Cr0;
+  UINT32  Tmp;
+  UINT32  Ser;
+
+  DwSpiResetChip (Dws);
+
+  if (!Dws->Version)
+    Dws->Version = DwReadL (Dws, DW_SPI_VERSION);
+
+  //
+  // Try to detect the number of native chip-selects if the platform
+  // driver didn't set it up. There can be up to 16 lines configured.
+  //
+  if (!Dws->NumCs) {
+
+    DwWriteL (Dws, DW_SPI_SER, 0xffff);
+    Ser = DwReadL (Dws, DW_SPI_SER);
+    DwWriteL (Dws, DW_SPI_SER, 0);
+
+    Dws->NumCs = Hweight16 (Ser);
+  }
+
+  //
+  // Try to detect the FIFO depth if not set by interface driver,
+  // the depth could be from 2 to 256 from HW spec
+  //
+  if (!Dws->FifoLen) {
+    UINT32 Fifo;
+
+    for (Fifo = 1; Fifo < 256; Fifo++) {
+      DwWriteL (Dws, DW_SPI_TXFTLR, Fifo);
+      if (Fifo != DwReadL (Dws, DW_SPI_TXFTLR))
+        break;
+    }
+    DwWriteL (Dws, DW_SPI_TXFTLR, 0);
+
+    Dws->FifoLen = (Fifo == 1) ? 0 : Fifo;
+  }
+
+  //
+  // Detect CTRLR0.DFS field size and offset by testing the lowest bits
+  // writability. Note DWC SSI controller also has the extended DFS, but
+  // with zero offset.
+  //
+  Cr0 = DwReadL (Dws, DW_SPI_CTRLR0);
+  Tmp = Cr0;
+  DwSpiEnableChip (Dws, 0);
+  DwWriteL (Dws, DW_SPI_CTRLR0, 0xffffffff);
+  Cr0 = DwReadL (Dws, DW_SPI_CTRLR0);
+  DwWriteL (Dws, DW_SPI_CTRLR0, Tmp);
+  DwSpiEnableChip (Dws, 1);
+
+  if (!(Cr0 & CTRLR0_DFS_MASK)) {
+    Dws->DfsOffset = CTRLR0_DFS_32_OFFSET;
+  } else {
+    Dws->DfsOffset = CTRLR0_DFS_OFFSET;
+  }
+
+  DEBUG ((DEBUG_INFO,"[Spi%u base: 0x%lx, MaxFreq: %u, CS num: %u, FIFO depth/width: %u/%u, Version: %c.%c%c%c]\n",
+          Dws->BusNum, Dws->Regs, Dws->MaxFreq, Dws->NumCs,
+          Dws->FifoLen, (Dws->DfsOffset == CTRLR0_DFS_OFFSET) ? 16 : 32,
+          Dws->Version >> 24, Dws->Version >> 16,
+          Dws->Version >> 8, Dws->Version));
+}
+
+STATIC
+VOID
+Tpm2PreInitialize (
+  VOID
+  )
+{
+  volatile UINTN      TopRegs;
+  UINT32              Val;
+
+  TopRegs = mSubCtrl->Regs + mSubCtrl->Offset + TOP_SPI0_CS_OFFSET;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x14;
+  MmioWrite32 (TopRegs, Val);
+  Val = MmioRead32 (TopRegs);
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DDR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+  Val = MmioRead32 (TopRegs);
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+}
+
+EFI_STATUS
+EFIAPI
+Tpm2SpiInitialize (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  UINT32                          SpiBus = SPI_BUS_NUM;
+  UINT8                           Cs     = SPI_SLAVE_NUM;
+  UINT8                           Mode   = SPI_POLARITY;
+
+  Status = GetTopInstanceByPcd ();
+  Status = SetMemory (mSubCtrl->Regs + mSubCtrl->Offset);
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Status = GetGpioInstanceByPcd ();
+  Status = SetMemory (mDwGpioInsatce->Regs);
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Status = GetSpiInstanceByPcd ();
+  Status = SetMemory (mDwSpiInsatce->Regs);
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Tpm2PreInitialize ();
+  SpiHwInit (mDwSpiInsatce);
+
+  Tpm2SpiSlave = AllocateZeroPool (sizeof (SPI_DEVICE));
+  if (!Tpm2SpiSlave)
+    return EFI_OUT_OF_RESOURCES;
+
+  Status = DwSpiSetup (Tpm2SpiSlave, SpiBus, Cs, Mode);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR,"Cannot setup spi slave\n"));
+    return Status;
+  }
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+DwSpiCheckStatus (
+  IN OUT DW_SPI   *Dws,
+  IN     BOOLEAN  IsReadFromRisr
+  )
+{
+  UINT32     IrqStatus;
+  EFI_STATUS Status;
+
+  Status = EFI_SUCCESS;
+
+  if (IsReadFromRisr)
+    IrqStatus = DwReadL (Dws, DW_SPI_RISR);
+  else
+    IrqStatus = DwReadL (Dws, DW_SPI_ISR);
+
+  if (IrqStatus & DW_SPI_INT_RXOI) {
+    DEBUG ((DEBUG_ERROR, "RX FIFO overflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  if (IrqStatus & DW_SPI_INT_RXUI) {
+    DEBUG ((DEBUG_ERROR, "RX FIFO underflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  if (IrqStatus & DW_SPI_INT_TXOI) {
+    DEBUG ((DEBUG_ERROR, "TX FIFO overflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Generically handle the erroneous situation
+  //
+  if (EFI_ERROR (Status))
+    DwSpiResetChip (Dws);
+
+  return Status;
+}
+
+STATIC
+UINT32
+DwSpiTxMax (
+  IN DW_SPI *Dws
+  )
+{
+  UINT32 TxRoom, RxTxGap;
+
+  TxRoom = Dws->FifoLen - DwReadL (Dws, DW_SPI_TXFLR);
+
+  //
+  // Another concern is about the tx/rx mismatch, we
+  // though to use (Dws->FifoLen - rxflr - txflr) as
+  // one maximum value for tx, but it doesn't cover the
+  // data which is out of tx/rx fifo and inside the
+  // shift registers. So a control from sw point of
+  // view is taken.
+  //
+  RxTxGap = Dws->FifoLen - (Dws->RxLen - Dws->TxLen);
+
+  //
+  // Return the max entries we can fill into tx fifo
+  //
+  return MIN3((UINT32)Dws->TxLen, TxRoom, RxTxGap);
+}
+
+STATIC
+UINT32
+DwSpiRxMax (
+  IN DW_SPI *Dws
+  )
+{
+  //
+  // Return the max entries we should read out of rx fifo
+  //
+  return MIN_T(UINT32, Dws->RxLen, DwReadL (Dws, DW_SPI_RXFLR));
+}
+
+VOID
+DwSpiUpdateConfig (
+  IN OUT DW_SPI      *Dws,
+  IN     SPI_DEVICE  *Spi,
+  IN     DW_SPI_CFG  *Cfg
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+  UINT32           Cr0;
+  UINT32           SpeedHz;
+  UINT16           ClkDiv;
+
+  Chip = SpiGetCtldata (Spi);
+  Cr0  = Chip->Cr0;
+
+  //
+  // CTRLR0[ 4/3: 0] or CTRLR0[ 20: 16] Data Frame Size
+  //
+  Cr0 |= (Cfg->Dfs - 1) << Dws->DfsOffset;
+  Cr0 |= FieldPrep (CTRLR0_TMOD_MASK, Cfg->Tmode);
+
+  DwWriteL (Dws, DW_SPI_CTRLR0, Cr0);
+
+  if (Cfg->Tmode == CTRLR0_TMOD_EPROMREAD ||
+      Cfg->Tmode == CTRLR0_TMOD_RO)
+    DwWriteL (Dws, DW_SPI_CTRLR1, Cfg->Ndf ? Cfg->Ndf - 1 : 0);
+
+  //
+  // Note DW APB SSI clock divider doesn't support odd numbers
+  //
+  ClkDiv = (DIV_ROUND_UP(Dws->MaxFreq, Cfg->Freq) + 1) & 0xfffe;
+  SpeedHz = Dws->MaxFreq / ClkDiv;
+
+  if (Dws->CurrentFreq != SpeedHz) {
+    DwSpiSetClk (Dws, ClkDiv);
+    Dws->CurrentFreq = SpeedHz;
+  }
+
+  //
+  // Update RX sample delay if required
+  //
+  if (Dws->CurRxSampleDly != Chip->RxSampleDly) {
+    DwWriteL (Dws, DW_SPI_RX_SAMPLE_DLY, Chip->RxSampleDly);
+    Dws->CurRxSampleDly = Chip->RxSampleDly;
+  }
+}
+
+EFI_STATUS
+DwSpiTransferOneConfig (
+  IN  SPI_DEVICE          *Spi,
+  IN  UINT32              BitsPerWord,
+  IN  UINT32              SpeedHz
+  )
+{
+  DW_SPI_CFG  Cfg;
+  DW_SPI      *Dws = mDwSpiInsatce;
+
+  if (SpeedHz == 0)
+    SpeedHz = Dws->MaxFreq;
+  if (BitsPerWord == 0)
+    BitsPerWord = 8;
+
+  Cfg.Tmode = CTRLR0_TMOD_TR;
+  Cfg.Dfs   = BitsPerWord;
+  Cfg.Freq  = SpeedHz;
+
+  DwSpiEnableChip (Dws, 0);
+
+  DwSpiUpdateConfig (Dws, Spi, &Cfg);
+
+  //
+  // For poll mode just disable all interrupts
+  //
+  DwSpiMaskIntr (Dws, 0xff);
+
+  Dws->SetCs (Tpm2SpiSlave, 0);
+
+  DwSpiEnableChip (Dws, 1);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+DwSpiTransferOne (
+  DW_SPI     *Dws
+  )
+{
+  UINT32      TxMax;
+  UINT32      RxMax;
+  UINT32      RxW;
+  UINT32      TxW;
+  EFI_STATUS  Status;
+
+  do {
+    TxMax     = DwSpiTxMax (Dws);
+    while (TxMax--) {
+      TxW = *(UINT8 *)(Dws->Tx);
+      DwWriteL (Dws, DW_SPI_DR, TxW);
+      Dws->Tx += Dws->NBytes;
+      --Dws->TxLen;
+    }
+    RxMax     = DwSpiRxMax (Dws);
+    while (RxMax--) {
+      RxW = DwReadL (Dws, DW_SPI_DR);
+      *(UINT8 *)(Dws->Rx) = RxW;
+      Dws->Rx += Dws->NBytes;
+      --Dws->RxLen;
+    }
+    Status = DwSpiCheckStatus (Dws, TRUE);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "check status error\n"));
+      return Status;
+    }
+  } while (Dws->RxLen);  
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+DwSpiFlowControl (
+  DW_SPI      *Dws
+  )
+{
+  UINT32      Index;
+  UINT32      TxMax;
+  UINT32      RxMax;
+  UINT32      RxW;
+  EFI_STATUS  Status;
+
+  for (Index = 0; Index < TRY_TIMES; Index++) {
+    Dws->TxLen  = 1;
+    Dws->RxLen  = Dws->TxLen;
+    do {
+      TxMax     = DwSpiTxMax (Dws);
+      while (TxMax--) {
+        DwWriteL (Dws, DW_SPI_DR, 0);
+        --Dws->TxLen;
+      }
+      RxMax     = DwSpiRxMax (Dws);
+      while (RxMax--) {
+        RxW = DwReadL (Dws, DW_SPI_DR);
+        --Dws->RxLen;
+      }
+      Status = DwSpiCheckStatus (Dws, TRUE);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "check status error\n"));
+        return Status;
+      }
+    } while (Dws->RxLen);
+
+    if (RxW & 0x01)
+      break;
+  }
+  if (Index == TRY_TIMES)
+    return EFI_TIMEOUT;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS 
+Tpm2WriteNBytes (
+  IN UINTN  regs,
+  IN UINT8* Data,
+  IN UINT16  Size
+  )
+{
+  DW_SPI      *Dws;
+  UINT8       TransferLen;
+  UINT8       mTxBuffer[68];
+  UINT8       mRxBuffer[68];
+  EFI_STATUS  Status;
+  UINT32      BitsPerWord;
+  UINT32      SpeedHz;
+
+  BitsPerWord = 8;
+  SpeedHz     = SPI_SPEED_HZ;
+  Status      = DwSpiTransferOneConfig (Tpm2SpiSlave, BitsPerWord, SpeedHz);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Cannot config spi controller\n"));
+    return Status;
+  }
+
+  Dws = mDwSpiInsatce;
+  Dws->NBytes = RoundupPowOfTwo (BITS_TO_BYTES (8));
+
+  while (Size) {
+    TransferLen  = MIN_T(UINT16, Size, 64);
+    mTxBuffer[0] = 0x00 | ((TransferLen - 1) & 0x3f);
+    mTxBuffer[1] = 0xD4;
+    mTxBuffer[2] = (UINT8)((regs >> 8) & 0xff);
+    mTxBuffer[3] = (UINT8)(regs & 0xff);
+    CopyMem (&mTxBuffer[4], Data, TransferLen);
+
+    Dws->Tx      = mTxBuffer;
+    Dws->TxLen   = 4;
+    Dws->Rx      = mRxBuffer;
+    Dws->RxLen   = Dws->TxLen;
+
+    AssertCs ();
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: command transfer failed\n"));
+      return Status;
+    }
+
+    if ((mRxBuffer[3] & 0x01) == 0) {
+      Status = DwSpiFlowControl (Dws);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Tpm: flow control failed\n"));
+        return Status;
+      }
+    }
+
+    Dws->TxLen  = TransferLen;
+    Dws->RxLen  = Dws->TxLen;
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: data transfer failed\n"));
+      return Status;
+    }
+    DeAssertCs ();
+    MicroSecondDelay (5);
+  
+    Data += TransferLen;
+    Size -= TransferLen;
+  }
+
+  AssertCs ();
+  return Status;
+}
+
+EFI_STATUS 
+Tpm2readNBytes (
+  IN UINTN   regs,
+  IN UINT16  Size,
+  OUT UINT8  *OutBuffer
+  )
+{
+  DW_SPI      *Dws;
+  UINT8       TransferLen;
+  UINT8       mTxBuffer[68];
+  UINT8       mRxBuffer[68];
+  EFI_STATUS  Status;
+  UINT32      BitsPerWord;
+  UINT32      SpeedHz;
+  UINT16      OriSize;
+
+  BitsPerWord = 8;
+  SpeedHz     = SPI_SPEED_HZ;
+  Status      = DwSpiTransferOneConfig (Tpm2SpiSlave, BitsPerWord, SpeedHz);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Cannot config spi controller\n"));
+    return Status;
+  }
+
+  OriSize     = Size;
+  Dws         = mDwSpiInsatce;
+  Dws->NBytes = RoundupPowOfTwo (BITS_TO_BYTES (8));
+
+  while (Size) {
+    TransferLen  = MIN_T(UINT16, Size, 64);
+    mTxBuffer[0] = 0x80 | ((TransferLen - 1) & 0x3f);
+    mTxBuffer[1] = 0xD4;
+    mTxBuffer[2] = (UINT8)((regs >> 8) & 0xff);
+    mTxBuffer[3] = (UINT8)(regs & 0xff);
+
+    Dws->Tx      = mTxBuffer;
+    Dws->TxLen   = 4;
+    Dws->Rx      = mRxBuffer;
+    Dws->RxLen   = Dws->TxLen;
+
+    AssertCs ();
+    Status = DwSpiTransferOne (Dws);
+
+    if ((mRxBuffer[3] & 0x01) == 0) {
+      Status = DwSpiFlowControl (Dws);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Tpm: flow control failed\n"));
+        return Status;
+      }
+    }
+
+    Dws->TxLen  = TransferLen;
+    Dws->RxLen  = Dws->TxLen;
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: data transfer failed\n"));
+      return Status;
+    }
+
+    DeAssertCs ();
+    MicroSecondDelay (5);
+
+    Size -= TransferLen;
+  }
+  CopyMem (OutBuffer, &mRxBuffer[4], OriSize);
+  AssertCs ();
+
+  return Status;
+}
+
+UINT8
+Tpm2Read8 (
+  IN UINTN  regs
+  )
+{
+  UINT8       ReadByte;
+  EFI_STATUS  Status;
+
+  Status = Tpm2readNBytes (regs, sizeof (UINT8), &ReadByte);
+  if (EFI_ERROR (Status))
+    return 0xff;
+
+  return ReadByte;
+}
+
+UINT16
+Tpm2Read16 (
+  IN UINTN  regs
+  )
+{
+  UINT8       RxBuffer[2];
+  UINT16      ReadByte;
+  EFI_STATUS  Status;
+
+  Status = Tpm2readNBytes (regs, sizeof (UINT16), RxBuffer);
+  if (EFI_ERROR (Status))
+    return 0xffff;
+
+  ReadByte = ((RxBuffer[0]) << 8) | RxBuffer[1];
+
+  return ReadByte;
+}
+
+UINT32
+Tpm2Read32 (
+  IN UINTN regs
+  )
+{
+  UINT8       RxBuffer[4];
+  UINT32      ReadByte;
+  EFI_STATUS  Status;
+  
+  Status = Tpm2readNBytes (regs, sizeof (UINT32), RxBuffer);
+  if (EFI_ERROR (Status))
+    return 0xffffffff;
+
+  ReadByte = ((RxBuffer[0]) << 24) | ((RxBuffer[1]) << 16)
+              | ((RxBuffer[2]) << 8) | RxBuffer[3];
+
+  return ReadByte;
+}
+
+VOID
+Tpm2Write8 (
+  IN UINTN regs,
+  IN UINT8 Data
+  )
+{
+  Tpm2WriteNBytes (regs, &Data, sizeof (UINT8));
+}
+
+VOID
+Tpm2Write32 (
+  IN UINTN  regs,
+  IN UINT32 Data
+  )
+{
+  UINT8       TxBuffer[4];
+
+  TxBuffer[0] = (UINT8)((Data >> 24) | 0xff);
+  TxBuffer[1] = (UINT8)((Data >> 16) | 0xff);
+  TxBuffer[2] = (UINT8)((Data >> 8) | 0xff);
+  TxBuffer[4] = (UINT8)(Data | 0xff);
+
+  Tpm2WriteNBytes (regs, TxBuffer, sizeof (UINT8));
+}

--- a/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2TransferPei.c
+++ b/Silicon/Sophgo/Library/Tpm2DeviceLibDTpm/Tpm2TransferPei.c
@@ -1,0 +1,1043 @@
+/** @file
+  This file is used to implement DesignWare SPI communication.
+
+  Copyright (c) 2009, Intel Corporation.
+  Copyright (C) 2014 Stefan Roese <sr@denx.de>
+  Copyright (C) 2020 Sean Anderson <seanga2@gmail.com>
+  Copyright (c) 2024, SOPHGO Inc. All rights reserved.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/TimerLib.h>
+#include <Library/MemoryAllocationLib.h>
+
+#include <Library/PcdLib.h>
+#include <PiPei.h>
+
+#include "Tpm2Transfer.h"
+
+STATIC DW_GPIO              *mDwGpioInsatce;
+STATIC DW_SPI               *mDwSpiInsatce;
+STATIC SUB_CTRL             *mSubCtrl;
+STATIC SPI_DEVICE           *Tpm2SpiSlave;
+STATIC DW_SPI_CHIP_DATA     mChip;
+
+STATIC
+VOID
+DwWriteL (
+  IN  DW_SPI  *Dws,
+  IN  UINT32  OffSet,
+  IN  UINT32  Value
+  )
+{
+  volatile UINTN Regs = Dws->Regs + OffSet;
+  MmioWrite32 (Regs, Value);
+}
+
+STATIC
+UINT32
+DwReadL (
+  IN  DW_SPI  *Dws,
+  IN  UINT32  OffSet
+  )
+{
+  volatile UINTN Regs = Dws->Regs + OffSet;
+  return MmioRead32 (Regs);
+}
+
+/**
+  Set chip select line electric level.
+
+  @param[in]  Spi    The pointer to SPI_DEVICE.
+  @param[in]  Level  TRUE for high electric level, FALSE for low electric level.
+
+**/
+VOID
+DwSpiSetCs (
+  IN  SPI_DEVICE  *Spi,
+  IN  BOOLEAN     Level
+  )
+{
+  DW_SPI   *Dws;
+  BOOLEAN  IsCsActiveHigh;
+
+  Dws = mDwSpiInsatce;
+  IsCsActiveHigh = !!(Spi->Mode & SPI_CS_HIGH);
+
+  //
+  // DW SPI controller demands any native CS being set in order to
+  // proceed with data transfer. So in order to activate the SPI
+  // communications we must set a corresponding bit in the Slave
+  // Enable register no matter whether the SPI core is configured to
+  // support active-high or active-low CS level.
+  //
+  if (IsCsActiveHigh == Level)
+    DwWriteL (Dws, DW_SPI_SER, BIT(Spi->Cs));
+  else
+    DwWriteL (Dws, DW_SPI_SER, 0);
+}
+
+EFI_STATUS
+GetGpioInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mGpioBase;
+
+  mGpioBase = (UINTN)PcdGet64 (PcdTpm2GpioBaseAddress);
+  mDwGpioInsatce = AllocateZeroPool (sizeof (DW_GPIO));
+  if (!mDwGpioInsatce) {
+    DEBUG ((DEBUG_ERROR, "allocate gpio memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mDwGpioInsatce->Regs            = mGpioBase;
+  mDwGpioInsatce->NrGpios         = GPIO_PINS_PER_CONTROLLER;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+GetSpiInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mSpiBase;
+
+  mSpiBase = (UINTN)PcdGet64 (PcdTpm2SpiBaseAddress);
+  mDwSpiInsatce = AllocateZeroPool (sizeof (DW_SPI));
+  if (!mDwSpiInsatce) {
+    DEBUG ((DEBUG_ERROR, "allocate spi memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  mDwSpiInsatce->Regs             = mSpiBase;
+  mDwSpiInsatce->MaxFreq          = CLOCK_FREQURNCY;
+  mDwSpiInsatce->MaxMemFreq       = mDwSpiInsatce->MaxFreq;
+  mDwSpiInsatce->SetCs            = DwSpiSetCs;
+  mDwSpiInsatce->BusNum           = 0;
+  mDwSpiInsatce->DefRxSampleDlyNs = 0;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+GetTopInstanceByPcd (
+  VOID
+  )
+{
+  UINTN       mTopBase;
+
+  mTopBase = (UINTN)PcdGet64 (PcdTopBaseAddress);
+  mSubCtrl = AllocateZeroPool (sizeof (SUB_CTRL));
+  if (!mSubCtrl) {
+    DEBUG ((DEBUG_ERROR, "allocate gpio memory failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+  mSubCtrl->Regs    = mTopBase;
+  mSubCtrl->Offset  = TOP_PIN_MUX_OFFSET;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Find last (most-significant) bit set (1-based index).
+  Note GenericFls (0) = 0, GenericFls (1) = 1, GenericFls (0x80000000) = 32.
+
+  @param[in]   Num         The word to search.
+
+**/
+STATIC
+INT32
+GenericFls (
+  IN UINT32 Number
+  )
+{
+  int Result = 32;
+
+  if (!Number)
+    return 0;
+  if (!(Number & 0xffff0000u)) {
+    Number <<= 16;
+    Result -=  16;
+  }
+  if (!(Number & 0xff000000u)) {
+    Number <<= 8;
+    Result -=  8;
+  }
+  if (!(Number & 0xf0000000u)) {
+    Number <<= 4;
+    Result -=  4;
+  }
+  if (!(Number & 0xc0000000u)) {
+    Number <<= 2;
+    Result -=  2;
+  }
+  if (!(Number & 0x80000000u)) {
+    Number <<= 1;
+    Result -=  1;
+  }
+
+  return Result;
+}
+
+STATIC
+UINT32
+RoundupPowOfTwo (
+  IN  UINT32  Num
+  )
+{
+  if (Num == 0) {
+      return 1;
+  }
+
+  return 1U << GenericFls (Num - 1);;
+}
+
+STATIC
+UINT32
+Hweight16 (
+  UINT32 Val
+  )
+{
+  UINT32 Res;
+
+  Res = Val - ((Val >> 1) & 0x5555);
+  Res = (Res & 0x3333) + ((Res >> 2) & 0x3333);
+  Res = (Res + (Res >> 4)) & 0x0F0F;
+
+  return (Res + (Res >> 8)) & 0x00FF;
+}
+
+STATIC
+UINT32
+FieldPrep (
+  IN UINT32 Mask,
+  IN UINT32 Val
+  )
+{
+  INT32  Shift, Tmp;
+
+  Shift = 0;
+  Tmp   = Mask;
+  while ((Tmp & 1) == 0) {
+    Tmp >>= 1;
+    Shift++;
+  }
+
+  return (Val << Shift) & Mask;
+}
+
+STATIC
+VOID *
+SpiGetCtldata (
+  IN CONST SPI_DEVICE *Spi
+  )
+{
+  //
+  // Ctldata is for the bus_controller driver's runtime state
+  //
+  return Spi->ControllerState;
+}
+
+STATIC
+VOID
+SpiSetCtldata (
+  IN OUT SPI_DEVICE *Spi,
+  IN     VOID       *State
+  )
+{
+  Spi->ControllerState = State;
+}
+
+STATIC
+VOID
+DwSpiSetClk (
+  IN  DW_SPI *Dws,
+  IN  UINT16 Div
+  )
+{
+  DwWriteL (Dws, DW_SPI_BAUDR, Div);
+}
+
+STATIC
+VOID
+DwSpiEnableChip (
+  IN DW_SPI *Dws,
+  IN INT32  Enable
+  )
+{
+  DwWriteL (Dws, DW_SPI_SSIENR, (Enable ? 1 : 0));
+}
+
+STATIC
+VOID
+DwSpiMaskIntr (
+  IN DW_SPI *Dws,
+  IN UINT32 Mask
+  )
+{
+  UINT32 NewMask;
+
+  NewMask = DwReadL (Dws, DW_SPI_IMR) & ~Mask;
+  DwWriteL (Dws, DW_SPI_IMR, NewMask);
+}
+
+STATIC
+VOID
+DwSpiResetChip (
+  IN DW_SPI *Dws
+  )
+{
+  DwSpiEnableChip (Dws, 0);
+  DwSpiMaskIntr (Dws, 0xff);
+  DwReadL (Dws, DW_SPI_ICR);
+  DwWriteL (Dws, DW_SPI_SER, 0);
+  DwSpiEnableChip (Dws, 1);
+}
+
+STATIC
+UINT32
+DwSpiPrepareCr0 (
+  IN SPI_DEVICE *Spi
+  )
+{
+  UINT32 Cr0 = 0;
+
+  //
+  // CTRLR0[ 5: 4] Frame Format
+  //
+  Cr0 |= FieldPrep (CTRLR0_FRF_MASK, CTRLR0_FRF_SPI);
+
+  //
+  // SPI mode (SCPOL|SCPH)
+  // CTRLR0[ 6] Serial Clock Phase
+  // CTRLR0[ 7] Serial Clock Polarity
+  //
+  if (Spi->Mode & CTRLR0_SPI_CPOL)
+    Cr0 |= DW_CTRLR0_SCPOL;
+  if (Spi->Mode & CTRLR0_SPI_CPHA)
+    Cr0 |= DW_CTRLR0_SCPHA;
+
+  //
+  // CTRLR0[11] Shift Register Loop
+  //
+  if (Spi->Mode & CTRLR0_SPI_LOOP)
+    Cr0 |= DW_CTRLR0_SRL;
+
+  return Cr0;
+}
+
+STATIC
+VOID
+AssertCs (
+  VOID
+  )
+{
+  volatile UINTN     TopRegs;
+  UINT32             Val;
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val & 0xfd;
+  MmioWrite32 (TopRegs, Val);
+}
+
+STATIC
+VOID
+DeAssertCs (
+  VOID
+  )
+{
+  volatile UINTN     TopRegs;
+  UINT32             Val;
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+}
+
+/**
+  Setup a spi slave using the given parameters.
+
+  @param[in]       This           The pointer to SOPHGO_SPI_PROTOCOL.
+  @param[in, out]  Spi            The pointer to SPI_DEVICE.
+  @param[in]       SpiBus         The spi bus number used by this spi slave.
+  @param[in]       Cs             The chip select lines used by this spi slave.
+  @param[in]       Mode           Defines how data is clocked out and in.
+
+  @retval  EFI_SUCCESS            The operation completed successfully.
+  @retval  EFI_INVALID_PARAMETER  The SpiBus exceeds the number of spi controllers
+  @retval  EFI_OUT_OF_RESOURCES   Cat not allocate memory.
+
+**/
+EFI_STATUS
+EFIAPI
+DwSpiSetup (
+  IN OUT SPI_DEVICE          *Spi,
+  IN     UINT32              SpiBus,
+  IN     UINT8               Cs,
+  IN     UINT8               Mode
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+  UINT32           RxSampleDlyNs;
+  DW_SPI           *Dws;
+
+  Dws          = mDwSpiInsatce;
+  Spi->SpiBus = SpiBus;
+  Spi->Cs     = Cs;
+  Spi->Mode   = Mode;
+  Chip        = SpiGetCtldata (Spi);
+
+  //
+  // Only alloc on first setup
+  //
+  if (!Chip) {
+    Chip =  &mChip;
+    SpiSetCtldata (Spi, Chip);
+
+    RxSampleDlyNs = Dws->DefRxSampleDlyNs;
+
+    Chip->RxSampleDly = DIV_ROUND_CLOSEST (RxSampleDlyNs, NSEC_PER_SEC / Dws->MaxFreq);
+  }
+
+  //
+  // Update CR0 data each time the setup callback is invoked since
+  // the device parameters could have been changed, for instance, by
+  // the MMC SPI driver or something else.
+  //
+  Chip->Cr0 = DwSpiPrepareCr0 (Spi);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Clean a spi slave.
+
+  @param[in]       This  The pointer to SOPHGO_SPI_PROTOCOL.
+  @param[in, out]  Spi   The pointer to SPI_DEVICE.
+
+  @retval  EFI_SUCCESS   The operation completed successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+DwSpiCleanup (
+  IN OUT SPI_DEVICE          *Spi
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+
+  Chip = SpiGetCtldata (Spi);
+
+  SpiSetCtldata (Spi, NULL);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+VOID
+SpiHwInit (
+  IN OUT  DW_SPI  *Dws
+  )
+{
+  UINT32  Cr0;
+  UINT32  Tmp;
+  UINT32  Ser;
+
+  DwSpiResetChip (Dws);
+
+  if (!Dws->Version)
+    Dws->Version = DwReadL (Dws, DW_SPI_VERSION);
+
+  //
+  // Try to detect the number of native chip-selects if the platform
+  // driver didn't set it up. There can be up to 16 lines configured.
+  //
+  if (!Dws->NumCs) {
+
+    DwWriteL (Dws, DW_SPI_SER, 0xffff);
+    Ser = DwReadL (Dws, DW_SPI_SER);
+    DwWriteL (Dws, DW_SPI_SER, 0);
+
+    Dws->NumCs = Hweight16 (Ser);
+  }
+
+  //
+  // Try to detect the FIFO depth if not set by interface driver,
+  // the depth could be from 2 to 256 from HW spec
+  //
+  if (!Dws->FifoLen) {
+    UINT32 Fifo;
+
+    for (Fifo = 1; Fifo < 256; Fifo++) {
+      DwWriteL (Dws, DW_SPI_TXFTLR, Fifo);
+      if (Fifo != DwReadL (Dws, DW_SPI_TXFTLR))
+        break;
+    }
+    DwWriteL (Dws, DW_SPI_TXFTLR, 0);
+
+    Dws->FifoLen = (Fifo == 1) ? 0 : Fifo;
+  }
+
+  //
+  // Detect CTRLR0.DFS field size and offset by testing the lowest bits
+  // writability. Note DWC SSI controller also has the extended DFS, but
+  // with zero offset.
+  //
+  Cr0 = DwReadL (Dws, DW_SPI_CTRLR0);
+  Tmp = Cr0;
+  DwSpiEnableChip (Dws, 0);
+  DwWriteL (Dws, DW_SPI_CTRLR0, 0xffffffff);
+  Cr0 = DwReadL (Dws, DW_SPI_CTRLR0);
+  DwWriteL (Dws, DW_SPI_CTRLR0, Tmp);
+  DwSpiEnableChip (Dws, 1);
+
+  if (!(Cr0 & CTRLR0_DFS_MASK)) {
+    Dws->DfsOffset = CTRLR0_DFS_32_OFFSET;
+  } else {
+    Dws->DfsOffset = CTRLR0_DFS_OFFSET;
+  }
+
+  DEBUG ((DEBUG_INFO,"[Spi%u base: 0x%lx, MaxFreq: %u, CS num: %u, FIFO depth/width: %u/%u, Version: %c.%c%c%c]\n",
+          Dws->BusNum, Dws->Regs, Dws->MaxFreq, Dws->NumCs,
+          Dws->FifoLen, (Dws->DfsOffset == CTRLR0_DFS_OFFSET) ? 16 : 32,
+          Dws->Version >> 24, Dws->Version >> 16,
+          Dws->Version >> 8, Dws->Version));
+}
+
+STATIC
+VOID
+Tpm2PreInitialize (
+  VOID
+  )
+{
+  volatile UINTN      TopRegs;
+  UINT32              Val;
+
+  TopRegs = mSubCtrl->Regs + mSubCtrl->Offset + TOP_SPI0_CS_OFFSET;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x14;
+  MmioWrite32 (TopRegs, Val);
+  Val = MmioRead32 (TopRegs);
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DDR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+  Val = MmioRead32 (TopRegs);
+
+  TopRegs = mDwGpioInsatce->Regs + GPIO_SWPORTA_DR;
+  Val = MmioRead32 (TopRegs);
+  Val = Val | 0x02;
+  MmioWrite32 (TopRegs, Val);
+}
+
+EFI_STATUS
+EFIAPI
+Tpm2SpiInitialize (
+  VOID
+  )
+{
+  EFI_STATUS                      Status;
+  UINT32                          SpiBus = SPI_BUS_NUM;
+  UINT8                           Cs     = SPI_SLAVE_NUM;
+  UINT8                           Mode   = SPI_POLARITY;
+
+  //
+  // add top/gpio/spi regs region in memory map and set uncacheable attribute
+  //
+  Status = GetTopInstanceByPcd ();
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Status = GetGpioInstanceByPcd ();
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Status = GetSpiInstanceByPcd ();
+  if (EFI_ERROR (Status))
+    return Status;
+
+  Tpm2PreInitialize ();
+  SpiHwInit (mDwSpiInsatce);
+
+  Tpm2SpiSlave = AllocateZeroPool (sizeof (SPI_DEVICE));
+  if (!Tpm2SpiSlave)
+    return EFI_OUT_OF_RESOURCES;
+
+  Status = DwSpiSetup (Tpm2SpiSlave, SpiBus, Cs, Mode);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR,"Cannot setup spi slave\n"));
+    return Status;
+  }
+
+  return Status;
+}
+
+STATIC
+EFI_STATUS
+DwSpiCheckStatus (
+  IN OUT DW_SPI   *Dws,
+  IN     BOOLEAN  IsReadFromRisr
+  )
+{
+  UINT32     IrqStatus;
+  EFI_STATUS Status;
+
+  Status = EFI_SUCCESS;
+
+  if (IsReadFromRisr)
+    IrqStatus = DwReadL (Dws, DW_SPI_RISR);
+  else
+    IrqStatus = DwReadL (Dws, DW_SPI_ISR);
+
+  if (IrqStatus & DW_SPI_INT_RXOI) {
+    DEBUG ((DEBUG_ERROR, "RX FIFO overflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  if (IrqStatus & DW_SPI_INT_RXUI) {
+    DEBUG ((DEBUG_ERROR, "RX FIFO underflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  if (IrqStatus & DW_SPI_INT_TXOI) {
+    DEBUG ((DEBUG_ERROR, "TX FIFO overflow detected\n"));
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Generically handle the erroneous situation
+  //
+  if (EFI_ERROR (Status))
+    DwSpiResetChip (Dws);
+
+  return Status;
+}
+
+STATIC
+UINT32
+DwSpiTxMax (
+  IN DW_SPI *Dws
+  )
+{
+  UINT32 TxRoom, RxTxGap;
+
+  TxRoom = Dws->FifoLen - DwReadL (Dws, DW_SPI_TXFLR);
+
+  //
+  // Another concern is about the tx/rx mismatch, we
+  // though to use (Dws->FifoLen - rxflr - txflr) as
+  // one maximum value for tx, but it doesn't cover the
+  // data which is out of tx/rx fifo and inside the
+  // shift registers. So a control from sw point of
+  // view is taken.
+  //
+  RxTxGap = Dws->FifoLen - (Dws->RxLen - Dws->TxLen);
+
+  //
+  // Return the max entries we can fill into tx fifo
+  //
+  return MIN3((UINT32)Dws->TxLen, TxRoom, RxTxGap);
+}
+
+STATIC
+UINT32
+DwSpiRxMax (
+  IN DW_SPI *Dws
+  )
+{
+  //
+  // Return the max entries we should read out of rx fifo
+  //
+  return MIN_T(UINT32, Dws->RxLen, DwReadL (Dws, DW_SPI_RXFLR));
+}
+
+VOID
+DwSpiUpdateConfig (
+  IN OUT DW_SPI      *Dws,
+  IN     SPI_DEVICE  *Spi,
+  IN     DW_SPI_CFG  *Cfg
+  )
+{
+  DW_SPI_CHIP_DATA *Chip;
+  UINT32           Cr0;
+  UINT32           SpeedHz;
+  UINT16           ClkDiv;
+
+  Chip = SpiGetCtldata (Spi);
+  Cr0  = Chip->Cr0;
+
+  //
+  // CTRLR0[ 4/3: 0] or CTRLR0[ 20: 16] Data Frame Size
+  //
+  Cr0 |= (Cfg->Dfs - 1) << Dws->DfsOffset;
+  Cr0 |= FieldPrep (CTRLR0_TMOD_MASK, Cfg->Tmode);
+
+  DwWriteL (Dws, DW_SPI_CTRLR0, Cr0);
+
+  if (Cfg->Tmode == CTRLR0_TMOD_EPROMREAD ||
+      Cfg->Tmode == CTRLR0_TMOD_RO)
+    DwWriteL (Dws, DW_SPI_CTRLR1, Cfg->Ndf ? Cfg->Ndf - 1 : 0);
+
+  //
+  // Note DW APB SSI clock divider doesn't support odd numbers
+  //
+  ClkDiv = (DIV_ROUND_UP(Dws->MaxFreq, Cfg->Freq) + 1) & 0xfffe;
+  SpeedHz = Dws->MaxFreq / ClkDiv;
+
+  if (Dws->CurrentFreq != SpeedHz) {
+    DwSpiSetClk (Dws, ClkDiv);
+    Dws->CurrentFreq = SpeedHz;
+  }
+
+  //
+  // Update RX sample delay if required
+  //
+  if (Dws->CurRxSampleDly != Chip->RxSampleDly) {
+    DwWriteL (Dws, DW_SPI_RX_SAMPLE_DLY, Chip->RxSampleDly);
+    Dws->CurRxSampleDly = Chip->RxSampleDly;
+  }
+}
+
+EFI_STATUS
+DwSpiTransferOneConfig (
+  IN  SPI_DEVICE          *Spi,
+  IN  UINT32              BitsPerWord,
+  IN  UINT32              SpeedHz
+  )
+{
+  DW_SPI_CFG  Cfg;
+  DW_SPI      *Dws = mDwSpiInsatce;
+
+  if (SpeedHz == 0)
+    SpeedHz = Dws->MaxFreq;
+  if (BitsPerWord == 0)
+    BitsPerWord = 8;
+
+  Cfg.Tmode = CTRLR0_TMOD_TR;
+  Cfg.Dfs   = BitsPerWord;
+  Cfg.Freq  = SpeedHz;
+
+  DwSpiEnableChip (Dws, 0);
+
+  DwSpiUpdateConfig (Dws, Spi, &Cfg);
+
+  //
+  // For poll mode just disable all interrupts
+  //
+  DwSpiMaskIntr (Dws, 0xff);
+
+  Dws->SetCs (Tpm2SpiSlave, 0);
+
+  DwSpiEnableChip (Dws, 1);
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+DwSpiTransferOne (
+  DW_SPI     *Dws
+  )
+{
+  UINT32      TxMax;
+  UINT32      RxMax;
+  UINT32      RxW;
+  UINT32      TxW;
+  EFI_STATUS  Status;
+
+  do {
+    TxMax     = DwSpiTxMax (Dws);
+    while (TxMax--) {
+      TxW = *(UINT8 *)(Dws->Tx);
+      DwWriteL (Dws, DW_SPI_DR, TxW);
+      Dws->Tx += Dws->NBytes;
+      --Dws->TxLen;
+    }
+    RxMax     = DwSpiRxMax (Dws);
+    while (RxMax--) {
+      RxW = DwReadL (Dws, DW_SPI_DR);
+      *(UINT8 *)(Dws->Rx) = RxW;
+      Dws->Rx += Dws->NBytes;
+      --Dws->RxLen;
+    }
+    Status = DwSpiCheckStatus (Dws, TRUE);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "check status error\n"));
+      return Status;
+    }
+  } while (Dws->RxLen);  
+
+  return EFI_SUCCESS;
+}
+
+STATIC
+EFI_STATUS
+DwSpiFlowControl (
+  DW_SPI      *Dws
+  )
+{
+  UINT32      Index;
+  UINT32      TxMax;
+  UINT32      RxMax;
+  UINT32      RxW;
+  EFI_STATUS  Status;
+
+  for (Index = 0; Index < TRY_TIMES; Index++) {
+    Dws->TxLen  = 1;
+    Dws->RxLen  = Dws->TxLen;
+    do {
+      TxMax     = DwSpiTxMax (Dws);
+      while (TxMax--) {
+        DwWriteL (Dws, DW_SPI_DR, 0);
+        --Dws->TxLen;
+      }
+      RxMax     = DwSpiRxMax (Dws);
+      while (RxMax--) {
+        RxW = DwReadL (Dws, DW_SPI_DR);
+        --Dws->RxLen;
+      }
+      Status = DwSpiCheckStatus (Dws, TRUE);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "check status error\n"));
+        return Status;
+      }
+    } while (Dws->RxLen);
+
+    if (RxW & 0x01)
+      break;
+  }
+  if (Index == TRY_TIMES)
+    return EFI_TIMEOUT;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS 
+Tpm2WriteNBytes (
+  IN UINTN  regs,
+  IN UINT8* Data,
+  IN UINT16  Size
+  )
+{
+  DW_SPI      *Dws;
+  UINT8       TransferLen;
+  UINT8       mTxBuffer[68];
+  UINT8       mRxBuffer[68];
+  EFI_STATUS  Status;
+  UINT32      BitsPerWord;
+  UINT32      SpeedHz;
+
+  BitsPerWord = 8;
+  SpeedHz     = SPI_SPEED_HZ;
+  Status      = DwSpiTransferOneConfig (Tpm2SpiSlave, BitsPerWord, SpeedHz);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Cannot config spi controller\n"));
+    return Status;
+  }
+
+  Dws = mDwSpiInsatce;
+  Dws->NBytes = RoundupPowOfTwo (BITS_TO_BYTES (8));
+
+  while (Size) {
+    TransferLen  = MIN_T(UINT16, Size, 64);
+    mTxBuffer[0] = 0x00 | ((TransferLen - 1) & 0x3f);
+    mTxBuffer[1] = 0xD4;
+    mTxBuffer[2] = (UINT8)((regs >> 8) & 0xff);
+    mTxBuffer[3] = (UINT8)(regs & 0xff);
+    CopyMem (&mTxBuffer[4], Data, TransferLen);
+
+    Dws->Tx      = mTxBuffer;
+    Dws->TxLen   = 4;
+    Dws->Rx      = mRxBuffer;
+    Dws->RxLen   = Dws->TxLen;
+
+    AssertCs ();
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: command transfer failed\n"));
+      return Status;
+    }
+
+    if ((mRxBuffer[3] & 0x01) == 0) {
+      Status = DwSpiFlowControl (Dws);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Tpm: flow control failed\n"));
+        return Status;
+      }
+    }
+
+    Dws->TxLen  = TransferLen;
+    Dws->RxLen  = Dws->TxLen;
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: data transfer failed\n"));
+      return Status;
+    }
+
+    DeAssertCs ();
+    MicroSecondDelay (5);
+  
+    Data += TransferLen;
+    Size -= TransferLen;
+  }
+  AssertCs ();
+  return Status;
+}
+
+EFI_STATUS 
+Tpm2readNBytes (
+  IN UINTN   regs,
+  IN UINT16  Size,
+  OUT UINT8  *OutBuffer
+  )
+{
+  DW_SPI      *Dws;
+  UINT8       TransferLen;
+  UINT8       mTxBuffer[68];
+  UINT8       mRxBuffer[68];
+  EFI_STATUS  Status;
+  UINT32      BitsPerWord;
+  UINT32      SpeedHz;
+  UINT16      OriSize;
+
+  BitsPerWord = 8;
+  SpeedHz     = SPI_SPEED_HZ;
+  Status      = DwSpiTransferOneConfig (Tpm2SpiSlave, BitsPerWord, SpeedHz);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Cannot config spi controller\n"));
+    return Status;
+  }
+
+  OriSize     = Size;
+  Dws         = mDwSpiInsatce;
+  Dws->NBytes = RoundupPowOfTwo (BITS_TO_BYTES (8));
+
+  while (Size) {
+    TransferLen  = MIN_T(UINT16, Size, 64);
+    mTxBuffer[0] = 0x80 | ((TransferLen - 1) & 0x3f);
+    mTxBuffer[1] = 0xD4;
+    mTxBuffer[2] = (UINT8)((regs >> 8) & 0xff);
+    mTxBuffer[3] = (UINT8)(regs & 0xff);
+
+    Dws->Tx      = mTxBuffer;
+    Dws->TxLen   = 4;
+    Dws->Rx      = mRxBuffer;
+    Dws->RxLen   = Dws->TxLen;
+
+    AssertCs ();
+    Status = DwSpiTransferOne (Dws);
+
+    if ((mRxBuffer[3] & 0x01) == 0) {
+      Status = DwSpiFlowControl (Dws);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Tpm: flow control failed\n"));
+        return Status;
+      }
+    }
+
+    Dws->TxLen  = TransferLen;
+    Dws->RxLen  = Dws->TxLen;
+    Status = DwSpiTransferOne (Dws);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Tpm: data transfer failed\n"));
+      return Status;
+    }
+
+    DeAssertCs ();
+    MicroSecondDelay (5);
+
+    Size -= TransferLen;
+  }
+  CopyMem (OutBuffer, &mRxBuffer[4], OriSize);
+  AssertCs ();
+
+  return Status;
+}
+
+UINT8
+Tpm2Read8 (
+  IN UINTN  regs
+  )
+{
+  UINT8       ReadByte;
+  EFI_STATUS  Status;
+
+  Status = Tpm2readNBytes (regs, sizeof (UINT8), &ReadByte);
+  if (EFI_ERROR (Status))
+    return 0xff;
+
+  return ReadByte;
+}
+
+UINT16
+Tpm2Read16 (
+  IN UINTN  regs
+  )
+{
+  UINT8       RxBuffer[2];
+  UINT16      ReadByte;
+  EFI_STATUS  Status;
+
+  Status = Tpm2readNBytes (regs, sizeof (UINT16), RxBuffer);
+  if (EFI_ERROR (Status))
+    return 0xffff;
+
+  ReadByte = ((RxBuffer[0]) << 8) | RxBuffer[1];
+
+  return ReadByte;
+}
+
+UINT32
+Tpm2Read32 (
+  IN UINTN regs
+  )
+{
+  UINT8       RxBuffer[4];
+  UINT32      ReadByte;
+  EFI_STATUS  Status;
+  
+  Status = Tpm2readNBytes (regs, sizeof (UINT32), RxBuffer);
+  if (EFI_ERROR (Status))
+    return 0xffffffff;
+
+  ReadByte = ((RxBuffer[0]) << 24) | ((RxBuffer[1]) << 16)
+              | ((RxBuffer[2]) << 8) | RxBuffer[3];
+
+  return ReadByte;
+}
+
+VOID
+Tpm2Write8 (
+  IN UINTN regs,
+  IN UINT8 Data
+  )
+{
+  Tpm2WriteNBytes (regs, &Data, sizeof (UINT8));
+}
+
+VOID
+Tpm2Write32 (
+  IN UINTN  regs,
+  IN UINT32 Data
+  )
+{
+  UINT8       TxBuffer[4];
+
+  TxBuffer[0] = (UINT8)((Data >> 24) | 0xff);
+  TxBuffer[1] = (UINT8)((Data >> 16) | 0xff);
+  TxBuffer[2] = (UINT8)((Data >> 8) | 0xff);
+  TxBuffer[4] = (UINT8)(Data | 0xff);
+
+  Tpm2WriteNBytes (regs, TxBuffer, sizeof (UINT8));
+}

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044AcpiTables.inf
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/SG2044AcpiTables.inf
@@ -23,6 +23,7 @@
   Rhct.aslc
   Pptt.aslc
   Dsdt/SG2044Dsdt.asl
+  Ssdt.asl
 
 [Packages]
   EmbeddedPkg/EmbeddedPkg.dec

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/Ssdt.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/Ssdt.asl
@@ -1,0 +1,32 @@
+#include "SG2044AcpiHeader.h"
+
+DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
+  EFI_ACPI_RISCV_OEM_REVISION)
+{
+  External(\_SB.SPI0, DeviceObj)
+
+  Scope(\_SB.SPI0) {
+    Device (TPM) {
+      Name (_HID, "SMO0768")
+      Name (_UID, 0)
+        Method (_STA)
+        {
+          Return (0xF)
+        }
+      Name (_CRS, ResourceTemplate () {
+        SPISerialBus (
+          0,                // Chip Select
+          PolarityLow,      // CS Active Low
+          FourWireMode,
+          8,                // Bits per word
+          ControllerInitiated,
+          10000000,          // Connection speed in Hz
+          ClockPolarityLow,
+          ClockPhaseFirst,
+          "\\_SB.SPI0",     // SPI Path
+          0
+        )
+      })
+    }
+  }
+}

--- a/Silicon/Sophgo/Sophgo.dec
+++ b/Silicon/Sophgo/Sophgo.dec
@@ -70,6 +70,9 @@
   gSophgoTokenSpaceGuid.PcdFdOffset|0x0|UINT64|0x0000101C
   gSophgoTokenSpaceGuid.PcdMCUI2cBus|0x0|UINT32|0x0000101D
   gSophgoTokenSpaceGuid.PcdEfiMemoryBottom|0x0|UINT64|0x0000101E
+  gSophgoTokenSpaceGuid.PcdTpm2GpioBaseAddress|0x0|UINT64|0x0000101F
+  gSophgoTokenSpaceGuid.PcdTpm2SpiBaseAddress|0x0|UINT64|0x00001020
+  gSophgoTokenSpaceGuid.PcdTopBaseAddress|0x0|UINT64|0x00001021
 
 [PcdsDynamic]
   gSophgoTokenSpaceGuid.PcdFlashVariableOffset|0x0|UINT64|0x00001003


### PR DESCRIPTION
1. An option to enable TPM has been added to the SG2044.dsc, when enabled, the TPM modules will be packaged into FV.
2. Implemented a platform-specific TPM driver based SPI interface.
3. Added a SSDT table to describe TPM device information.
4. Provided TPM access and setting control via the bios menu.