### PR TITLE
Sophgo/SG2042Pkg: Modify platform name of SG2042_X4EVB

### DIFF
--- a/Platform/Sophgo/SG2042Pkg/SG2042_X4EVB/SG2042.dsc
+++ b/Platform/Sophgo/SG2042Pkg/SG2042_X4EVB/SG2042.dsc
@@ -14,7 +14,7 @@
 #
 ################################################################################
 [Defines]
-  PLATFORM_NAME                  = SG2042_EVB
+  PLATFORM_NAME                  = SG2042_X4EVB
   PLATFORM_GUID                  = 8014637B-6999-4110-9762-464BE11E935F
   PLATFORM_VERSION               = 0.1
   DSC_SPECIFICATION              = 0x0001001c


### PR DESCRIPTION
 Ensure that build_rv_edk2 can be executed correctly when building
 SG2042.fd for SG2042_X4EVB