### PR TITLE
SG2042Pkg/AcpiTables: Enable SRA1-20 PowerButton to work

### DIFF
--- a/Silicon/Sophgo/SG2042Pkg/AcpiTables/SRA1-20/Dsdt/PowerButton.asl
+++ b/Silicon/Sophgo/SG2042Pkg/AcpiTables/SRA1-20/Dsdt/PowerButton.asl
@@ -27,7 +27,7 @@ Scope(_SB)
     }
 
     Name (_CRS, ResourceTemplate () {
-     Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive,,,) { 96 }
+     Interrupt (ResourceConsumer, Level, ActiveHigh, Shared,,,) { 96 }
     })
 
     // SWPORTA_DDR
@@ -85,9 +85,9 @@ Scope(_SB)
       And (Local0, 0xFFFFFFFB, Local0)
       Store (Local0, SWPO)
 
-      // Set low active
+      // Set high active
       Store (POLA, Local0)
-      And (Local0, 0xFFFFFFFB, Local0)
+      Or (Local0, 0x4, Local0)
       Store (Local0, POLA)
 
       // Set edge sensitive


### PR DESCRIPTION
When the power button is pressed while the device is powered on, the CPLD will pull Pin2 up to notify that the host to shut down, so GPIO0-Pin2 is configured to be high edge sensitive.