### PR TITLE
Sophgo/SG2044: Optimize the processing logic of boot options

### DIFF
--- a/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Silicon/Sophgo/Library/PlatformBootManagerLib/PlatformBm.c
@@ -398,45 +398,41 @@ CheckBootOptionsStatus (
   EFI_BOOT_MANAGER_LOAD_OPTION    *BootOptions;
   UINTN                           BootOptionCount;
   UINTN                           BootOptionIndex;
-  EFI_HANDLE                      Handle1;
-  EFI_HANDLE                      Handle2;
-  EFI_STATUS                      Status1;
-  EFI_STATUS                      Status2;
-  EFI_DEVICE_PATH_PROTOCOL        *TempPath;
+  EFI_HANDLE                      Handle;
+  EFI_STATUS                      Status;
+  EFI_DEVICE_PATH_PROTOCOL        *CopyOptionPath;
   BOOLEAN                         InvalidFound;
   BOOLEAN                         HasValidAutoCreatedBlockDevice;
   UINTN                           FileSize;
   EFI_DEVICE_PATH_PROTOCOL        *CurFullPath;
   VOID                            *FileBuffer;
 
-  CurFullPath = NULL;
   InvalidFound = FALSE;
   HasValidAutoCreatedBlockDevice = FALSE;
   BootOptions = EfiBootManagerGetLoadOptions(&BootOptionCount, LoadOptionTypeBoot);
 
   for (BootOptionIndex = 0; BootOptionIndex < BootOptionCount; ++BootOptionIndex) {
-    TempPath = DuplicateDevicePath(BootOptions[BootOptionIndex].FilePath);
-    Status1 = gBS->LocateDevicePath (&gEfiBlockIoProtocolGuid, &TempPath, &Handle1);
-    Status2 = gBS->LocateDevicePath (&gEfiLoadFileProtocolGuid, &TempPath, &Handle2);
-
-    if (EFI_ERROR (Status1) && EFI_ERROR (Status2)) {
-      FileBuffer  = BmGetNextLoadOptionBuffer (BootOptions[BootOptionIndex].OptionType, BootOptions[BootOptionIndex].FilePath, &CurFullPath, &FileSize);
-      if (FileBuffer != NULL) {
-        FreePool(FileBuffer);
-      } else {
-          // Found invalid boot option
-          InvalidFound = TRUE;
-          DEBUG ((DEBUG_INFO, "Removing invalid boot option %d\n", BootOptions[BootOptionIndex].OptionNumber));
-          EfiBootManagerDeleteLoadOptionVariable(
-            BootOptions[BootOptionIndex].OptionNumber,
-            LoadOptionTypeBoot
-          );
+    FileBuffer = NULL;
+    CurFullPath = NULL;
+    CopyOptionPath = NULL;
+    FileBuffer = BmGetNextLoadOptionBuffer (BootOptions[BootOptionIndex].OptionType, BootOptions[BootOptionIndex].FilePath, &CurFullPath, &FileSize);
+    if (FileBuffer != NULL) {
+      FreePool (FileBuffer);
+      CopyOptionPath = DuplicateDevicePath(BootOptions[BootOptionIndex].FilePath);
+      Status = gBS->LocateDevicePath (&gEfiBlockIoProtocolGuid, &CopyOptionPath, &Handle);
+      if (!EFI_ERROR (Status)) {
+        // For valid block devices (not LoadFile devices), check if any are auto-created
+        if (IsAutoCreateBootOption(&BootOptions[BootOptionIndex]))
+          HasValidAutoCreatedBlockDevice = TRUE;
       }
-    } else if (!EFI_ERROR (Status1) && EFI_ERROR (Status2)) {
-      // For valid block devices (not LoadFile devices), check if any are auto-created
-      if (IsAutoCreateBootOption(&BootOptions[BootOptionIndex])) {
-        HasValidAutoCreatedBlockDevice = TRUE;
-      }
+    } else {
+        // Found invalid boot option
+        InvalidFound = TRUE;
+        DEBUG ((DEBUG_INFO, "Removing invalid boot option %d\n", BootOptions[BootOptionIndex].OptionNumber));
+        EfiBootManagerDeleteLoadOptionVariable(
+          BootOptions[BootOptionIndex].OptionNumber,
+          LoadOptionTypeBoot
+        );
     }
   }
 


### PR DESCRIPTION
  - Directly use the "BmGetNextLoadOptionBuffer" function to determine if the boot option is valid.

  - Ensure to minimize the manual operation of boot options by users in various scenarios, and enter the system by default.