### PR TITLE
SG2044: disable PcdPciDegradeResourceForOptionRom on all platforms

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SD3-10/SD3-10.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SD3-10/SD3-10.dsc
@@ -420,6 +420,10 @@
   #   TRUE  - S3 performance data will be supported in ACPI FPDT table.
   #   FALSE - S3 performance data will not be supported in ACPI FPDT table.
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwarePerformanceDataTableS3Support|FALSE
+  #
+  # No CSM on RISC-V: do not downgrade PMem64 BARs to PMem32 for devices with Option ROM.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE

--- a/Platform/Sophgo/SG2044Pkg/SRA3-40-8/SRA3-40-8.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SRA3-40-8/SRA3-40-8.dsc
@@ -422,6 +422,10 @@
   #   TRUE  - S3 performance data will be supported in ACPI FPDT table.
   #   FALSE - S3 performance data will not be supported in ACPI FPDT table.
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwarePerformanceDataTableS3Support|FALSE
+  #
+  # No CSM on RISC-V: do not downgrade PMem64 BARs to PMem32 for devices with Option ROM.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE

--- a/Platform/Sophgo/SG2044Pkg/SRA3-40/SRA3-40.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SRA3-40/SRA3-40.dsc
@@ -421,6 +421,10 @@
   #   TRUE  - S3 performance data will be supported in ACPI FPDT table.
   #   FALSE - S3 performance data will not be supported in ACPI FPDT table.
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwarePerformanceDataTableS3Support|FALSE
+  #
+  # No CSM on RISC-V: do not downgrade PMem64 BARs to PMem32 for devices with Option ROM.
+  #
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE
 
 [PcdsFixedAtBuild]
   gEfiMdeModulePkgTokenSpaceGuid.PcdStatusCodeUseMemory|FALSE


### PR DESCRIPTION
Upstream edk2 now defaults PcdPciDegradeResourceForOptionRom to TRUE. With Option-ROM devices (e.g. Intel X540), PciBus degrades PMem64 BARs to PMem32, but SG2044 roots have no set PMem32 window, causing PCI resource allocation failure. Set the PCD to FALSE to match pre-upgrade behavior.