### PR TITLE
SG2044/SD3-12: Switch IPMI transport to SSIF

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.dsc
@@ -235,8 +235,8 @@
   SmbusLib|MdePkg/Library/DxeSmbusLib/DxeSmbusLib.inf
   IpmiLib|MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.inf
   IpmiCommandLib|ManageabilityPkg/Library/IpmiCommandLib/IpmiCommandLib.inf
-  # ManageabilityTransportLib|Features/ManageabilityPkg/Library/ManageabilityTransportSsifLib/Dxe/DxeManageabilityTransportSsif.inf
-  ManageabilityTransportLib|edk2-platforms/Silicon/Sophgo/Library/SophgoManageabilityTransportSerialLib/Dxe/DxeManageabilityTransportSerial.inf
+  ManageabilityTransportLib|ManageabilityPkg/Library/ManageabilityTransportSsifLib/Dxe/DxeManageabilityTransportSsif.inf
+  # ManageabilityTransportLib|edk2-platforms/Silicon/Sophgo/Library/SophgoManageabilityTransportSerialLib/Dxe/DxeManageabilityTransportSerial.inf
   SophgoNs16550Lib|edk2-platforms/Silicon/Sophgo/Library/SophgoNs16550Lib/SophgoNs16550.inf
 
 !if $(TPM2_ENABLE) == TRUE
@@ -441,6 +441,8 @@
   gEfiMdePkgTokenSpaceGuid.PcdMaximumAsciiStringLength|1000000
   gEfiMdePkgTokenSpaceGuid.PcdMaximumLinkedListLength|1000000
 
+  # ssif bmc slave addr
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr|0x20
 
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
@@ -550,7 +552,7 @@
   # gSophgoTokenSpaceGuid.PcdMCUI2cBus|1
   gSophgoTokenSpaceGuid.PcdRtcI2cBusNum0|2
   gSophgoTokenSpaceGuid.PcdRtcI2cBusNum1|3
-  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|3
+  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|0
 
   gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency|50000000
 
@@ -826,6 +828,10 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap|3
 !endif
 
+# ssif
+  gManageabilityPkgTokenSpaceGuid.PcdSendSmbiosOnChanged|FALSE
+  gManageabilityPkgTokenSpaceGuid.PcdBmcSmbiosBlobTransferId|"/smbios"
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform.
@@ -1082,6 +1088,8 @@
   ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfig.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.inf
+  ManageabilityPkg/Universal/IpmiSmbiosTransferDxe/IpmiSmbiosTransferDxe.inf
+  ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.inf
 
   #
   # FAT filesystem + GPT/MBR partitioning + UDF filesystem

--- a/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.fdf
@@ -263,6 +263,8 @@ INF Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcDxe.inf
 INF ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfig.inf
+INF ManageabilityPkg/Universal/IpmiSmbiosTransferDxe/IpmiSmbiosTransferDxe.inf
+INF ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.inf
 
 #
 # TPM2 Dxe

--- a/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
+++ b/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
@@ -674,10 +674,10 @@ I2cSmbusWrite (
   )
 {
   I2C_MSG  Msg;
-  UINT8    Buf[18];
+  UINT8    Buf[34];
 
-  if (Len > 17) {
-    DEBUG ((DEBUG_ERROR, "%a: write %d bytes exceeds 17!\n", __func__, Len));
+  if (Len > 33) {
+    DEBUG ((DEBUG_ERROR, "%a: write %d bytes exceeds 33!\n", __func__, Len));
     return EFI_INVALID_PARAMETER;
   }
 

--- a/Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcCommon.c
+++ b/Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcCommon.c
@@ -130,9 +130,10 @@ SmbusHcCommonExecute (
         return EFI_INVALID_PARAMETER;
       }
 
-      DataLen = *Length;
-      CopyMem (&WriteTemp[0], Buffer, *Length);
-      DEBUG ((DEBUG_VERBOSE, "W %d: ", DataLen));
+      WriteTemp[0] = *Length;
+      CopyMem (&WriteTemp[1], Buffer, *Length);
+      DataLen = (*Length) + 1;
+      DEBUG ((DEBUG_VERBOSE, "W %d: ", *Length));
       DEBUG ((DEBUG_VERBOSE, "Addr 0x%x: ", SlaveAddress.SmbusDeviceAddress));
       for (Idx = 0; Idx < DataLen; Idx++) {
         DEBUG ((DEBUG_VERBOSE, "0x%x ", WriteTemp[Idx]));

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/SD3-12/Ssdt.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/SD3-12/Ssdt.asl
@@ -4,6 +4,7 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
   EFI_ACPI_RISCV_OEM_REVISION)
 {
   External(\_SB.SPI0, DeviceObj)
+  External(\_SB.I2C0, DeviceObj)
 
   Scope(\_SB.SPI0) {
     Device (TPM) {
@@ -14,7 +15,7 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
           Return (0xF)
         }
       Name (_CRS, ResourceTemplate () {
-        SPISerialBus (
+        SPISerialBusV2 (
           0,                // Chip Select
           PolarityLow,      // CS Active Low
           FourWireMode,
@@ -25,6 +26,27 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
           ClockPhaseFirst,
           "\\_SB.SPI0",     // SPI Path
           0
+        )
+      })
+    }
+  }
+  Scope(\_SB.I2C0) {
+    Device (IPI) {
+      Name (_HID, "IPI0001")
+      Name (_UID, 0)
+        Method (_STA)
+        {
+          Return (0xF)
+        }
+      Name (_CRS, ResourceTemplate () {
+        I2cSerialBusV2 (
+          0x10,              // 7 bits slave addr
+          ControllerInitiated,
+          100000,              // 100kHz
+          AddressingMode7Bit,  // 7 bits
+          "\\_SB.I2C0",        // I2C path
+          0,
+          ResourceConsumer
         )
       })
     }

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfigOem.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfigOem.c
@@ -7,12 +7,12 @@ SendBiosFmVersionToBmc (
   )
 {
 	CHAR16      BiosFmVersion[16];
-  CHAR8       AsciiBiosFmVersion[16];
-  UINT8       Commanddata[SMBIOS_OEM_IPMI_CMD_MAX_LEN];
-  UINT8       Commanddatasize;
-  UINT8       Response[20];
-  UINT32       Responsesize;
-  EFI_STATUS  Status;
+	CHAR8       AsciiBiosFmVersion[16];
+	UINT8       Commanddata[SMBIOS_OEM_IPMI_CMD_MAX_LEN];
+	UINT8       Commanddatasize;
+	UINT8       Response[20];
+	UINT32       Responsesize;
+	EFI_STATUS  Status;
 
 	Status = GetBiosFmVersion(BiosFmVersion);
 
@@ -23,28 +23,29 @@ SendBiosFmVersionToBmc (
 			__func__,
 			Status));
 	} else {
-    UnicodeStrToAsciiStrS(BiosFmVersion, AsciiBiosFmVersion, StrLen(BiosFmVersion) + 1);
+		UnicodeStrToAsciiStrS(BiosFmVersion, AsciiBiosFmVersion, StrLen(BiosFmVersion) + 1);
 
 		ZeroMem (Commanddata, 20);
 		ZeroMem (Response, 20);
 		CopyMem (&Commanddata[0], &AsciiBiosFmVersion[0], AsciiStrLen(AsciiBiosFmVersion));
 		Commanddatasize =  AsciiStrLen(AsciiBiosFmVersion);
 		Responsesize    = 10;
+		DEBUG ((DEBUG_INFO, "%s: Commanddatasize is %d\n", __func__, Commanddatasize));
 		Status = IpmiSubmitCommand (
-							SMBIOS_OEM_IPMI_NETFN,
-							SMBIOS_OEM_BIOS_FW_VERSION_CMD,
-							(UINT8 *) &Commanddata[0],
-							Commanddatasize,
-							(UINT8 *) &Response,
-							(UINT32 *) &Responsesize
-							);
+			SMBIOS_OEM_IPMI_NETFN,
+			SMBIOS_OEM_BIOS_FW_VERSION_CMD,
+			(UINT8 *) &Commanddata[0],
+			Commanddatasize,
+			(UINT8 *) &Response,
+			(UINT32 *) &Responsesize
+			);
 		if (EFI_ERROR(Status)) {
 			DEBUG((
 				DEBUG_ERROR,
 				"%a: IpmiSubmitCommand-%r\n",
 				__func__,
 				Status));
-		}
+	}
   }
   return Status;
 }
@@ -58,11 +59,11 @@ SendCpuInfoToBmc (
 	UINT8       Commanddata[SMBIOS_OEM_IPMI_CMD_MAX_LEN];
 	CHAR16      CpuSerialNumber[CPU_SERIALNUM_MAX_LEN];
 	CHAR16      CpuSpeed;
-  UINT8       Commanddatasize;
-  UINT8       Response[20];
-  UINT32      Responsesize;
+	UINT8       Commanddatasize;
+	UINT8       Response[20];
+	UINT32      Responsesize;
 	UINT8       Index, CpuManufacturerLen, CpuBrandNameLen;
-  EFI_STATUS  Status;
+  	EFI_STATUS  Status;
 
 	Index = 0;
 	CpuManufacturerLen   = AsciiStrLen(CPU_MANUFACTURER) + 1;
@@ -102,15 +103,15 @@ SendCpuInfoToBmc (
 
 		Commanddatasize = Index;
 		Responsesize    = 10;
-
+		DEBUG ((DEBUG_INFO, "%s: Commanddatasize is %d\n", __func__, Commanddatasize));
 		Status = IpmiSubmitCommand (
-            SMBIOS_OEM_IPMI_NETFN,           // NetFunction
-            SMBIOS_OEM_CPU_IPMI_CMD,     // Command
-            (UINT8 *) &Commanddata[0],  // *CommandData
-            Commanddatasize,            // CommandDataSize
-            (UINT8 *) &Response,        // *ResponseData
-            (UINT32 *) &Responsesize     // *ResponseDataSize
-            );
+			SMBIOS_OEM_IPMI_NETFN,           // NetFunction
+			SMBIOS_OEM_CPU_IPMI_CMD,     // Command
+			(UINT8 *) &Commanddata[0],  // *CommandData
+			Commanddatasize,            // CommandDataSize
+			(UINT8 *) &Response,        // *ResponseData
+			(UINT32 *) &Responsesize     // *ResponseDataSize
+			);
 		if (EFI_ERROR(Status)) {
 			DEBUG((
 				DEBUG_ERROR,
@@ -131,15 +132,15 @@ SendDdrInfoToBmc (
 {
 	CHAR16      MemoryManufacturer[MEM_MANUFACTURER_MAX_LEN];
 	UINT8       MemoryType;
-  UINT32      MemorySize;//MB
+  	UINT32      MemorySize;//MB
 	UINT16      MemorySpeed;//MT/s
-  UINT8       MemoryRank;
+  	UINT8       MemoryRank;
 	UINT8       Commanddata[SMBIOS_OEM_IPMI_CMD_MAX_LEN];
-  UINT8       Commanddatasize;
-  UINT8       Response[20];
-  UINT32      Responsesize;
+	UINT8       Commanddatasize;
+	UINT8       Response[20];
+	UINT32      Responsesize;
 	UINT8       Index;
-  EFI_STATUS  Status;
+  	EFI_STATUS  Status;
 
 	Status = GetMemoryInfo(MemoryManufacturer, &MemoryType, &MemorySize, &MemoryRank, &MemorySpeed);
 
@@ -164,15 +165,15 @@ SendDdrInfoToBmc (
 
 		Commanddatasize = Index;
 		Responsesize    = 10;
-
+		DEBUG ((DEBUG_INFO, "%s: Commanddatasize is %d\n", __func__, Commanddatasize));
 		Status = IpmiSubmitCommand (
-							SMBIOS_OEM_IPMI_NETFN,           // Net Function
-							SMBIOS_OEM_DDR_IPMI_CMD,     // Command
-							(UINT8 *) &Commanddata[0],  // *CommandData
-							Commanddatasize,            // CommandDataSize
-							(UINT8 *) &Response,        // *ResponseData
-							(UINT32 *) &Responsesize     // *ResponseDataSize
-							);
+			SMBIOS_OEM_IPMI_NETFN,           // Net Function
+			SMBIOS_OEM_DDR_IPMI_CMD,     // Command
+			(UINT8 *) &Commanddata[0],  // *CommandData
+			Commanddatasize,            // CommandDataSize
+			(UINT8 *) &Response,        // *ResponseData
+			(UINT32 *) &Responsesize     // *ResponseDataSize
+			);
 		if (EFI_ERROR(Status)) {
 			DEBUG((
 				DEBUG_ERROR,


### PR DESCRIPTION
 - Switch ManageabilityTransportLib from serial to SSIF with multi-partition support. Disable PEC and set transaction support to multi-partition read/write with middle.

 - Add I2C0 ACPI device (IPI0001) for SSIF discovery, configure slave addr 0x20 on I2C bus 0, and add SmbiosTransfer/BlobTransfer modules to platform DSC/FDF.

 - Fix SmbusHc Block Write to prepend length byte per SMBus specification, and increase DwI2c TX buffer from 18 to 34 bytes for SSIF multi-part payloads.