### PR TITLE
SG2044: add missing SmbiosPlatformReady protocol to SD3-10 INF

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/SmbiosPlatformDxe.inf
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/SmbiosPlatformDxe.inf
@@ -74,6 +74,7 @@
 
 [Protocols]
   gEfiSmbiosProtocolGuid                            ## CONSUMED
+  gSophgoSmbiosPlatformReadyProtocolGuid              ## PRODUCES
 
 [Pcd]
   gSophgoTokenSpaceGuid.PcdMisa


### PR DESCRIPTION
Commit 15b1956934 added gSophgoSmbiosPlatformReadyProtocolGuid installation to the shared SmbiosPlatformDxe.c, but only updated the SRA3-40 and SRA3-40-8 INFs. The SD3-10 SmbiosPlatformDxe.inf was missing the protocol in its [Protocols] section, so AutoGen.c did not generate the symbol definition, causing a link error:

  SmbiosPlatformDxe.c:132: undefined reference to `gSophgoSmbiosPlatformReadyProtocolGuid'

SD3-12 is unaffected because it reuses the SRA3-40 INF.