### PR TITLE
SG2044: wait for platform SMBIOS before HII setup drivers

### DIFF
--- a/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.inf
@@ -54,6 +54,7 @@
 [Protocols]
   gEfiSmbiosProtocolGuid                        ## CONSUMES
   gEfiHiiConfigAccessProtocolGuid               ## CONSUMES
+  gSophgoSmbiosPlatformReadyProtocolGuid        ## CONSUMES
 
 [FeaturePcd]
 
@@ -72,4 +73,5 @@
 
 [Depex]
   gEfiHiiConfigRoutingProtocolGuid  AND
-  gEfiHiiDatabaseProtocolGuid
+  gEfiHiiDatabaseProtocolGuid       AND
+  gSophgoSmbiosPlatformReadyProtocolGuid

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/ReserveMemoryDxe/ReserveMemoryDxe.inf
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/ReserveMemoryDxe/ReserveMemoryDxe.inf
@@ -57,7 +57,9 @@
   gEfiHiiStringProtocolGuid                     ## CONSUMES
   gEfiHiiPackageListProtocolGuid                ## CONSUMES
   gReserveMemoryRestoreProtocolGuid             ## PRODUCES
+  gSophgoSmbiosPlatformReadyProtocolGuid        ## CONSUMES
 
 [Depex]
   gEfiHiiConfigRoutingProtocolGuid  AND
-  gEfiHiiDatabaseProtocolGuid
+  gEfiHiiDatabaseProtocolGuid       AND
+  gSophgoSmbiosPlatformReadyProtocolGuid


### PR DESCRIPTION
Add gSophgoSmbiosPlatformReadyProtocolGuid to the DEPEX of InformationDxe and ReserveMemoryDxe so AllocSmbiosData() runs after SmbiosPlatformDxe publishes Type 0/4/7/17 tables, fixing empty CPU/DDR/cache info in the BIOS setup menu.