### PR TITLE
SG2044: fix SMBIOS memory speed and L1 cache in bios display

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/Type17/PlatformMemoryDeviceData.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/Type17/PlatformMemoryDeviceData.c
@@ -27,7 +27,7 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE17, PlatformMemoryDevice) = {
     0,                                // Bank 0
     MemoryTypeLpddr5,                 // DDR4
     {0,0,0,0,0,0,0,0,0,0,0,0,0,0,1},  // unbuffered
-    8533,                             // DRAM speed - requires update
+    0xFFFF,                           // DRAM speed - requires update
     2,                                // varies between diffrent production runs
     0,                                // serial
     0,                                // asset tag

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SD3-10/Type17/PlatformMemoryDeviceFunction.c
@@ -69,7 +69,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
       }
 
       Value = FixedPcdGet64(PcdDdrRate);
-      InputData->Speed = Value / 1000000;
+      InputData->ExtendedSpeed = Value / 1000000;
       InputData->ConfiguredMemoryClockSpeed = Value / 1000000;
 
       Value = FixedPcdGet64(PcdDdrRank);

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40-8/Type17/PlatformMemoryDeviceData.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40-8/Type17/PlatformMemoryDeviceData.c
@@ -27,7 +27,7 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE17, PlatformMemoryDevice) = {
     0,                                // Bank 0
     MemoryTypeLpddr5,                 // DDR4
     {0,0,0,0,0,0,0,0,0,0,0,0,0,0,1},  // unbuffered
-    8533,                             // DRAM speed - requires update
+    0xFFFF,                             // DRAM speed - requires update
     2,                                // varies between diffrent production runs
     0,                                // serial
     0,                                // asset tag

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40-8/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40-8/Type17/PlatformMemoryDeviceFunction.c
@@ -69,7 +69,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
       }
 
       Value = FixedPcdGet64(PcdDdrRate);
-      InputData->Speed = Value / 1000000;
+      InputData->ExtendedSpeed = Value / 1000000;
       InputData->ConfiguredMemoryClockSpeed = Value / 1000000;
 
       Value = FixedPcdGet64(PcdDdrRank);

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40/Type17/PlatformMemoryDeviceData.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40/Type17/PlatformMemoryDeviceData.c
@@ -27,7 +27,7 @@ SMBIOS_PLATFORM_DXE_TABLE_DATA (SMBIOS_TABLE_TYPE17, PlatformMemoryDevice) = {
     0,                                // Bank 0
     MemoryTypeLpddr5,                 // DDR4
     {0,0,0,0,0,0,0,0,0,0,0,0,0,0,1},  // unbuffered
-    8533,                             // DRAM speed - requires update
+    0xFFFF,                             // DRAM speed - requires update
     2,                                // varies between diffrent production runs
     0,                                // serial
     0,                                // asset tag

--- a/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40/Type17/PlatformMemoryDeviceFunction.c
+++ b/Platform/Sophgo/SG2044Pkg/Drivers/SRA3-40/Type17/PlatformMemoryDeviceFunction.c
@@ -69,7 +69,7 @@ SMBIOS_PLATFORM_DXE_TABLE_FUNCTION (PlatformMemoryDevice) {
       }
 
       Value = FixedPcdGet64(PcdDdrRate);
-      InputData->Speed = Value / 1000000;
+      InputData->ExtendedSpeed = Value / 1000000;
       InputData->ConfiguredMemoryClockSpeed = Value / 1000000;
 
       Value = FixedPcdGet64(PcdDdrRank);

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/InformationDxe/InformationDxe.c
@@ -253,6 +253,12 @@ InformationInit(
     ParsedData->ExtendedSpeed = 0;
     ParsedData->MemoryRank = 0;
     ParsedData->ExtendSize = 0;
+  } else {
+    // SG2044 L1 cache is Unified in SMBios: Split evenly into I-cache and
+    // D-cache halves so the display fields show per-subcache sizes correctly.
+    UINT32 L1TotalSize = ParsedData->L1ICacheSize;
+    ParsedData->L1ICacheSize = L1TotalSize / 2;
+    ParsedData->L1DCacheSize = L1TotalSize / 2;
   }
   FillInformationData(&gInformationData);
   SyncToVarStore(&gInformationData);
@@ -331,4 +337,3 @@ InformationUnload(
 
   return EFI_SUCCESS;
 }
-


### PR DESCRIPTION
## Summary

+ Use ExtendedSpeed instead of Speed for SMBIOS Type17 memory device rate across all platforms (SD3-10, SRA3-40, SRA3-40-8), setting Speed to 0xFFFF per SMBIOS spec
+ Split unified L1 cache total size evenly into I-cache and D-cache halves in InformationDxe for correct per-subcache display