### PR TITLE
SG2044: Refactor I2C/SMBus driver and enable SSIF transport for SD3-12

### DIFF
--- a/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.dsc
+++ b/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.dsc
@@ -235,8 +235,8 @@
   SmbusLib|MdePkg/Library/DxeSmbusLib/DxeSmbusLib.inf
   IpmiLib|MdeModulePkg/Library/DxeIpmiLibIpmiProtocol/DxeIpmiLibIpmiProtocol.inf
   IpmiCommandLib|ManageabilityPkg/Library/IpmiCommandLib/IpmiCommandLib.inf
-  # ManageabilityTransportLib|Features/ManageabilityPkg/Library/ManageabilityTransportSsifLib/Dxe/DxeManageabilityTransportSsif.inf
-  ManageabilityTransportLib|edk2-platforms/Silicon/Sophgo/Library/SophgoManageabilityTransportSerialLib/Dxe/DxeManageabilityTransportSerial.inf
+  ManageabilityTransportLib|ManageabilityPkg/Library/ManageabilityTransportSsifLib/Dxe/DxeManageabilityTransportSsif.inf
+  # ManageabilityTransportLib|edk2-platforms/Silicon/Sophgo/Library/SophgoManageabilityTransportSerialLib/Dxe/DxeManageabilityTransportSerial.inf
   SophgoNs16550Lib|edk2-platforms/Silicon/Sophgo/Library/SophgoNs16550Lib/SophgoNs16550.inf
 
 !if $(TPM2_ENABLE) == TRUE
@@ -441,6 +441,8 @@
   gEfiMdePkgTokenSpaceGuid.PcdMaximumAsciiStringLength|1000000
   gEfiMdePkgTokenSpaceGuid.PcdMaximumLinkedListLength|1000000
 
+  # ssif bmc slave addr
+  gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr|0x20
 
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdVpdBaseAddress|0x0
@@ -550,7 +552,7 @@
   # gSophgoTokenSpaceGuid.PcdMCUI2cBus|1
   gSophgoTokenSpaceGuid.PcdRtcI2cBusNum0|2
   gSophgoTokenSpaceGuid.PcdRtcI2cBusNum1|3
-  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|3
+  gSophgoTokenSpaceGuid.PcdSsifI2cBusNum|0
 
   gUefiCpuPkgTokenSpaceGuid.PcdCpuCoreCrystalClockFrequency|50000000
 
@@ -826,6 +828,10 @@
   gEfiSecurityPkgTokenSpaceGuid.PcdTcg2HashAlgorithmBitmap|3
 !endif
 
+# ssif
+  gManageabilityPkgTokenSpaceGuid.PcdSendSmbiosOnChanged|FALSE
+  gManageabilityPkgTokenSpaceGuid.PcdBmcSmbiosBlobTransferId|"/smbios"
+
 ################################################################################
 #
 # Components Section - list of all EDK II Modules needed by this Platform.
@@ -1082,6 +1088,8 @@
   ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfig.inf
   Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.inf
+  ManageabilityPkg/Universal/IpmiSmbiosTransferDxe/IpmiSmbiosTransferDxe.inf
+  ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.inf
 
   #
   # FAT filesystem + GPT/MBR partitioning + UDF filesystem

--- a/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.fdf
+++ b/Platform/Sophgo/SG2044Pkg/SD3-12/SD3-12.fdf
@@ -263,6 +263,8 @@ INF Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcDxe.inf
 INF ManageabilityPkg/Universal/IpmiProtocol/Dxe/IpmiProtocolDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/IpmiBootDxe/IpmiBootDxe.inf
 INF Silicon/Sophgo/SG2044Pkg/Drivers/BmcConfigDxe/BmcConfig.inf
+INF ManageabilityPkg/Universal/IpmiSmbiosTransferDxe/IpmiSmbiosTransferDxe.inf
+INF ManageabilityPkg/Universal/IpmiBlobTransferDxe/IpmiBlobTransferDxe.inf
 
 #
 # TPM2 Dxe

--- a/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
+++ b/Silicon/Sophgo/Drivers/DwI2cDxe/DwI2cDxe.c
@@ -470,56 +470,15 @@ I2cXfer (
 }
 
 /**
-  I2c smbus read 1 byte data command.
+  I2C read operation — write data to the slave then read data bytes back.
 
-  @param[in]   This  The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
-  @param[in]   I2c   I2c bus number.
-  @param[in]   Addr  I2c slave address.
-  @param[in]   Cmd   Smbus command.
-  @param[out]  Data  Buffer used to store the read data.
-
-  @retval  EFI_SUCCESS              Read data success.
-  @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
-  @retval  EFI_DEVICE_ERROR         There was an error during the transmission.
-  @retval  EFI_TIMEOUT              Waiting for bus busy timedout or transfer timeout.
-
-**/
-EFI_STATUS
-EFIAPI
-I2cSmbusReadByte (
-  IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
-  IN  INT32                       I2c,
-  IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  OUT UINT8                       *Data
-  )
-{
-  I2C_MSG  Msg[2];
-
-  SetMem ((VOID *)Msg, sizeof (Msg), 0);
-
-  Msg[0].Addr  = Addr;
-  Msg[0].Flags = 0;
-  Msg[0].Len   = 1;
-  Msg[0].Buf   = &Cmd;
-
-  Msg[1].Addr  = Addr;
-  Msg[1].Flags = I2C_M_RD;
-  Msg[1].Len   = 1;
-  Msg[1].Buf   = Data;
-
-  return I2cXfer (I2c, Msg, 2);
-}
-
-/**
-  I2c smbus read specified byte length data command.
-
-  @param[in]   This  The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
-  @param[in]   I2c   I2c bus number.
-  @param[in]   Addr  I2c slave address.
-  @param[in]   Len   Byte size of the data to be written.
-  @param[in]   Cmd   Smbus command.
-  @param[out]  Data  Buffer used to store the read data.
+  @param[in]   This       The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
+  @param[in]   I2c        I2c bus number.
+  @param[in]   Addr       I2c slave address.
+  @param[in]   WriteLen   Number of bytes to write before reading.
+  @param[in]   WriteData  Data to write before reading (e.g. register offset).
+  @param[in]   ReadLen    Number of bytes to read.
+  @param[out]  ReadData   Buffer to store the read data.
 
   @retval  EFI_SUCCESS              Read data success.
   @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
@@ -529,13 +488,14 @@ I2cSmbusReadByte (
 **/
 EFI_STATUS
 EFIAPI
-I2cSmbusRead (
+I2cMasterRead (
   IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
   IN  INT32                       I2c,
   IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  IN  UINT32                      Len,
-  OUT UINT8                       *Data
+  IN  UINT32                      WriteLen,
+  IN  UINT8                       *WriteData,
+  IN  UINT32                      ReadLen,
+  OUT UINT8                       *ReadData
   )
 {
   I2C_MSG  Msg[2];
@@ -544,68 +504,25 @@ I2cSmbusRead (
 
   Msg[0].Addr  = Addr;
   Msg[0].Flags = 0;
-  Msg[0].Len   = 1;
-  Msg[0].Buf   = &Cmd;
+  Msg[0].Len   = WriteLen;
+  Msg[0].Buf   = WriteData;
 
   Msg[1].Addr  = Addr;
   Msg[1].Flags = I2C_M_RD;
-  Msg[1].Len   = Len;
-  Msg[1].Buf   = Data;
+  Msg[1].Len   = ReadLen;
+  Msg[1].Buf   = ReadData;
 
   return I2cXfer (I2c, Msg, 2);
 }
 
 /**
-  I2c smbus write 1 byte data command.
+  I2C write operation — write data bytes to the I2C slave.
 
   @param[in]  This  The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
   @param[in]  I2c   I2c bus number.
   @param[in]  Addr  I2c slave address.
-  @param[in]  Cmd   Smbus command.
-  @param[in]  Data  Data to be writen.
-
-  @retval  EFI_SUCCESS         Write data success.
-  @retval  EFI_NOT_FOUND       Unable to find i2c slave with the given address.
-  @retval  EFI_DEVICE_ERROR    There was an error during the transmission.
-  @retval  EFI_TIMEOUT         Waiting for bus busy timedout or transfer timeout.
-
-**/
-EFI_STATUS
-EFIAPI
-I2cSmbusWriteByte (
-  IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
-  IN  INT32                       I2c,
-  IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  IN  UINT8                       Data
-  )
-{
-  I2C_MSG  Msg;
-  UINT8    Buf[2];
-
-  SetMem ((VOID *)(&Msg), sizeof (Msg), 0);
-
-  Buf[0]    = Cmd;
-  Buf[1]    = Data;
-
-  Msg.Addr  = Addr;
-  Msg.Flags = 0;
-  Msg.Len   = 2;
-  Msg.Buf   = Buf;
-
-  return I2cXfer (I2c, &Msg, 1);
-}
-
-/**
-  I2c smbus write multiple bytes to the device,
-  maximum 16 bytes in a single operation.
-
-  @param[in]  This        The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
-  @param[in]  I2c         I2c bus number.
-  @param[in]  Addr        I2c slave address.
-  @param[in]  EepromAddr  The address to write data in.
-  @param[in]  DataLen     The bytes of data to be writen.
-  @param[in]  Data        Data to be writen.
+  @param[in]  Len   Number of bytes to write.
+  @param[in]  Data  Data to be written.
 
   @retval  EFI_SUCCESS              Write data success.
   @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
@@ -616,79 +533,22 @@ I2cSmbusWriteByte (
 **/
 EFI_STATUS
 EFIAPI
-I2cSmbusWriteBlockData (
+I2cMasterWrite (
   IN        SOPHGO_I2C_MASTER_PROTOCOL  *This,
   IN        INT32                       I2c,
   IN        UINT8                       Addr,
-  IN        UINT32                      EepromAddr,
-  IN        UINT32                      DataLen,
-  IN CONST  UINT8                       *Data)
-{
-  I2C_MSG  Msg;
-  UINT8    Buf[18];
-
-  if (DataLen > 16) {
-    DEBUG ((DEBUG_ERROR, "%a: write %d bytes exceeds 16!\n", __func__, DataLen));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  SetMem ((VOID *)(&Msg), sizeof (Msg), 0);
-  CopyMem ((VOID *)(Buf + 2), (CONST VOID *)Data, DataLen);
-  Buf[0] = (EepromAddr >> 8) & 0xff;
-  Buf[1] = EepromAddr & 0xff;
-
-  Msg.Addr  = Addr;
-  Msg.Flags = 0;
-  Msg.Len   = DataLen + 2;
-  Msg.Buf   = Buf;
-
-  return I2cXfer (I2c, &Msg, 1);
-}
-
-/**
-  I2c smbus write specified byte length data command.
-
-  @param[in]  This  The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
-  @param[in]  I2c   I2c bus number.
-  @param[in]  Addr  I2c slave address.
-  @param[in]  Cmd   Smbus command.
-  @param[in]  Len   Byte size of the data to be written.
-  @param[in]  Data  Buffer used to store the written data.
-
-  @retval  EFI_SUCCESS              Write data success.
-  @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
-  @retval  EFI_DEVICE_ERROR         There was an error during the transmission.
-  @retval  EFI_TIMEOUT              Waiting for bus busy timedout or transfer timeout.
-  @retval  EFI_INVALID_PARAMETER    Invalid function parameter.
-
-**/
-EFI_STATUS
-EFIAPI
-I2cSmbusWrite (
-  IN        SOPHGO_I2C_MASTER_PROTOCOL  *This,
-  IN        INT32                       I2c,
-  IN        UINT8                       Addr,
-  IN        UINT8                       Cmd,
   IN        UINT32                      Len,
   IN CONST  UINT8                       *Data
   )
 {
   I2C_MSG  Msg;
-  UINT8    Buf[18];
-
-  if (Len > 17) {
-    DEBUG ((DEBUG_ERROR, "%a: write %d bytes exceeds 17!\n", __func__, Len));
-    return EFI_INVALID_PARAMETER;
-  }
 
   SetMem ((VOID *)(&Msg), sizeof (Msg), 0);
-  CopyMem ((VOID *)(Buf + 1), (CONST VOID *)Data, Len);
-  Buf[0] = Cmd;
 
   Msg.Addr  = Addr;
   Msg.Flags = 0;
-  Msg.Len   = Len + 1;
-  Msg.Buf   = Buf;
+  Msg.Len   = Len;
+  Msg.Buf   = (UINT8 *)Data;
 
   return I2cXfer (I2c, &Msg, 1);
 }
@@ -837,10 +697,8 @@ DwI2cEntryPoint (
     goto ErrorI2cInit;
   }
 
-  mI2cMasterProtocol->ReadByte  = I2cSmbusReadByte;
-  mI2cMasterProtocol->WriteByte = I2cSmbusWriteByte;
-  mI2cMasterProtocol->Read      = I2cSmbusRead;
-  mI2cMasterProtocol->Write     = I2cSmbusWrite;
+  mI2cMasterProtocol->Read  = I2cMasterRead;
+  mI2cMasterProtocol->Write = I2cMasterWrite;
 
   Status = gBS->InstallMultipleProtocolInterfaces (
                   &ImageHandle,

--- a/Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcCommon.c
+++ b/Silicon/Sophgo/Drivers/SmbusHcDxe/SmbusHcCommon.c
@@ -130,9 +130,24 @@ SmbusHcCommonExecute (
         return EFI_INVALID_PARAMETER;
       }
 
-      DataLen = *Length;
-      CopyMem (&WriteTemp[0], Buffer, *Length);
-      DEBUG ((DEBUG_VERBOSE, "W %d: ", DataLen));
+      WriteTemp[0] = Command;
+      WriteTemp[1] = *Length;
+      CopyMem (&WriteTemp[2], Buffer, *Length);
+      DataLen = (*Length) + 2;
+
+      //
+      // PEC handling
+      //
+      if (PecCheck) {
+        CrcTemp[0] = I2C_WRITE_ADDRESS (SlaveAddress.SmbusDeviceAddress);
+        Pec        = CalculatePec (0, &CrcTemp[0], 1);
+        Pec        = CalculatePec (Pec, WriteTemp, DataLen);
+        DEBUG ((DEBUG_VERBOSE, "WriteBlock PEC = 0x%x\n", Pec));
+        WriteTemp[DataLen] = Pec;
+        DataLen           += 1;
+      }
+
+      DEBUG ((DEBUG_VERBOSE, "W %d: ", *Length));
       DEBUG ((DEBUG_VERBOSE, "Addr 0x%x: ", SlaveAddress.SmbusDeviceAddress));
       for (Idx = 0; Idx < DataLen; Idx++) {
         DEBUG ((DEBUG_VERBOSE, "0x%x ", WriteTemp[Idx]));
@@ -141,7 +156,7 @@ SmbusHcCommonExecute (
       Status = mI2cMasterProtocol->Write (mI2cMasterProtocol,
                                       I2C_BUS_NUMBER,
                                       SlaveAddress.SmbusDeviceAddress,
-                                      Command, DataLen, WriteTemp);
+                                      DataLen, WriteTemp);
 
       if (EFI_ERROR (Status)) {
         if (Status != EFI_TIMEOUT) {
@@ -154,11 +169,12 @@ SmbusHcCommonExecute (
     case EfiSmbusReadBlock:
 
       WriteTemp[0] = Command;
-      DataLen = *Length;
+      DataLen = *Length + 2; // +1 byte for Data Length +1 byte for PEC
       Status = mI2cMasterProtocol->Read (mI2cMasterProtocol,
                                      I2C_BUS_NUMBER,
                                      SlaveAddress.SmbusDeviceAddress,
-                                     WriteTemp[0], DataLen, ReadTemp);
+                                     1, WriteTemp,
+                                     DataLen, ReadTemp);
 
       if (EFI_ERROR (Status)) {
         if (Status != EFI_TIMEOUT) {

--- a/Silicon/Sophgo/Include/DwI2c.h
+++ b/Silicon/Sophgo/Include/DwI2c.h
@@ -23,53 +23,67 @@
 //
 typedef struct _SOPHGO_I2C_MASTER_PROTOCOL SOPHGO_I2C_MASTER_PROTOCOL;
 
+/**
+  I2C read operation — write data to the I2C slave then read data bytes back.
+
+  This performs a combined I2C transaction: first writes WriteLen bytes
+  (typically a register address), then reads ReadLen bytes from the slave.
+
+  @param[in]   This       The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
+  @param[in]   I2c        I2c bus number.
+  @param[in]   Addr       I2c slave address.
+  @param[in]   WriteLen   Number of bytes to write before reading.
+  @param[in]   WriteData  Data to write before reading (e.g. register offset).
+  @param[in]   ReadLen    Number of bytes to read.
+  @param[out]  ReadData   Buffer to store the read data.
+
+  @retval  EFI_SUCCESS              Read data success.
+  @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
+  @retval  EFI_DEVICE_ERROR         There was an error during the transmission.
+  @retval  EFI_TIMEOUT              Waiting for bus busy timedout or transfer timeout.
+
+**/
 typedef
 EFI_STATUS
-(EFIAPI *I2C_SMBUS_READ_BYTE) (
+(EFIAPI *I2C_MASTER_READ) (
   IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
   IN  INT32                       I2c,
   IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  OUT UINT8                       *Data
+  IN  UINT32                      WriteLen,
+  IN  UINT8                       *WriteData,
+  IN  UINT32                      ReadLen,
+  OUT UINT8                       *ReadData
   );
 
-typedef
-EFI_STATUS
-(EFIAPI *I2C_SMBUS_WRITE_BYTE) (
-  IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
-  IN  INT32                       I2c,
-  IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  IN  UINT8                       Data
-  );
+/**
+  I2C write operation — write data bytes to the I2C slave.
 
-typedef
-EFI_STATUS
-(EFIAPI *I2C_SMBUS_READ) (
-  IN  SOPHGO_I2C_MASTER_PROTOCOL  *This,
-  IN  INT32                       I2c,
-  IN  UINT8                       Addr,
-  IN  UINT8                       Cmd,
-  IN  UINT32                      Len,
-  OUT UINT8                       *Data
-  );
+  @param[in]  This  The pointer to SOPHGO_I2C_MASTER_PROTOCOL.
+  @param[in]  I2c   I2c bus number.
+  @param[in]  Addr  I2c slave address.
+  @param[in]  Len   Number of bytes to write.
+  @param[in]  Data  Data to be written.
 
+  @retval  EFI_SUCCESS              Write data success.
+  @retval  EFI_NOT_FOUND            Unable to find i2c slave with the given address.
+  @retval  EFI_DEVICE_ERROR         There was an error during the transmission.
+  @retval  EFI_TIMEOUT              Waiting for bus busy timedout or transfer timeout.
+  @retval  EFI_INVALID_PARAMETER    Invalid function parameter.
+
+**/
 typedef
 EFI_STATUS
-(EFIAPI *I2C_SMBUS_WRITE) (
+(EFIAPI *I2C_MASTER_WRITE) (
   IN        SOPHGO_I2C_MASTER_PROTOCOL  *This,
   IN        INT32                       I2c,
   IN        UINT8                       Addr,
-  IN        UINT8                       Cmd,
   IN        UINT32                      Len,
   IN CONST  UINT8                       *Data
   );
 
 struct _SOPHGO_I2C_MASTER_PROTOCOL {
-  I2C_SMBUS_READ_BYTE   ReadByte;
-  I2C_SMBUS_WRITE_BYTE  WriteByte;
-  I2C_SMBUS_READ        Read;
-  I2C_SMBUS_WRITE       Write;
+  I2C_MASTER_READ   Read;
+  I2C_MASTER_WRITE  Write;
 };
 
 extern EFI_GUID  gSophgoI2cMasterProtocolGuid;

--- a/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
+++ b/Silicon/Sophgo/Library/Ds1307RealTimeClockLib/Ds1307RealTimeClockLib.c
@@ -20,11 +20,13 @@
 #include <Library/UefiRuntimeLib.h>
 #include <Library/PcdLib.h>
 #include <Include/DwI2c.h>
+#include <Library/BaseMemoryLib.h>
 
 #define DS1307_ADDR         0x68
 #define INS5609_ADDR        0x32
 
 #define DS1307_SEC_BIT_CH   0x80  /* Clock Halt (in Register 0) */
+#define DS1307_DATA_REG     0x0
 
 //
 // TIME MASKS
@@ -74,11 +76,12 @@ RtcRead (
   )
 {
   EFI_STATUS   Status;
+  UINT8        RegAddr = DS1307_DATA_REG;
 
   Status = mI2cMasterProtocol->Read (mI2cMasterProtocol,
                                      mI2cBusNum,
                                      mSlaveAddr,
-                                     0, Length, Data);
+                                     1, &RegAddr, Length, Data);
 
   return Status;
 }
@@ -94,15 +97,19 @@ STATIC
 EFI_STATUS
 RtcWrite (
   IN   UINT32  Length,
-  OUT  UINT8   *Data
+  IN   UINT8   *Data
   )
 {
   EFI_STATUS   Status;
+  UINT8        Buf[Length + 1];
+
+  Buf[0] = DS1307_DATA_REG;
+  CopyMem (&Buf[1], Data, Length);
 
   Status = mI2cMasterProtocol->Write (mI2cMasterProtocol,
                                       mI2cBusNum,
                                       mSlaveAddr,
-                                      0, Length, Data);
+                                      Length + 1, Buf);
 
   return Status;
 }
@@ -132,7 +139,7 @@ LibGetTime (
 
   Status = RtcRead (7, TimeBcd);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: I2c smbus read error, Status: %r.\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: I2c read error, Status: %r.\n", __func__, Status));
     return EFI_DEVICE_ERROR;
   } else if (TimeBcd[0] & DS1307_SEC_BIT_CH) {
     DEBUG ((DEBUG_ERROR, "%a: Error, RTC oscillator has stopped!\n", __func__));
@@ -193,7 +200,7 @@ LibSetTime (
 
   Status = RtcRead (1, &Second);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: I2c smbus read error, Status: %r.\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: I2c read error, Status: %r.\n", __func__, Status));
     return EFI_DEVICE_ERROR;
   } else if (Second & DS1307_SEC_BIT_CH) {
     DEBUG ((DEBUG_ERROR, "%a: Error, RTC oscillator has stopped\n", __func__));
@@ -214,7 +221,7 @@ LibSetTime (
 
   Status = RtcWrite (7, TimeBcd);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a: I2c smbus write error, Status: %r.\n", __func__, Status));
+    DEBUG ((DEBUG_ERROR, "%a: I2c write error, Status: %r.\n", __func__, Status));
     return EFI_DEVICE_ERROR;
   }
 
@@ -289,30 +296,36 @@ FindOneRtcSlave (
   EFI_STATUS Status;
   UINT32     SlaveIndex, BusIndex;
   UINT8      Data = 0;
+  UINT8      Buf[2];
   UINT32     I2cBusNums[2];
 
   gBS->SetMem (I2cBusNums, sizeof (I2cBusNums), 0);
   I2cBusNums[0] = FixedPcdGet32 (PcdRtcI2cBusNum0);
   I2cBusNums[1] = FixedPcdGet32 (PcdRtcI2cBusNum1);
+  gBS->SetMem (Buf, sizeof (Buf), 0);
+  Buf[0] = DS1307_DATA_REG;
 
   for (BusIndex = 0; BusIndex < sizeof (I2cBusNums) / sizeof (I2cBusNums[0]); ++BusIndex){
     for (SlaveIndex = 0; SlaveIndex < sizeof (mRtcSlaveAddrs) / sizeof (mRtcSlaveAddrs[0]); ++SlaveIndex) {
-      Status = mI2cMasterProtocol->ReadByte (mI2cMasterProtocol,
-                                             I2cBusNums[BusIndex],
-                                             mRtcSlaveAddrs[SlaveIndex],
-                                             0, &Data);
+      Status = mI2cMasterProtocol->Read (mI2cMasterProtocol,
+                                         I2cBusNums[BusIndex],
+                                         mRtcSlaveAddrs[SlaveIndex],
+                                         1, Buf, 1, &Data);
       if (!EFI_ERROR (Status)) {
         mI2cBusNum = I2cBusNums[BusIndex];
         mSlaveAddr = mRtcSlaveAddrs[SlaveIndex];
+        DEBUG ((DEBUG_INFO, "%a: RTC found on I2cBus %d, SlaveAddr 0x%02x, read Data 0x%02x\n",
+                __func__, mI2cBusNum, mSlaveAddr, Data));
         //
         // Enable the oscillator (CH bit = 0) in the initial state
         //
         if (Data & DS1307_SEC_BIT_CH) {
           Data &= ~DS1307_SEC_BIT_CH;
-          Status = mI2cMasterProtocol->WriteByte (mI2cMasterProtocol,
-                                                  mI2cBusNum,
-                                                  mSlaveAddr,
-                                                  0, Data);
+          Buf[1] = Data;
+          Status = mI2cMasterProtocol->Write (mI2cMasterProtocol,
+                                              mI2cBusNum,
+                                              mSlaveAddr,
+                                              2, Buf);
         }
         return Status;
       }

--- a/Silicon/Sophgo/SG2044Pkg/AcpiTables/SD3-12/Ssdt.asl
+++ b/Silicon/Sophgo/SG2044Pkg/AcpiTables/SD3-12/Ssdt.asl
@@ -4,6 +4,7 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
   EFI_ACPI_RISCV_OEM_REVISION)
 {
   External(\_SB.SPI0, DeviceObj)
+  External(\_SB.I2C0, DeviceObj)
 
   Scope(\_SB.SPI0) {
     Device (TPM) {
@@ -14,7 +15,7 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
           Return (0xF)
         }
       Name (_CRS, ResourceTemplate () {
-        SPISerialBus (
+        SPISerialBusV2 (
           0,                // Chip Select
           PolarityLow,      // CS Active Low
           FourWireMode,
@@ -25,6 +26,27 @@ DefinitionBlock ("SsdtTable.aml", "SSDT", 2, "SOPHGO", "2044    ",
           ClockPhaseFirst,
           "\\_SB.SPI0",     // SPI Path
           0
+        )
+      })
+    }
+  }
+  Scope(\_SB.I2C0) {
+    Device (IPI) {
+      Name (_HID, "IPI0001")
+      Name (_UID, 0)
+        Method (_STA)
+        {
+          Return (0xF)
+        }
+      Name (_CRS, ResourceTemplate () {
+        I2cSerialBusV2 (
+          0x10,              // 7 bits slave addr
+          ControllerInitiated,
+          100000,              // 100kHz
+          AddressingMode7Bit,  // 7 bits
+          "\\_SB.I2C0",        // I2C path
+          0,
+          ResourceConsumer
         )
       })
     }

--- a/Silicon/Sophgo/SG2044Pkg/Drivers/FirmwareManagerUiDxe/MCUFirmwareUpdate.c
+++ b/Silicon/Sophgo/SG2044Pkg/Drivers/FirmwareManagerUiDxe/MCUFirmwareUpdate.c
@@ -56,18 +56,18 @@ MCUFlashSetOffset (
   )
 {
   EFI_STATUS Status = EFI_SUCCESS;
-  UINT8 Data[4];
+  UINT8 Data[5];
 
-  Data[0] = (Offset >> 24) & 0xFF;
-  Data[1] = (Offset >> 16) & 0xFF;
-  Data[2] = (Offset >> 8) & 0xFF;
-  Data[3] = Offset & 0xFF;
+  Data[0] = REG_FLASH_OFFSET;
+  Data[1] = (Offset >> 24) & 0xFF;
+  Data[2] = (Offset >> 16) & 0xFF;
+  Data[3] = (Offset >> 8) & 0xFF;
+  Data[4] = Offset & 0xFF;
 
   Status = I2cMasterProtocol->Write(
     I2cMasterProtocol,
     MCUI2cBus,
     MCU_SLAVE_ADDR,
-    REG_FLASH_OFFSET,
     sizeof(Data),
     Data
     );
@@ -91,6 +91,7 @@ MCUFlashSetBlockData (
   EFI_STATUS Status = EFI_SUCCESS;
   UINT8 SmbusBlockMax = 16;
   UINT8 Reg, Slen, Left, Off = 0;
+  UINT8 Buf[SmbusBlockMax + 1];
 
   Reg = REG_FLASH_DATA;
 
@@ -101,13 +102,15 @@ MCUFlashSetBlockData (
     else
       Slen = Left;
 
+    Buf[0] = Reg;
+    CopyMem (&Buf[1], (UINT8 *)Buffer + Off, Slen);
+
     Status = I2cMasterProtocol->Write(
       I2cMasterProtocol,
       MCUI2cBus,
       MCU_SLAVE_ADDR,
-      Reg,
-      Slen,
-      (UINT8 *)Buffer + Off
+      Slen + 1,
+      Buf
       );
     if (EFI_ERROR(Status)) {
       Print (L"\rMCU flash set block data failed\n");
@@ -148,7 +151,8 @@ MCUFlashGetBlockData (
       I2cMasterProtocol,
       MCUI2cBus,
       MCU_SLAVE_ADDR,
-      Reg,
+      1,
+      &Reg,
       Slen,
       (UINT8 *)Buffer + Off
       );
@@ -172,18 +176,20 @@ MCUFlashUnlock (
   )
 {
   EFI_STATUS Status = EFI_SUCCESS;
+  UINT8      Buf[2];
 
-  Status = I2cMasterProtocol->WriteByte(
+  Buf[0] = REG_FLASH_CMD;
+  Buf[1] = FLASH_CMD_UNLOCK;
+  Status = I2cMasterProtocol->Write(
     I2cMasterProtocol,
     MCUI2cBus,
     MCU_SLAVE_ADDR,
-    REG_FLASH_CMD,
-    FLASH_CMD_UNLOCK
+    2,
+    Buf
     );
 
   if (EFI_ERROR(Status))
     Print (L"\rMCU flash unlock failed\n");
-
 
   return Status;
 }
@@ -196,13 +202,16 @@ MCUFlashLock (
   )
 {
   EFI_STATUS Status = EFI_SUCCESS;
+  UINT8      Buf[2];
 
-  Status = I2cMasterProtocol->WriteByte(
+  Buf[0] = REG_FLASH_CMD;
+  Buf[1] = FLASH_CMD_LOCK;
+  Status = I2cMasterProtocol->Write(
     I2cMasterProtocol,
     MCUI2cBus,
     MCU_SLAVE_ADDR,
-    REG_FLASH_CMD,
-    FLASH_CMD_LOCK
+    2,
+    Buf
     );
 
   if (EFI_ERROR(Status))
@@ -220,6 +229,7 @@ MCUFlashErasePage (
   )
 {
   EFI_STATUS Status = EFI_SUCCESS;
+  UINT8      Buf[2];
 
   if (Offset & FLASH_PAGE_MASK) {
     Print (L"\rOffset should page aligned when erase page\n");
@@ -232,12 +242,14 @@ MCUFlashErasePage (
     Offset
     );
 
-  Status = I2cMasterProtocol->WriteByte(
+  Buf[0] = REG_FLASH_CMD;
+  Buf[1] = FLASH_CMD_ERASE;
+  Status = I2cMasterProtocol->Write(
     I2cMasterProtocol,
     MCUI2cBus,
     MCU_SLAVE_ADDR,
-    REG_FLASH_CMD,
-    FLASH_CMD_ERASE
+    2,
+    Buf
     );
 
   return Status;
@@ -407,12 +419,15 @@ MCUFirmwareCheck (
   EFI_STATUS Status = EFI_SUCCESS;
   UINT8 BoardTypeInFile = 0;
   UINT8 BoardType = 0;
+  UINT8 RegAddr = REG_BOARD_TYPE;
 
-  Status = I2cMasterProtocol->ReadByte(
+  Status = I2cMasterProtocol->Read(
     I2cMasterProtocol,
     MCUI2cBus,
     MCU_SLAVE_ADDR,
-    REG_BOARD_TYPE,
+    1,
+    &RegAddr,
+    1,
     &BoardType
     );
 


### PR DESCRIPTION
 Commit 1: Refactor I2C master protocol to generic read/write operations
Replace SMBus-specific I2C functions with generic I2cMasterRead/I2cMasterWrite
that accept arbitrary data length. Move SMBus framing (command byte, length
byte, PEC) from I2C driver to SmbusHc layer.

Commit 2: Adapt Ds1307RealTimeClockLib and MCUFirmwareUpdate to new I2C interface
Replace ReadByte/WriteByte calls with I2cMasterRead/I2cMasterWrite, passing
register addresses as write data.

Commit 3: Switch IPMI transport from Serial to SSIF for SD3-12
Enable SSIF over I2C for BMC communication, add IPI0001 ACPI device, and
include IPMI SMBIOS/Blob transfer modules.
